### PR TITLE
fix: check read_buf's remaining before put_slice in obfs's http impl

### DIFF
--- a/clash_lib/src/proxy/shadowsocks/simple_obfs/http.rs
+++ b/clash_lib/src/proxy/shadowsocks/simple_obfs/http.rs
@@ -123,12 +123,12 @@ impl AsyncRead for HTTPObfs {
                             let body = &b.filled()[idx + 4..b.filled().len()];
                             if body.len() < buf.remaining() {
                                 buf.put_slice(body);
-                                return std::task::Poll::Ready(Ok(()));
+                                std::task::Poll::Ready(Ok(()))
                             } else {
                                 buf.put_slice(&body[..buf.remaining()]);
                                 pin.read_buf.reserve(body.len() - buf.remaining());
                                 pin.read_buf.clone_from_slice(&body[buf.remaining()..]);
-                                return std::task::Poll::Ready(Ok(()));
+                                std::task::Poll::Ready(Ok(()))
                             }
                         } else {
                             std::task::Poll::Ready(Err(std::io::Error::new(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/Watfaq/clash-rs/issues/426

### 💡 Background and solution

maintain a BytesMut in the stream to buffer the data that has already been read but cannot be passed to poll_read's buf, similar to other impls of `AsyncRead` in outbound handlers.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
fix: fix buf out of len issue in shadowsocks's simple_obfs's http implementation

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
