### PR TITLE
enhance/multi docker test

### DIFF
--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -291,12 +291,10 @@ impl OutboundHandler for Handler {
 #[cfg(all(test, not(ci)))]
 mod tests {
 
-    use crate::proxy::utils::test_utils::docker_runner::{
-        MultiDockerTestRunner, DockerTestRunnerBuilder,
-    };
-    use crate::proxy::utils::test_utils::run_chained;
-
     use super::super::utils::test_utils::{consts::*, docker_runner::DockerTestRunner, run};
+    use crate::proxy::utils::test_utils::docker_runner::{
+        DockerTestRunnerBuilder, MultiDockerTestRunner,
+    };
 
     use super::*;
 
@@ -329,7 +327,7 @@ mod tests {
         };
         let port = opts.port;
         let handler = Handler::new(opts);
-        run(handler, get_ss_runner(port)).await
+        run(handler, get_ss_runner(port).await?).await
     }
 
     async fn get_shadowtls_runner(
@@ -384,6 +382,6 @@ mod tests {
         chained
             .add(get_shadowtls_runner(ss_port, shadow_tls_port))
             .await;
-        run_chained(handler, chained).await
+        run(handler, chained).await
     }
 }

--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -291,7 +291,10 @@ impl OutboundHandler for Handler {
 #[cfg(all(test, not(ci)))]
 mod tests {
 
-    use crate::proxy::utils::test_utils::docker_runner::DockerTestRunnerBuilder;
+    use crate::proxy::utils::test_utils::docker_runner::{
+        MultiDockerTestRunner, DockerTestRunnerBuilder,
+    };
+    use crate::proxy::utils::test_utils::run_chained;
 
     use super::super::utils::test_utils::{consts::*, docker_runner::DockerTestRunner, run};
 
@@ -299,12 +302,14 @@ mod tests {
 
     const PASSWORD: &str = "FzcLbKs2dY9mhL";
     const CIPHER: &str = "aes-256-gcm";
+    const SHADOW_TLS_PASSWORD: &str = "password";
 
-    async fn get_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_ss_runner(port: u16) -> anyhow::Result<DockerTestRunner> {
+        let host = format!("0.0.0.0:{}", port);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SS_RUST)
             .entrypoint(&["ssserver"])
-            .cmd(&["-s", "0.0.0.0:10002", "-m", CIPHER, "-k", PASSWORD, "-U"])
+            .cmd(&["-s", &host, "-m", CIPHER, "-k", PASSWORD, "-U"])
             .build()
             .await
     }
@@ -322,7 +327,63 @@ mod tests {
             plugin_opts: Default::default(),
             udp: false,
         };
+        let port = opts.port;
         let handler = Handler::new(opts);
-        run(handler, get_runner()).await
+        run(handler, get_ss_runner(port)).await
+    }
+
+    async fn get_shadowtls_runner(
+        ss_port: u16,
+        stls_port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
+        let ss_server_env = format!("SERVER=127.0.0.1:{}", ss_port);
+        let listen_env = format!("LISTEN=0.0.0.0:{}", stls_port);
+        let password = format!("PASSWORD={}", SHADOW_TLS_PASSWORD);
+        DockerTestRunnerBuilder::new()
+            .image(IMAGE_SHADOW_TLS)
+            .env(&[
+                "MODE=server",
+                // the port that we need to fill in the config
+                &listen_env,
+                // shadowsocks server addr
+                &ss_server_env,
+                "TLS=www.feishu.cn:443",
+                &password,
+                "V3=1",
+            ])
+            // .cmd(&["-s", "0.0.0.0:10002", "-m", CIPHER, "-k", PASSWORD, "-U"])
+            .build()
+            .await
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_shadowtls() -> anyhow::Result<()> {
+        // the real port that used for communication
+        let shadow_tls_port = 10002;
+        // not important, you can assign any port that is not conflict with others
+        let ss_port = 10004;
+        let opts = HandlerOptions {
+            name: "test-ss".to_owned(),
+            common_opts: Default::default(),
+            server: LOCAL_ADDR.to_owned(),
+            port: shadow_tls_port,
+            password: PASSWORD.to_owned(),
+            cipher: CIPHER.to_owned(),
+            plugin_opts: Some(OBFSOption::ShadowTls(ShadowTlsOption {
+                host: "www.feishu.cn".to_owned(),
+                password: "password".to_owned(),
+                strict: true,
+            })),
+            udp: false,
+        };
+        let handler = Handler::new(opts);
+        // we need to store all the runners in a container, to make sure all of them can be destroyed after the test
+        let mut chained = MultiDockerTestRunner::default();
+        chained.add(get_ss_runner(ss_port)).await;
+        chained
+            .add(get_shadowtls_runner(ss_port, shadow_tls_port))
+            .await;
+        run_chained(handler, chained).await
     }
 }

--- a/clash_lib/src/proxy/trojan/mod.rs
+++ b/clash_lib/src/proxy/trojan/mod.rs
@@ -278,7 +278,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_ws_runner()).await
+        run(handler, get_ws_runner().await?).await
     }
 
     async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
