### PR TITLE
feat: support shadow-tls(v3 only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,9 +822,9 @@ checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "by_address"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte_string"
@@ -1132,13 +1132,14 @@ dependencies = [
  "rand",
  "regex",
  "register-count",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "rustls-pemfile",
  "security-framework",
  "serde",
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "sha1",
  "sha2",
  "shadowsocks",
  "smoltcp",
@@ -1629,11 +1630,11 @@ dependencies = [
 
 [[package]]
 name = "derive-adhoc"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc3f185a1a0d933e54447b3492fe9880db2c3ad37c04b3a3bf9b24a73b7bd02"
+checksum = "0c768757217a40364c3af0b732d10bf9ed8af1e4f80b32fd5eeed94f375304b8"
 dependencies = [
- "derive-adhoc-macros 0.8.3",
+ "derive-adhoc-macros 0.8.4",
  "heck 0.4.1",
 ]
 
@@ -1656,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "derive-adhoc-macros"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f1a082460419acefc6a66ff74c6e15c460d9b95530697f5d10892ee624aa60"
+checksum = "3b41d3d974cda1ce7e9b40f7ec5160a099f20345bc3137447e526e3ba9d63245"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.12.1",
@@ -2515,7 +2516,7 @@ dependencies = [
  "once_cell",
  "rand",
  "ring 0.16.20",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "rustls-pemfile",
  "serde",
  "thiserror",
@@ -2541,7 +2542,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand",
  "resolv-conf",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "serde",
  "smallvec",
  "thiserror",
@@ -2565,7 +2566,7 @@ dependencies = [
  "hickory-proto",
  "hickory-resolver",
  "http 0.2.12",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "serde",
  "thiserror",
  "time",
@@ -2778,7 +2779,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -3288,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -3980,9 +3981,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"
@@ -4262,7 +4263,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "thiserror",
  "tokio",
  "tracing",
@@ -4278,7 +4279,7 @@ dependencies = [
  "rand",
  "ring 0.16.20",
  "rustc-hash",
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4420,7 +4421,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4440,7 +4441,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4451,9 +4452,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "register-count"
@@ -4608,9 +4609,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+version = "0.21.8"
+source = "git+https://github.com/Watfaq/rustls.git?rev=43ecd5c610741668488e6d57857f9900a2087a5b#43ecd5c610741668488e6d57857f9900a2087a5b"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -4654,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -5543,10 +5543,9 @@ dependencies = [
 [[package]]
 name = "tokio-rustls"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=fcda89f6348c1e696b239bc7e0b168015cfb8c08#fcda89f6348c1e696b239bc7e0b168015cfb8c08"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.8",
  "tokio",
 ]
 
@@ -5918,7 +5917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c579e92f3b9e419e68cd317d33f567491365b81f943b063d30f32e4a2f072c5"
 dependencies = [
  "config",
- "derive-adhoc 0.8.3",
+ "derive-adhoc 0.8.4",
  "derive_builder_fork_arti",
  "directories",
  "educe",
@@ -6096,7 +6095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4613dfe9d946db3b5769b860a16598a9c4a0f85df21653d0765b1238106d297"
 dependencies = [
  "async-trait",
- "derive-adhoc 0.8.3",
+ "derive-adhoc 0.8.4",
  "derive_more",
  "educe",
  "either",
@@ -6164,7 +6163,7 @@ checksum = "365c02c66f2f0159078714dd44947fb06c76956a3621fc102783119e5093be96"
 dependencies = [
  "amplify",
  "arrayvec",
- "derive-adhoc 0.8.3",
+ "derive-adhoc 0.8.4",
  "derive_builder_fork_arti",
  "derive_more",
  "downcast-rs",
@@ -6346,7 +6345,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4bbf6c0a786daab669a75ec7380ae57f9aba91f2c4ea05a12e596d9bc6b49a0"
 dependencies = [
- "derive-adhoc 0.8.3",
+ "derive-adhoc 0.8.4",
  "derive_more",
  "filetime",
  "fs-mistrust",
@@ -6448,7 +6447,7 @@ dependencies = [
  "amplify",
  "async-trait",
  "backtrace",
- "derive-adhoc 0.8.3",
+ "derive-adhoc 0.8.4",
  "derive_more",
  "educe",
  "futures",
@@ -7415,27 +7414,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.10+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-oslog",
  "tracing-subscriber",
- "tracing-test",
  "tracing-timing",
  "tuic",
  "tuic-quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ opt-level = "s"
 codegen-units = 1
 lto = true
 strip = true
+
+[patch.crates-io]
+tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "fcda89f6348c1e696b239bc7e0b168015cfb8c08"}
+rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "43ecd5c610741668488e6d57857f9900a2087a5b"}

--- a/clash_lib/Cargo.toml
+++ b/clash_lib/Cargo.toml
@@ -127,7 +127,6 @@ tokio-test = "0.4.4"
 axum-macros = "0.4.0"
 bollard = "0.16"
 serial_test = "3.0.0"
-tracing-test = "0.2.4"
 
 [target.'cfg(macos)'.dependencies]
 security-framework = "2.10.0"

--- a/clash_lib/Cargo.toml
+++ b/clash_lib/Cargo.toml
@@ -52,6 +52,7 @@ opentelemetry-otlp = { version = "0.15.0", features = ["http-proto"] }
 crc32fast = "1.4.0"
 brotli = "3.5.0"
 hmac = "0.12.1"
+sha1 = "0.10"
 sha2 = "0.10.8"
 md-5 = "0.10.5"
 chacha20poly1305 = "0.10"

--- a/clash_lib/src/app/inbound/network_listener.rs
+++ b/clash_lib/src/app/inbound/network_listener.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
-#[derive(Eq, PartialEq, Hash)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub enum ListenerType {
     Http,
     Socks5,
@@ -114,13 +114,14 @@ impl NetworkInboundListener {
         };
 
         if listener.handle_tcp() {
+            let listener_type = self.listener_type.clone();
             info!("{} TCP listening at: {}:{}", self.name, ip, self.port);
 
             let tcp_listener = listener.clone();
             runners.push(
                 async move {
                     tcp_listener.listen_tcp().await.map_err(|e| {
-                        warn!("handler tcp listen failed: {}", e);
+                        warn!("handler of {:?} tcp listen failed: {}", listener_type, e);
                         e.into()
                     })
                 }

--- a/clash_lib/src/proxy/converters/shadowsocks.rs
+++ b/clash_lib/src/proxy/converters/shadowsocks.rs
@@ -46,6 +46,15 @@ impl TryFrom<&OutboundShadowsocks> for AnyOutboundHandler {
                         .try_into()
                         .map(OBFSOption::V2Ray)
                         .ok(),
+                    "shadow-tls" => s
+                        .plugin_opts
+                        .clone()
+                        .ok_or(Error::InvalidConfig(
+                            "plugin_opts is required for plugin obfs".to_owned(),
+                        ))?
+                        .try_into()
+                        .map(OBFSOption::ShadowTls)
+                        .ok(),
                     _ => {
                         return Err(Error::InvalidConfig(format!(
                             "unsupported plugin: {}",

--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -263,7 +263,7 @@ impl OutboundHandler for Handler {
                 }
                 OBFSOption::ShadowTls(opts) => {
                     tracing::debug!("using shadow-tls with option: {:?}", opts);
-                    
+
                     (shadow_tls::Connector::wrap(opts, s).await?) as _
                 }
             },

--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -330,12 +330,10 @@ impl OutboundHandler for Handler {
 #[cfg(all(test, not(ci)))]
 mod tests {
 
-    use crate::proxy::utils::test_utils::docker_runner::{
-        MultiDockerTestRunner, DockerTestRunnerBuilder,
-    };
-    use crate::proxy::utils::test_utils::run_chained;
-
     use super::super::utils::test_utils::{consts::*, docker_runner::DockerTestRunner, run};
+    use crate::proxy::utils::test_utils::docker_runner::{
+        DockerTestRunnerBuilder, MultiDockerTestRunner,
+    };
 
     use super::*;
 
@@ -368,7 +366,7 @@ mod tests {
         };
         let port = opts.port;
         let handler = Handler::new(opts);
-        run(handler, get_ss_runner(port)).await
+        run(handler, get_ss_runner(port).await?).await
     }
 
     async fn get_shadowtls_runner(
@@ -423,6 +421,6 @@ mod tests {
         chained
             .add(get_shadowtls_runner(ss_port, shadow_tls_port))
             .await;
-        run_chained(handler, chained).await
+        run(handler, chained).await
     }
 }

--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -263,8 +263,8 @@ impl OutboundHandler for Handler {
                 }
                 OBFSOption::ShadowTls(opts) => {
                     tracing::debug!("using shadow-tls with option: {:?}", opts);
-                    let res = shadow_tls::Connector::wrap(opts, s).await?;
-                    res
+                    
+                    (shadow_tls::Connector::wrap(opts, s).await?) as _
                 }
             },
             None => s,

--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -330,7 +330,10 @@ impl OutboundHandler for Handler {
 #[cfg(all(test, not(ci)))]
 mod tests {
 
-    use crate::proxy::utils::test_utils::docker_runner::DockerTestRunnerBuilder;
+    use crate::proxy::utils::test_utils::docker_runner::{
+        MultiDockerTestRunner, DockerTestRunnerBuilder,
+    };
+    use crate::proxy::utils::test_utils::run_chained;
 
     use super::super::utils::test_utils::{consts::*, docker_runner::DockerTestRunner, run};
 
@@ -338,12 +341,14 @@ mod tests {
 
     const PASSWORD: &str = "FzcLbKs2dY9mhL";
     const CIPHER: &str = "aes-256-gcm";
+    const SHADOW_TLS_PASSWORD: &str = "password";
 
-    async fn get_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_ss_runner(port: u16) -> anyhow::Result<DockerTestRunner> {
+        let host = format!("0.0.0.0:{}", port);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SS_RUST)
             .entrypoint(&["ssserver"])
-            .cmd(&["-s", "0.0.0.0:10002", "-m", CIPHER, "-k", PASSWORD, "-U"])
+            .cmd(&["-s", &host, "-m", CIPHER, "-k", PASSWORD, "-U"])
             .build()
             .await
     }
@@ -361,7 +366,63 @@ mod tests {
             plugin_opts: Default::default(),
             udp: false,
         };
+        let port = opts.port;
         let handler = Handler::new(opts);
-        run(handler, get_runner()).await
+        run(handler, get_ss_runner(port)).await
+    }
+
+    async fn get_shadowtls_runner(
+        ss_port: u16,
+        stls_port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
+        let ss_server_env = format!("SERVER=127.0.0.1:{}", ss_port);
+        let listen_env = format!("LISTEN=0.0.0.0:{}", stls_port);
+        let password = format!("PASSWORD={}", SHADOW_TLS_PASSWORD);
+        DockerTestRunnerBuilder::new()
+            .image(IMAGE_SHADOW_TLS)
+            .env(&[
+                "MODE=server",
+                // the port that we need to fill in the config
+                &listen_env,
+                // shadowsocks server addr
+                &ss_server_env,
+                "TLS=www.feishu.cn:443",
+                &password,
+                "V3=1",
+            ])
+            // .cmd(&["-s", "0.0.0.0:10002", "-m", CIPHER, "-k", PASSWORD, "-U"])
+            .build()
+            .await
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_shadowtls() -> anyhow::Result<()> {
+        // the real port that used for communication
+        let shadow_tls_port = 10002;
+        // not important, you can assign any port that is not conflict with others
+        let ss_port = 10004;
+        let opts = HandlerOptions {
+            name: "test-ss".to_owned(),
+            common_opts: Default::default(),
+            server: LOCAL_ADDR.to_owned(),
+            port: shadow_tls_port,
+            password: PASSWORD.to_owned(),
+            cipher: CIPHER.to_owned(),
+            plugin_opts: Some(OBFSOption::ShadowTls(ShadowTlsOption {
+                host: "www.feishu.cn".to_owned(),
+                password: "password".to_owned(),
+                strict: true,
+            })),
+            udp: false,
+        };
+        let handler = Handler::new(opts);
+        // we need to store all the runners in a container, to make sure all of them can be destroyed after the test
+        let mut chained = MultiDockerTestRunner::default();
+        chained.add(get_ss_runner(ss_port)).await;
+        chained
+            .add(get_shadowtls_runner(ss_port, shadow_tls_port))
+            .await;
+        run_chained(handler, chained).await
     }
 }

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
@@ -1,0 +1,161 @@
+use std::io;
+use std::ptr::copy_nonoverlapping;
+use std::sync::Arc;
+
+use rand::Rng;
+
+use rand::distributions::Distribution;
+use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::rustls::ClientConfig;
+use tokio_rustls::TlsConnector;
+
+use crate::proxy::shadowsocks::ShadowTlsOption;
+use crate::proxy::AnyStream;
+
+use super::prelude::*;
+
+use super::stream::{ProxyTlsStream, VerifiedStream};
+use super::utils::Hmac;
+
+#[derive(Clone, Debug)]
+#[allow(unused)]
+pub struct Opts {
+    pub fastopen: bool,
+    pub sni: String,
+    pub strict: bool,
+}
+
+pub struct Connector {
+    pub password: String,
+    pub server_addr: String,
+    pub tls_config: ClientConfig,
+    pub connector: TlsConnector,
+}
+
+impl Connector {
+    fn connector() -> TlsConnector {
+        use crate::common::tls::GLOBAL_ROOT_STORE;
+
+        let tls_config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(GLOBAL_ROOT_STORE.clone())
+            .with_no_client_auth();
+        let connector = TlsConnector::from(Arc::new(tls_config.clone()));
+        connector
+    }
+
+    pub async fn wrap(opts: &ShadowTlsOption, stream: AnyStream) -> std::io::Result<AnyStream> {
+        let proxy_stream = ProxyTlsStream::new(stream, &opts.password);
+
+        tracing::trace!("tcp connected, start handshaking");
+
+        let hamc_handshake = Hmac::new(&opts.password, (&[], &[]));
+        let sni_name = rustls::ServerName::try_from(opts.host.as_str())
+            .unwrap_or_else(|_| panic!("invalid server name: {}", opts.host));
+        let session_id_generator = move |data: &_| generate_session_id(&hamc_handshake, data);
+        let connector = Self::connector();
+        let mut tls = connector
+            .connect_with(sni_name, proxy_stream, Some(session_id_generator), |_| {})
+            .await?;
+        // perform a fake request, will do the handshake
+        tracing::trace!("handshake done");
+
+        let authorized = tls.get_mut().0.authorized();
+        let maybe_server_random_and_hamc = tls
+            .get_mut()
+            .0
+            .state()
+            .as_ref()
+            .map(|s| (s.server_random, s.hmac.to_owned()));
+
+        if (!authorized || maybe_server_random_and_hamc.is_none()) && opts.strict {
+            tracing::warn!("V3 strict enabled: traffic hijacked or TLS1.3 is not supported, perform fake request");
+
+            tls.get_mut().0.fake_request = true;
+
+            let r = fake_request(tls).await;
+
+            return Err(io::Error::new(io::ErrorKind::Other, format!("V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request, res:{:?}", r)));
+        }
+
+        let (server_random, hmac_nop) = match maybe_server_random_and_hamc {
+            Some(inner) => inner,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("server random and hmac not extracted from handshake, fail to connect"),
+                ));
+            }
+        };
+
+        let hmac_client = Hmac::new(&opts.password, (&server_random, "C".as_bytes()));
+        let hmac_server = Hmac::new(&opts.password, (&server_random, "S".as_bytes()));
+
+        let verified_stream = VerifiedStream::new(
+            tls.into_inner().0.raw,
+            hmac_client,
+            hmac_server,
+            Some(hmac_nop),
+        );
+
+        return Ok(Box::new(verified_stream));
+    }
+}
+
+/// Take a slice of tls message[5..] and returns signed session id.
+///
+/// Only used by V3 protocol.
+fn generate_session_id(hmac: &Hmac, buf: &[u8]) -> [u8; TLS_SESSION_ID_SIZE] {
+    /// Note: SESSION_ID_START does not include 5 TLS_HEADER_SIZE.
+    const SESSION_ID_START: usize = 1 + 3 + 2 + TLS_RANDOM_SIZE + 1;
+
+    if buf.len() < SESSION_ID_START + TLS_SESSION_ID_SIZE {
+        tracing::warn!("unexpected client hello length");
+        return [0; TLS_SESSION_ID_SIZE];
+    }
+
+    let mut session_id = [0; TLS_SESSION_ID_SIZE];
+    rand::thread_rng().fill(&mut session_id[..TLS_SESSION_ID_SIZE - HMAC_SIZE]);
+    let mut hmac = hmac.to_owned();
+    hmac.update(&buf[0..SESSION_ID_START]);
+    hmac.update(&session_id);
+    hmac.update(&buf[SESSION_ID_START + TLS_SESSION_ID_SIZE..]);
+    let hmac_val = hmac.finalize();
+    unsafe {
+        copy_nonoverlapping(
+            hmac_val.as_ptr(),
+            session_id.as_mut_ptr().add(TLS_SESSION_ID_SIZE - HMAC_SIZE),
+            HMAC_SIZE,
+        )
+    }
+    session_id
+}
+
+/// Doing fake request.
+///
+/// Only used by V3 protocol.
+async fn fake_request<S: tokio::io::AsyncRead + AsyncWrite + Unpin>(
+    mut stream: TlsStream<S>,
+) -> std::io::Result<()> {
+    const HEADER: &[u8; 207] = b"GET / HTTP/1.1\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\nAccept: gzip, deflate, br\nConnection: Close\nCookie: sessionid=";
+    const FAKE_REQUEST_LENGTH_RANGE: (usize, usize) = (16, 64);
+    let cnt =
+        rand::thread_rng().gen_range(FAKE_REQUEST_LENGTH_RANGE.0..FAKE_REQUEST_LENGTH_RANGE.1);
+    let mut buffer = Vec::with_capacity(cnt + HEADER.len() + 1);
+
+    buffer.extend_from_slice(HEADER);
+    rand::distributions::Alphanumeric
+        .sample_iter(rand::thread_rng())
+        .take(cnt)
+        .for_each(|c| buffer.push(c));
+    buffer.push(b'\n');
+
+    stream.write_all(&buffer).await?;
+    let _ = stream.shutdown().await;
+
+    // read until eof
+    let mut buf = Vec::with_capacity(1024);
+    let r = stream.read_to_end(&mut buf).await;
+    r.map(|_| ())
+}

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
@@ -41,7 +41,7 @@ impl Connector {
             .with_safe_defaults()
             .with_root_certificates(GLOBAL_ROOT_STORE.clone())
             .with_no_client_auth();
-        
+
         TlsConnector::from(Arc::new(tls_config.clone()))
     }
 
@@ -73,7 +73,8 @@ impl Connector {
 
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request".to_string(),
+                "V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request"
+                    .to_string(),
             ));
         }
 
@@ -82,7 +83,8 @@ impl Connector {
             None => {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
-                    "server random and hmac not extracted from handshake, fail to connect".to_string(),
+                    "server random and hmac not extracted from handshake, fail to connect"
+                        .to_string(),
                 ));
             }
         };

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
@@ -41,8 +41,8 @@ impl Connector {
             .with_safe_defaults()
             .with_root_certificates(GLOBAL_ROOT_STORE.clone())
             .with_no_client_auth();
-        let connector = TlsConnector::from(Arc::new(tls_config.clone()));
-        connector
+        
+        TlsConnector::from(Arc::new(tls_config.clone()))
     }
 
     pub async fn wrap(opts: &ShadowTlsOption, stream: AnyStream) -> std::io::Result<AnyStream> {
@@ -73,9 +73,7 @@ impl Connector {
 
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!(
-                    "V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request"
-                ),
+                "V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request".to_string(),
             ));
         }
 
@@ -84,7 +82,7 @@ impl Connector {
             None => {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
-                    format!("server random and hmac not extracted from handshake, fail to connect"),
+                    "server random and hmac not extracted from handshake, fail to connect".to_string(),
                 ));
             }
         };
@@ -99,7 +97,7 @@ impl Connector {
             Some(hmac_nop),
         );
 
-        return Ok(Box::new(verified_stream));
+        Ok(Box::new(verified_stream))
     }
 }
 

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
@@ -71,7 +71,12 @@ impl Connector {
             tls.get_mut().0.fake_request = true;
             fake_request(tls).await?;
 
-            return Err(io::Error::new(io::ErrorKind::Other, format!("V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request")));
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "V3 strict enabled: traffic hijacked or TLS1.3 is not supported, fake request"
+                ),
+            ));
         }
 
         let (server_random, hmac_nop) = match maybe_server_random_and_hamc {

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/mod.rs
@@ -1,0 +1,6 @@
+mod connector;
+mod stream;
+mod utils;
+
+use utils::prelude;
+pub use connector::Connector;

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/mod.rs
@@ -2,5 +2,5 @@ mod connector;
 mod stream;
 mod utils;
 
-use utils::prelude;
 pub use connector::Connector;
+use utils::prelude;

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
@@ -1,0 +1,508 @@
+use std::{
+    mem::MaybeUninit,
+    pin::Pin,
+    ptr::{copy, copy_nonoverlapping},
+    task::{ready, Poll},
+};
+
+use byteorder::{BigEndian, WriteBytesExt};
+use bytes::{BufMut, BytesMut};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::utils::{prelude::*, Hmac, *};
+
+#[derive(Default, Debug)]
+pub enum ReadState {
+    #[default]
+    WaitingHeader,
+    WaitingData(usize, [u8; TLS_HEADER_SIZE]),
+    FlushingData,
+}
+
+#[derive(Default, Debug)]
+pub enum WriteState {
+    #[default]
+    BuildingData,
+    FlushingData(usize, usize, usize),
+}
+
+pub trait AsyncReadUnpin: AsyncRead + Unpin {}
+
+impl<T: AsyncRead + Unpin> AsyncReadUnpin for T {}
+
+pub trait ReadExtBase {
+    fn prepare(&mut self) -> (&mut dyn AsyncReadUnpin, &mut BytesMut, &mut usize);
+}
+
+pub trait ReadExt {
+    fn poll_read_exact(
+        &mut self,
+        cx: &mut std::task::Context,
+        size: usize,
+    ) -> Poll<std::io::Result<()>>;
+}
+
+impl<T: ReadExtBase> ReadExt for T {
+    fn poll_read_exact(
+        &mut self,
+        cx: &mut std::task::Context,
+        size: usize,
+    ) -> Poll<std::io::Result<()>> {
+        let (raw, read_buf, read_pos) = self.prepare();
+        read_buf.reserve(size);
+        // # safety: read_buf has reserved `size`
+        unsafe { read_buf.set_len(size) }
+        loop {
+            if *read_pos < size {
+                // # safety: read_pos<size==read_buf.len(), and read_buf[0..read_pos] is initialized
+                let dst = unsafe {
+                    &mut *((&mut read_buf[*read_pos..size]) as *mut _ as *mut [MaybeUninit<u8>])
+                };
+                let mut buf = ReadBuf::uninit(dst);
+                let ptr = buf.filled().as_ptr();
+                ready!(Pin::new(&mut *raw).poll_read(cx, &mut buf))?;
+                assert_eq!(ptr, buf.filled().as_ptr());
+                if buf.filled().is_empty() {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "unexpected eof",
+                    )));
+                }
+                *read_pos += buf.filled().len();
+            } else {
+                assert!(*read_pos == size);
+                *read_pos = 0;
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Certs {
+    pub(crate) server_random: [u8; TLS_RANDOM_SIZE],
+    pub(crate) hmac: Hmac,
+    pub(crate) key: Vec<u8>,
+}
+
+pub struct ProxyTlsStream<S> {
+    pub raw: S,
+    password: String,
+
+    pub read_state: ReadState,
+    pub read_pos: usize,
+    pub read_buf: BytesMut,
+
+    // need to get from the handshake packets
+    pub certs: Option<Certs>,
+    read_authorized: bool,
+    tls13: bool,
+
+    // if true, the stream will only act as a wrapper, and won't modify the inner byte stream
+    pub fake_request: bool,
+}
+
+impl<S> ProxyTlsStream<S> {
+    pub fn new(raw: S, password: &str) -> Self {
+        Self {
+            raw,
+            password: password.to_string(),
+
+            read_state: Default::default(),
+            read_pos: Default::default(),
+            read_buf: Default::default(),
+
+            certs: None,
+            read_authorized: false,
+            tls13: false,
+
+            fake_request: false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn authorized(&self) -> bool {
+        self.read_authorized
+    }
+
+    #[inline(always)]
+    pub fn state(&self) -> &Option<Certs> {
+        &self.certs
+    }
+
+    #[allow(unused)]
+    pub fn tls13(&self) -> bool {
+        self.tls13
+    }
+}
+
+impl<S: AsyncReadUnpin> ReadExtBase for ProxyTlsStream<S> {
+    fn prepare(&mut self) -> (&mut dyn AsyncReadUnpin, &mut BytesMut, &mut usize) {
+        (&mut self.raw, &mut self.read_buf, &mut self.read_pos)
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for ProxyTlsStream<S> {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+
+        if this.fake_request {
+            return Pin::new(&mut this.raw).poll_read(cx, buf);
+        }
+
+        // let r = Pin::new(&mut this.raw).poll_read(cx, buf);
+
+        loop {
+            match this.read_state {
+                ReadState::WaitingHeader => {
+                    ready!(this.poll_read_exact(cx, TLS_HEADER_SIZE))?;
+                    let buf = this.read_buf.split().freeze().to_vec();
+
+                    let mut size: [u8; 2] = Default::default();
+                    size.copy_from_slice(&buf[3..5]);
+                    let data_size = u16::from_be_bytes(size) as usize;
+
+                    let mut header = [0u8; TLS_HEADER_SIZE];
+                    header.copy_from_slice(&buf[..TLS_HEADER_SIZE]);
+
+                    this.read_state = ReadState::WaitingData(data_size, header);
+                }
+                ReadState::WaitingData(size, mut header) => {
+                    ready!(this.poll_read_exact(cx, size))?;
+                    // now the data is ready with the required size
+                    let mut body = this.read_buf.split().freeze().to_vec();
+
+                    match header[0] {
+                        HANDSHAKE => {
+                            if body.len() > SERVER_RANDOM_OFFSET + TLS_RANDOM_SIZE
+                                && body[0] == SERVER_HELLO
+                            {
+                                let mut server_random = [0; TLS_RANDOM_SIZE];
+                                unsafe {
+                                    copy_nonoverlapping(
+                                        body.as_ptr().add(SERVER_RANDOM_OFFSET),
+                                        server_random.as_mut_ptr(),
+                                        TLS_RANDOM_SIZE,
+                                    )
+                                }
+                                let hmac = Hmac::new(&this.password, (&server_random, &[]));
+                                let key = kdf(&this.password, &server_random);
+                                this.certs = Some(Certs {
+                                    server_random,
+                                    hmac,
+                                    key,
+                                });
+                                this.tls13 = support_tls13(&body);
+                            }
+                        }
+                        APPLICATION_DATA => {
+                            this.read_authorized = false;
+                            if body.len() > HMAC_SIZE {
+                                if let Some(Certs { hmac, key, .. }) = this.certs.as_mut() {
+                                    hmac.update(&body[HMAC_SIZE..]);
+                                    if hmac.finalize() == body[0..HMAC_SIZE] {
+                                        // 1. xor to the the original data
+                                        xor_slice(&mut body[HMAC_SIZE..], key);
+                                        // 2. remove the hmac
+                                        unsafe {
+                                            copy(
+                                                body.as_ptr().add(HMAC_SIZE),
+                                                body.as_mut_ptr(),
+                                                body.len() - HMAC_SIZE,
+                                            )
+                                        };
+                                        // 3. rewrite the data size in the header
+                                        (&mut header[3..5])
+                                            .write_u16::<BigEndian>(size as u16 - HMAC_SIZE as u16)
+                                            .unwrap();
+                                        this.read_authorized = true;
+                                        // 4. rewrite the body length to be put into the read buf
+                                        unsafe {
+                                            body.set_len(body.len() - HMAC_SIZE);
+                                        }
+                                        // 4. put the header and body into our own read buf
+                                        tracing::debug!("shadowtls authorization sucess");
+                                    } else {
+                                        tracing::debug!("shadowtls verification failed");
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+
+                    this.read_buf.put(&header[..]);
+                    this.read_buf.put(&body[..]);
+                    this.read_state = ReadState::FlushingData;
+                }
+                ReadState::FlushingData => {
+                    // now the data is ready in the read_buf
+                    let size = this.read_buf.len();
+                    let to_read = std::cmp::min(buf.remaining(), size);
+                    let payload = this.read_buf.split_to(to_read);
+                    buf.put_slice(&payload);
+                    if to_read < size {
+                        // there're unread data, continues in next poll
+                        this.read_state = ReadState::FlushingData;
+                    } else {
+                        // all data consumed, ready to read next chunk
+                        this.read_state = ReadState::WaitingHeader;
+                    }
+
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for ProxyTlsStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.raw).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.raw).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.raw).poll_shutdown(cx)
+    }
+}
+
+#[derive(Debug)]
+pub struct VerifiedStream<S> {
+    pub raw: S,
+    client_cert: Hmac,
+    server_cert: Hmac,
+    nop_cert: Option<Hmac>,
+
+    pub read_buf: BytesMut,
+    pub read_pos: usize,
+    pub read_state: ReadState,
+
+    pub write_buf: BytesMut,
+    pub write_state: WriteState,
+}
+
+impl<S> VerifiedStream<S> {
+    pub(crate) fn new(
+        raw: S,
+        client_cert: Hmac,
+        server_cert: Hmac,
+        nop_cert: Option<Hmac>,
+    ) -> Self {
+        Self {
+            raw,
+            client_cert,
+            server_cert,
+            nop_cert,
+            read_buf: Default::default(),
+            read_pos: Default::default(),
+            read_state: Default::default(),
+            write_buf: Default::default(),
+            write_state: Default::default(),
+        }
+    }
+}
+
+impl<S: AsyncReadUnpin> ReadExtBase for VerifiedStream<S> {
+    fn prepare(&mut self) -> (&mut dyn AsyncReadUnpin, &mut BytesMut, &mut usize) {
+        (&mut self.raw, &mut self.read_buf, &mut self.read_pos)
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for VerifiedStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+
+        loop {
+            match this.read_state {
+                ReadState::WaitingHeader => {
+                    ready!(this.poll_read_exact(cx, TLS_HEADER_SIZE))?;
+                    let buf = this.read_buf.split().freeze().to_vec();
+
+                    let mut size: [u8; 2] = Default::default();
+                    size.copy_from_slice(&buf[3..5]);
+                    let data_size = u16::from_be_bytes(size) as usize;
+
+                    let mut header = [0u8; TLS_HEADER_SIZE];
+                    header.copy_from_slice(&buf[..TLS_HEADER_SIZE]);
+
+                    this.read_state = ReadState::WaitingData(data_size, header);
+                }
+                ReadState::WaitingData(size, header) => {
+                    ready!(this.poll_read_exact(cx, size))?;
+                    // now the data is ready with the required size
+                    let mut data = this.read_buf.split().freeze().to_vec();
+
+                    match header[0] {
+                        APPLICATION_DATA => {
+                            // ignore the rest useless data
+                            if let Some(ref mut nop_cert) = this.nop_cert {
+                                if verify_appdata(&header, &mut data, nop_cert, false) {
+                                    this.read_state = ReadState::WaitingHeader;
+                                    continue;
+                                } else {
+                                    this.nop_cert.take();
+                                }
+                            }
+
+                            // the application data from the data server
+                            // we need to verfiy and removec the hmac(4 bytes)
+                            if verify_appdata(&header, &mut data, &mut this.server_cert, true) {
+                                // modify data, reuse the read buf
+                                tracing::trace!("shadowtls verify appdata success, strip the hmac");
+                                this.read_buf.clear();
+                                this.read_buf.put(&data[HMAC_SIZE..]);
+                                this.read_state = ReadState::FlushingData;
+                            } else {
+                                tracing::error!("shadowtls appdata verify failed");
+                                return Poll::Ready(Err(std::io::Error::new(
+                                    std::io::ErrorKind::InvalidData,
+                                    "appdata verify failed",
+                                )));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                ReadState::FlushingData => {
+                    // now the data is ready in the read_buf
+                    let size = this.read_buf.len();
+                    let to_read = std::cmp::min(buf.remaining(), size);
+                    let payload = this.read_buf.split_to(to_read);
+                    buf.put_slice(&payload);
+                    if to_read < size {
+                        // there're unread data, continues in next poll
+                        this.read_state = ReadState::FlushingData;
+                    } else {
+                        // all data consumed, ready to read next chunk
+                        this.read_state = ReadState::WaitingHeader;
+                    }
+
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for VerifiedStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        let this = self.get_mut();
+        loop {
+            match this.write_state {
+                WriteState::BuildingData => {
+                    // header(5 bytes) + zero hmac(4 bytes)
+                    const DEFAULT_HEADER_HMAC: [u8; TLS_HMAC_HEADER_SIZE] =
+                        [APPLICATION_DATA, TLS_MAJOR, TLS_MINOR.0, 0, 0, 0, 0, 0, 0];
+
+                    let mut header_body = Vec::with_capacity(COPY_BUF_SIZE);
+                    header_body.extend_from_slice(&DEFAULT_HEADER_HMAC);
+
+                    (&mut header_body[3..5])
+                        .write_u16::<BigEndian>((buf.len() + HMAC_SIZE) as u16)
+                        .unwrap();
+                    header_body.extend_from_slice(buf);
+
+                    this.client_cert.update(buf);
+                    let hmac_val = this.client_cert.finalize();
+                    this.client_cert.update(&hmac_val);
+                    unsafe {
+                        copy_nonoverlapping(
+                            hmac_val.as_ptr(),
+                            header_body.as_mut_ptr().add(TLS_HEADER_SIZE),
+                            HMAC_SIZE,
+                        )
+                    };
+
+                    this.write_buf.put_slice(&header_body);
+                    this.write_state =
+                        WriteState::FlushingData(buf.len(), header_body.len(), 0);
+                }
+                WriteState::FlushingData(consume, total, written) => {
+                    let nw = ready!(tokio_util::io::poll_write_buf(
+                        Pin::new(&mut this.raw),
+                        cx,
+                        &mut this.write_buf
+                    ))?;
+                    if nw == 0 {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::WriteZero,
+                            "failed to write whole data",
+                        ))
+                        .into();
+                    }
+
+                    if written + nw >= total {
+                        debug_assert_eq!(written + nw, total);
+                        // data chunk written, go to next chunk
+                        this.write_state = WriteState::BuildingData;
+                        return Poll::Ready(Ok(consume));
+                    }
+
+                    this.write_state = WriteState::FlushingData(consume, total, written + nw);
+                }
+            }
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.raw).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.raw).poll_shutdown(cx)
+    }
+}
+
+fn verify_appdata(
+    header: &[u8; TLS_HEADER_SIZE],
+    data: &mut [u8],
+    hmac: &mut Hmac,
+    sep: bool,
+) -> bool {
+    if header[1] != TLS_MAJOR || header[2] != TLS_MINOR.0 {
+        return false;
+    }
+    hmac.update(&data[HMAC_SIZE..]);
+    let hmac_real = hmac.finalize();
+    if sep {
+        hmac.update(&hmac_real);
+    }
+    data[0..HMAC_SIZE] == hmac_real
+}

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
@@ -441,8 +441,7 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for VerifiedStream<S> {
                     };
 
                     this.write_buf.put_slice(&header_body);
-                    this.write_state =
-                        WriteState::FlushingData(buf.len(), header_body.len(), 0);
+                    this.write_state = WriteState::FlushingData(buf.len(), header_body.len(), 0);
                 }
                 WriteState::FlushingData(consume, total, written) => {
                     let nw = ready!(tokio_util::io::poll_write_buf(

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
@@ -225,7 +225,6 @@ impl<S: AsyncRead + Unpin> AsyncRead for ProxyTlsStream<S> {
                                             body.set_len(body.len() - HMAC_SIZE);
                                         }
                                         // 4. put the header and body into our own read buf
-                                        tracing::debug!("shadowtls authorization sucess");
                                     } else {
                                         tracing::debug!("shadowtls verification failed");
                                     }
@@ -373,7 +372,6 @@ impl<S: AsyncRead + Unpin> AsyncRead for VerifiedStream<S> {
                             // we need to verfiy and removec the hmac(4 bytes)
                             if verify_appdata(&header, &mut data, &mut this.server_cert, true) {
                                 // modify data, reuse the read buf
-                                tracing::trace!("shadowtls verify appdata success, strip the hmac");
                                 this.read_buf.clear();
                                 this.read_buf.put(&data[HMAC_SIZE..]);
                                 this.read_state = ReadState::FlushingData;

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/stream.rs
@@ -9,7 +9,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 use bytes::{BufMut, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use super::utils::{prelude::*, Hmac, *};
+use super::utils::{prelude::*, *};
 
 #[derive(Default, Debug)]
 pub enum ReadState {

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/utils.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/utils.rs
@@ -84,6 +84,7 @@ pub(crate) fn xor_slice(data: &mut [u8], key: &[u8]) {
         .for_each(|(d, k)| *d ^= k);
 }
 
+#[allow(unused)]
 pub(crate) trait CursorExt {
     fn read_by_u16(&mut self) -> std::io::Result<Vec<u8>>;
     fn skip(&mut self, n: usize) -> std::io::Result<()>;

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/utils.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/utils.rs
@@ -1,0 +1,166 @@
+use std::{io::Read, ptr::copy_nonoverlapping};
+
+use byteorder::{BigEndian, ReadBytesExt};
+use hmac::Mac;
+
+use prelude::*;
+use sha2::{Digest, Sha256};
+
+pub(crate) mod prelude {
+    pub(crate) const TLS_MAJOR: u8 = 0x03;
+    pub(crate) const TLS_MINOR: (u8, u8) = (0x03, 0x01);
+    pub(crate) const SUPPORTED_VERSIONS_TYPE: u16 = 43;
+    pub(crate) const TLS_RANDOM_SIZE: usize = 32;
+    pub(crate) const TLS_HEADER_SIZE: usize = 5;
+    pub(crate) const TLS_SESSION_ID_SIZE: usize = 32;
+    pub(crate) const TLS_13: u16 = 0x0304;
+
+    pub(crate) const SERVER_HELLO: u8 = 0x02;
+    pub(crate) const HANDSHAKE: u8 = 0x16;
+    pub(crate) const APPLICATION_DATA: u8 = 0x17;
+
+    pub(crate) const SERVER_RANDOM_OFFSET: usize = 1 + 3 + 2;
+    pub(crate) const SESSION_ID_LEN_IDX: usize = TLS_HEADER_SIZE + 1 + 3 + 2 + TLS_RANDOM_SIZE;
+    pub(crate) const TLS_HMAC_HEADER_SIZE: usize = TLS_HEADER_SIZE + HMAC_SIZE;
+
+    pub(crate) const COPY_BUF_SIZE: usize = 4096;
+    pub(crate) const HMAC_SIZE: usize = 4;
+}
+
+#[derive(Clone)]
+pub(crate) struct Hmac(hmac::Hmac<sha1::Sha1>);
+
+impl std::fmt::Debug for Hmac {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Hmac").finish()
+    }
+}
+
+impl Hmac {
+    #[inline]
+    pub(crate) fn new(password: &str, init_data: (&[u8], &[u8])) -> Self {
+        // Note: infact new_from_slice never returns Err.
+        let mut hmac: hmac::Hmac<sha1::Sha1> =
+            hmac::Hmac::new_from_slice(password.as_bytes()).expect("unable to build hmac instance");
+        hmac.update(init_data.0);
+        hmac.update(init_data.1);
+        Self(hmac)
+    }
+
+    #[inline]
+    // #[tracing::instrument(skip(data), level = "debug")]
+    pub(crate) fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    #[inline]
+    pub(crate) fn finalize(&self) -> [u8; HMAC_SIZE] {
+        let hmac = self.0.clone();
+        let hash = hmac.finalize().into_bytes();
+        let mut res = [0; HMAC_SIZE];
+        unsafe { copy_nonoverlapping(hash.as_slice().as_ptr(), res.as_mut_ptr(), HMAC_SIZE) };
+        res
+    }
+
+    #[inline]
+    pub(crate) fn to_owned(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+#[inline]
+pub(crate) fn kdf(password: &str, server_random: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(password.as_bytes());
+    hasher.update(server_random);
+    let hash = hasher.finalize();
+    hash.to_vec()
+}
+
+#[inline]
+pub(crate) fn xor_slice(data: &mut [u8], key: &[u8]) {
+    data.iter_mut()
+        .zip(key.iter().cycle())
+        .for_each(|(d, k)| *d ^= k);
+}
+
+pub(crate) trait CursorExt {
+    fn read_by_u16(&mut self) -> std::io::Result<Vec<u8>>;
+    fn skip(&mut self, n: usize) -> std::io::Result<()>;
+    fn skip_by_u8(&mut self) -> std::io::Result<u8>;
+    fn skip_by_u16(&mut self) -> std::io::Result<u16>;
+}
+
+impl<T> CursorExt for std::io::Cursor<T>
+where
+    std::io::Cursor<T>: std::io::Read,
+{
+    #[inline]
+    fn read_by_u16(&mut self) -> std::io::Result<Vec<u8>> {
+        let len = self.read_u16::<BigEndian>()?;
+        let mut buf = vec![0; len as usize];
+        self.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    #[inline]
+    fn skip(&mut self, n: usize) -> std::io::Result<()> {
+        for _ in 0..n {
+            self.read_u8()?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn skip_by_u8(&mut self) -> std::io::Result<u8> {
+        let len = self.read_u8()?;
+        self.skip(len as usize)?;
+        Ok(len)
+    }
+
+    #[inline]
+    fn skip_by_u16(&mut self) -> std::io::Result<u16> {
+        let len = self.read_u16::<BigEndian>()?;
+        self.skip(len as usize)?;
+        Ok(len)
+    }
+}
+
+/// Parse ServerHello and return if tls1.3 is supported.
+pub(crate) fn support_tls13(frame: &[u8]) -> bool {
+    if frame.len() < SESSION_ID_LEN_IDX {
+        return false;
+    }
+    let mut cursor = std::io::Cursor::new(&frame[SESSION_ID_LEN_IDX..]);
+    macro_rules! read_ok {
+        ($res: expr) => {
+            match $res {
+                Ok(r) => r,
+                Err(_) => {
+                    return false;
+                }
+            }
+        };
+    }
+
+    // skip session id
+    read_ok!(cursor.skip_by_u8());
+    // skip cipher suites
+    read_ok!(cursor.skip(3));
+    // skip ext length
+    let cnt = read_ok!(cursor.read_u16::<BigEndian>());
+
+    for _ in 0..cnt {
+        let ext_type = read_ok!(cursor.read_u16::<BigEndian>());
+        if ext_type != SUPPORTED_VERSIONS_TYPE {
+            read_ok!(cursor.skip_by_u16());
+            continue;
+        }
+        let ext_len = read_ok!(cursor.read_u16::<BigEndian>());
+        let ext_val = read_ok!(cursor.read_u16::<BigEndian>());
+        let use_tls13 = ext_len == 2 && ext_val == TLS_13;
+        tracing::debug!("found supported_versions extension, tls1.3: {use_tls13}");
+        return use_tls13;
+    }
+    false
+}

--- a/clash_lib/src/proxy/trojan/mod.rs
+++ b/clash_lib/src/proxy/trojan/mod.rs
@@ -278,7 +278,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_ws_runner()).await
+        run(handler, get_ws_runner().await?).await
     }
 
     async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
@@ -317,6 +317,6 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_grpc_runner()).await
+        run(handler, get_grpc_runner().await?).await
     }
 }

--- a/clash_lib/src/proxy/trojan/mod.rs
+++ b/clash_lib/src/proxy/trojan/mod.rs
@@ -225,8 +225,6 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use tracing_test::traced_test;
-
     use crate::proxy::utils::test_utils::{
         config_helper::test_config_base_dir,
         consts::*,
@@ -254,9 +252,15 @@ mod tests {
     }
 
     #[tokio::test]
-    #[traced_test]
     #[serial_test::serial]
     async fn test_trojan_ws() -> anyhow::Result<()> {
+        let _ = tracing_subscriber::fmt()
+            // any additional configuration of the subscriber you might want here..
+            .try_init();
+
+        let span = tracing::info_span!("test_trojan_ws");
+        let _enter = span.enter();
+
         let opts = Opts {
             name: "test-trojan-ws".to_owned(),
             common_opts: Default::default(),

--- a/clash_lib/src/proxy/utils/socket_helpers.rs
+++ b/clash_lib/src/proxy/utils/socket_helpers.rs
@@ -82,6 +82,7 @@ pub async fn new_tcp_stream<'a>(
             io::ErrorKind::Other,
             format!("can't resolve dns: {}", address),
         ))?;
+    tracing::debug!("resolved addr of {:?}:{:?}", address, dial_addr);
 
     let socket = match (dial_addr, resolver.ipv6()) {
         (IpAddr::V4(_), _) => {

--- a/clash_lib/src/proxy/utils/test_utils/config_helper.rs
+++ b/clash_lib/src/proxy/utils/test_utils/config_helper.rs
@@ -44,11 +44,7 @@ pub async fn load_config() -> anyhow::Result<(
 
     debug!("initializing cache store");
     let cache_store = profile::ThreadSafeCacheFile::new(
-        root
-            .join("cache.db")
-            .as_path()
-            .to_str()
-            .unwrap(),
+        root.join("cache.db").as_path().to_str().unwrap(),
         config.profile.store_selected,
     );
 

--- a/clash_lib/src/proxy/utils/test_utils/config_helper.rs
+++ b/clash_lib/src/proxy/utils/test_utils/config_helper.rs
@@ -44,7 +44,7 @@ pub async fn load_config() -> anyhow::Result<(
 
     debug!("initializing cache store");
     let cache_store = profile::ThreadSafeCacheFile::new(
-        PathBuf::from(root)
+        root
             .join("cache.db")
             .as_path()
             .to_str()

--- a/clash_lib/src/proxy/utils/test_utils/consts.rs
+++ b/clash_lib/src/proxy/utils/test_utils/consts.rs
@@ -3,6 +3,7 @@ pub const EXAMPLE_REQ: &[u8] = b"GET / HTTP/1.1\r\nHost: example.com\r\nAccept: 
 pub const EXAMLE_RESP_200: &[u8] = b"HTTP/1.1 200";
 
 pub const IMAGE_SS_RUST: &str = "ghcr.io/shadowsocks/ssserver-rust:latest";
+pub const IMAGE_SHADOW_TLS: &str = "ghcr.io/ihciah/shadow-tls:latest";
 pub const IMAGE_TROJAN_GO: &str = "p4gefau1t/trojan-go:latest";
 pub const IMAGE_VMESS: &str = "v2fly/v2fly-core:v4.45.2";
 pub const IMAGE_XRAY: &str = "teddysun/xray:latest";

--- a/clash_lib/src/proxy/utils/test_utils/docker_runner.rs
+++ b/clash_lib/src/proxy/utils/test_utils/docker_runner.rs
@@ -17,8 +17,8 @@ pub struct DockerTestRunner {
 }
 
 impl DockerTestRunner {
-    pub async fn try_new<'a>(
-        image_conf: Option<CreateImageOptions<'a, String>>,
+    pub async fn try_new(
+        image_conf: Option<CreateImageOptions<'_, String>>,
         container_conf: Config<String>,
     ) -> Result<Self> {
         let docker: Docker = Docker::connect_with_socket_defaults()?;
@@ -41,8 +41,7 @@ impl DockerTestRunner {
 
     // you can run the cleanup manually
     pub async fn cleanup(self) -> anyhow::Result<()> {
-        let s = self
-            .instance
+        self.instance
             .remove_container(
                 &self.id,
                 Some(RemoveContainerOptions {
@@ -51,7 +50,7 @@ impl DockerTestRunner {
                 }),
             )
             .await?;
-        Ok(s)
+        Ok(())
     }
 }
 
@@ -214,7 +213,7 @@ impl DockerTestRunnerBuilder {
     pub fn mounts(mut self, pairs: &[(&str, &str)]) -> Self {
         self.host_config.mounts = Some(
             pairs
-                .into_iter()
+                .iter()
                 .map(|(src, dst)| Mount {
                     target: Some(dst.to_string()),
                     source: Some(src.to_string()),

--- a/clash_lib/src/proxy/utils/test_utils/mod.rs
+++ b/clash_lib/src/proxy/utils/test_utils/mod.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 use tracing::info;
 
-use self::docker_runner::DockerTestRunner;
+use self::docker_runner::{MultiDockerTestRunner, DockerTest, DockerTestRunner};
 
 pub mod config_helper;
 pub mod consts;
@@ -187,7 +187,20 @@ pub async fn run(
             return Err(e);
         }
     };
+    run_inner(handler, watch).await
+}
 
+pub async fn run_chained(
+    handler: Arc<dyn OutboundHandler>,
+    chained: MultiDockerTestRunner,
+) -> anyhow::Result<()> {
+    run_inner(handler, chained).await
+}
+
+pub async fn run_inner(
+    handler: Arc<dyn OutboundHandler>,
+    watch: impl DockerTest,
+) -> anyhow::Result<()> {
     watch
         .run_and_cleanup(async move {
             let rv = ping_pong_test(handler.clone(), 10001).await;

--- a/clash_lib/src/proxy/utils/test_utils/mod.rs
+++ b/clash_lib/src/proxy/utils/test_utils/mod.rs
@@ -197,13 +197,13 @@ pub async fn run(handler: Arc<dyn OutboundHandler>, watch: impl DockerTest) -> a
                 },
             )
             .await;
-            if rv.is_err() {
-                return Err(rv.unwrap_err());
+            if let Err(e) = rv {
+                return Err(e);
             } else {
                 tracing::info!("latency test success: {}", rv.unwrap().as_millis());
             }
 
-            return Ok(());
+            Ok(())
         })
         .await
 }

--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -255,9 +255,6 @@ impl OutboundHandler for Handler {
 
 #[cfg(all(test, not(ci)))]
 mod tests {
-
-    use tracing_test::traced_test;
-
     use crate::proxy::utils::test_utils::{
         config_helper::test_config_base_dir,
         consts::*,
@@ -279,9 +276,15 @@ mod tests {
     }
 
     #[tokio::test]
-    #[traced_test]
     #[serial_test::serial]
     async fn test_vmess_ws() -> anyhow::Result<()> {
+        let _ = tracing_subscriber::fmt()
+            // any additional configuration of the subscriber you might want here..
+            .try_init();
+
+        let span = tracing::info_span!("test_vmess_ws");
+        let _enter = span.enter();
+
         let opts = HandlerOptions {
             name: "test-vmess-ws".into(),
             common_opts: Default::default(),

--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -303,7 +303,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_ws_runner()).await
+        run(handler, get_ws_runner().await?).await
     }
 
     async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
@@ -346,7 +346,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_grpc_runner()).await
+        run(handler, get_grpc_runner().await?).await
     }
 
     async fn get_h2_runner() -> anyhow::Result<DockerTestRunner> {
@@ -389,6 +389,6 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_h2_runner()).await
+        run(handler, get_h2_runner().await?).await
     }
 }


### PR DESCRIPTION
implement shadow-tls protocol's client(v3)

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/Watfaq/clash-rs/issues/321

### 💡 Background and solution

see the background mentioned in the issue. 

solution:
1. patch the rustls & tokio-rusls crates, support customed client id in the client hello
2. implement shadow-tls's client v3
3. add shadow-tls option in shadowsocks's plugins

Tests has been done in my ubuntu 22.04.

### 📝 Changelog

Support shadow-tls(v3 only)

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
