### PR TITLE
fix(vmess): add h2c support for h2 and grpc transport

### DIFF
--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -82,7 +82,7 @@ impl Handler {
 
                 ws_builder.proxy_stream(stream).await?
             }
-            Some(VmessTransport::H2(ref opt)) => {                
+            Some(VmessTransport::H2(ref opt)) => {
                 stream = match self.opts.tls.as_ref() {
                     Some(tls_opt) => {
                         let mut tls_opt = tls_opt.clone();

--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -82,15 +82,15 @@ impl Handler {
 
                 ws_builder.proxy_stream(stream).await?
             }
-            Some(VmessTransport::H2(ref opt)) => {
-                let mut tls_opt = self
-                    .opts
-                    .tls
-                    .as_ref()
-                    .expect("H2 conn must have tls opt")
-                    .clone();
-                tls_opt.alpn = Some(vec!["h2".to_string()]);
-                stream = transport::tls::wrap_stream(stream, tls_opt.to_owned(), None).await?;
+            Some(VmessTransport::H2(ref opt)) => {                
+                stream = match self.opts.tls.as_ref() {
+                    Some(tls_opt) => {
+                        let mut tls_opt = tls_opt.clone();
+                        tls_opt.alpn = Some(vec!["h2".to_string()]);
+                        transport::tls::wrap_stream(stream, tls_opt.to_owned(), None).await?
+                    }
+                    None => stream,
+                };
 
                 let h2_builder = Http2Config {
                     hosts: vec![self.opts.server.clone()],
@@ -102,9 +102,12 @@ impl Handler {
                 h2_builder.proxy_stream(stream).await?
             }
             Some(VmessTransport::Grpc(ref opt)) => {
-                let tls_opt = self.opts.tls.as_ref().expect("gRPC conn must have tls opt");
-                stream =
-                    transport::tls::wrap_stream(stream, tls_opt.to_owned(), Some("h2")).await?;
+                stream = match self.opts.tls.as_ref() {
+                    Some(tls_opt) => {
+                        transport::tls::wrap_stream(stream, tls_opt.to_owned(), None).await?
+                    }
+                    None => stream,
+                };
 
                 let grpc_builder = transport::GrpcStreamBuilder::new(
                     self.opts.server.clone(),


### PR DESCRIPTION
* grpc with **h2c**: test ok as expect
* h2 with **h2c**: small page can read as expect
 * huge page, like: `https://www.aliyun.com` or `https://cloud.tencent.com` could read really small - seems can't finish in a minute.
 * I haven't tested it in h2 with tls

It seems buffer is really small?
![image](https://github.com/Watfaq/clash-rs/assets/41122242/66c435d5-c773-4190-9ba6-acc2a60cd9cf)
![image](https://github.com/Watfaq/clash-rs/assets/41122242/f6f342f8-25ba-4d8a-8bc2-a597fea85ed4)
![image](https://github.com/Watfaq/clash-rs/assets/41122242/95450f14-6647-4f8f-a166-493f9f29e0c2)

 
 