@@ -317,6 +317,6 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_grpc_runner()).await
+        run(handler, get_grpc_runner().await?).await
     }
 }

--- a/clash_lib/src/proxy/trojan/mod.rs
+++ b/clash_lib/src/proxy/trojan/mod.rs
@@ -231,7 +231,7 @@ mod tests {
         config_helper::test_config_base_dir,
         consts::*,
         docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
-        run,
+        run_default_test_suites_and_cleanup,
     };
 
     use super::*;
@@ -278,7 +278,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_ws_runner().await?).await
+        run_default_test_suites_and_cleanup(handler, get_ws_runner().await?).await
     }
 
     async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
@@ -317,6 +317,6 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_grpc_runner().await?).await
+        run_default_test_suites_and_cleanup(handler, get_grpc_runner().await?).await
     }
 }

--- a/clash_lib/src/proxy/utils/test_utils/consts.rs
+++ b/clash_lib/src/proxy/utils/test_utils/consts.rs
@@ -3,6 +3,7 @@ pub const EXAMPLE_REQ: &[u8] = b"GET / HTTP/1.1\r\nHost: example.com\r\nAccept: 
 pub const EXAMLE_RESP_200: &[u8] = b"HTTP/1.1 200";
 
 pub const IMAGE_SS_RUST: &str = "ghcr.io/shadowsocks/ssserver-rust:latest";
+pub const IMAGE_SHADOW_TLS: &str = "ghcr.io/ihciah/shadow-tls:latest";
 pub const IMAGE_TROJAN_GO: &str = "p4gefau1t/trojan-go:latest";
 pub const IMAGE_VMESS: &str = "v2fly/v2fly-core:v4.45.2";
 pub const IMAGE_XRAY: &str = "teddysun/xray:latest";

--- a/clash_lib/src/proxy/utils/test_utils/docker_runner.rs
+++ b/clash_lib/src/proxy/utils/test_utils/docker_runner.rs
@@ -60,8 +60,9 @@ pub struct MultiDockerTestRunner {
     runners: Vec<DockerTestRunner>,
 }
 
+// TODO: use this test runner to support test of ss's plugins
+#[allow(unused)]
 impl MultiDockerTestRunner {
-    #[allow(unused)]
     pub fn new(runners: Vec<DockerTestRunner>) -> Self {
         Self { runners }
     }
@@ -82,7 +83,7 @@ impl MultiDockerTestRunner {
 }
 
 #[async_trait::async_trait]
-pub trait DockerTest {
+pub trait RunAndCleanup {
     async fn run_and_cleanup(
         self,
         f: impl Future<Output = anyhow::Result<()>> + Send + 'static,
@@ -90,7 +91,7 @@ pub trait DockerTest {
 }
 
 #[async_trait::async_trait]
-impl DockerTest for DockerTestRunner {
+impl RunAndCleanup for DockerTestRunner {
     async fn run_and_cleanup(
         self,
         f: impl Future<Output = anyhow::Result<()>> + Send + 'static,
@@ -115,7 +116,7 @@ impl DockerTest for DockerTestRunner {
 }
 
 #[async_trait::async_trait]
-impl DockerTest for MultiDockerTestRunner {
+impl RunAndCleanup for MultiDockerTestRunner {
     async fn run_and_cleanup(
         self,
         f: impl Future<Output = anyhow::Result<()>> + Send + 'static,

--- a/clash_lib/src/proxy/utils/test_utils/mod.rs
+++ b/clash_lib/src/proxy/utils/test_utils/mod.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 use tracing::info;
 
-use self::docker_runner::DockerTestRunner;
+use self::docker_runner::{MultiDockerTestRunner, DockerTest, DockerTestRunner};
 
 pub mod config_helper;
 pub mod consts;
@@ -187,7 +187,20 @@ pub async fn run(
             return Err(e);
         }
     };
+    run_inner(handler, watch).await
+}
 
+pub async fn run_chained(
+    handler: Arc<dyn OutboundHandler>,
+    chained: MultiDockerTestRunner,
+) -> anyhow::Result<()> {
+    run_inner(handler, chained).await
+}
+
+pub async fn run_inner(
+    handler: Arc<dyn OutboundHandler>,
+    watch: impl DockerTest,
+) -> anyhow::Result<()> {
     watch
         .run_and_cleanup(async move {
             let rv = ping_pong_test(handler.clone(), 10001).await;

--- a/clash_lib/src/proxy/utils/test_utils/mod.rs
+++ b/clash_lib/src/proxy/utils/test_utils/mod.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 use tracing::info;
 
-use self::docker_runner::DockerTest;
+use self::docker_runner::RunAndCleanup;
 
 pub mod config_helper;
 pub mod consts;
@@ -176,7 +176,10 @@ pub async fn latency_test(
     Ok(end_time.duration_since(start_time))
 }
 
-pub async fn run(handler: Arc<dyn OutboundHandler>, watch: impl DockerTest) -> anyhow::Result<()> {
+pub async fn run_default_test_suites_and_cleanup(
+    handler: Arc<dyn OutboundHandler>,
+    watch: impl RunAndCleanup,
+) -> anyhow::Result<()> {
     watch
         .run_and_cleanup(async move {
             let rv = ping_pong_test(handler.clone(), 10001).await;

--- a/clash_lib/src/proxy/utils/test_utils/mod.rs
+++ b/clash_lib/src/proxy/utils/test_utils/mod.rs
@@ -178,9 +178,9 @@ pub async fn latency_test(
 
 pub async fn run_default_test_suites_and_cleanup(
     handler: Arc<dyn OutboundHandler>,
-    watch: impl RunAndCleanup,
+    docker_test_runner: impl RunAndCleanup,
 ) -> anyhow::Result<()> {
-    watch
+    docker_test_runner
         .run_and_cleanup(async move {
             let rv = ping_pong_test(handler.clone(), 10001).await;
             if rv.is_err() {

--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -262,7 +262,7 @@ mod tests {
         config_helper::test_config_base_dir,
         consts::*,
         docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
-        run,
+        run_default_test_suites_and_cleanup,
     };
 
     use super::*;
@@ -303,7 +303,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_ws_runner().await?).await
+        run_default_test_suites_and_cleanup(handler, get_ws_runner().await?).await
     }
 
     async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
@@ -346,7 +346,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_grpc_runner().await?).await
+        run_default_test_suites_and_cleanup(handler, get_grpc_runner().await?).await
     }
 
     async fn get_h2_runner() -> anyhow::Result<DockerTestRunner> {
@@ -389,6 +389,6 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_h2_runner().await?).await
+        run_default_test_suites_and_cleanup(handler, get_h2_runner().await?).await
     }
 }

--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -303,7 +303,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_ws_runner()).await
+        run(handler, get_ws_runner().await?).await
     }
 
     async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
@@ -346,7 +346,7 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_grpc_runner()).await
+        run(handler, get_grpc_runner().await?).await
     }
 
     async fn get_h2_runner() -> anyhow::Result<DockerTestRunner> {
@@ -389,6 +389,6 @@ mod tests {
             })),
         };
         let handler = Handler::new(opts);
-        run(handler, get_h2_runner()).await
+        run(handler, get_h2_runner().await?).await
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Previous PR(merged): https://github.com/Watfaq/clash-rs/pull/324

### 💡 Background and solution

to test the shadow-tls plugin for shadowsocks .etc, there are two ways: 

1. combine shadowsocks&shadow-tls binary file together, build and maintain a new one, so we can use the all-in-one image;
2. run shadowsocks image &  shadow-tls image together

the later one causes less trouble in the long term, but we need to support the running of multiple docker images at the same time. 

### 📝 Changelog

dev: support running of multiple docker images in docker test

### ☑️ Self-Check before Merge

in fact, this enhancement is picked from another branch of supporting shadow-tls protocol, the test of it has been done in my ubuntu laptop.

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
