### PR TITLE
feate: linux-musl target,docker image,add rc4-md5 cipher

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:latest
-COPY ./clash-rs/clash-x86_64-unknown-linux-musl /usr/bin/clash
+# Define an ARG for the target architecture
+ARG TARGETARCH
+COPY ./clash-rs/clash-${TARGETARCH} /usr/bin/clash
 # The yq library installed here is used to rewrite the config.yaml configuration file for clash, merge it, and other related operations.
 RUN apk update && apk add --no-cache -f yq && mkdir -p /root/.config/clash/
 WORKDIR /root

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,6 +1,7 @@
-# A base image built by an ops bigwig, open source
-FROM wener/base:latest
-COPY ./clash-rs/clash-x86_64-unknown-linux-musl /usr/local/bin/clash
-RUN apk add --no-cache -f yq && mkdir -p /root/.config/clash/
+FROM alpine:latest
+COPY ./clash-rs/clash-x86_64-unknown-linux-musl /usr/bin/clash
+# The yq library installed here is used to rewrite the config.yaml configuration file for clash, merge it, and other related operations.
+RUN apk update && apk add --no-cache -f yq && mkdir -p /root/.config/clash/
 WORKDIR /root
-CMD ["/usr/local/bin/clash","-d", "/root/.config/clash/"]
+ENTRYPOINT [ "/usr/bin/clash" ]
+CMD [ "-d", "/root/.config/clash/" ]

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,6 +1,6 @@
 # A base image built by an ops bigwig, open source
 FROM wener/base:latest
-COPY ./clash-rs-upx /usr/local/bin/clash
+COPY ./clash-rs/clash-x86_64-unknown-linux-musl /usr/local/bin/clash
 RUN apk add --no-cache -f yq && mkdir -p /root/.config/clash/
 WORKDIR /root
 CMD ["/usr/local/bin/clash","-d", "/root/.config/clash/"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 
 env:
   PACKAGE: "clash"
+  REGISTRY: "ghcr.io"
+  IMAGE_NAME: "clash-rs"
+
 
 jobs:
   compile:
@@ -84,6 +87,11 @@ jobs:
             cross: true
             extra-args: "--all-features"
             rustflags: "-Ctarget-feature=+crt-static --cfg tokio_unstable"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            release-name: aarch64-unknown-linux-musl
+            cross: true
+            extra-args: "--all-features"
           - os: ubuntu-latest
             target: armv7-unknown-linux-gnueabi
             release-name: armv7-unknown-linux-gnueabi-static-crt
@@ -282,6 +290,9 @@ jobs:
     needs: [ compile ]
     name: Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -292,8 +303,8 @@ jobs:
         run: |
           echo "OWNER=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
           echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-          echo "TAG_VERSION=ghcr.io/${GITHUB_REPOSITORY_OWNER@L}/clash-rs:${VERSION}" >> $GITHUB_ENV
-          echo "TAG_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER@L}/clash-rs:latest" >> $GITHUB_ENV
+          echo "TAG_VERSION=${REGISTRY}/${GITHUB_REPOSITORY_OWNER@L}/${IMAGE_NAME}:${VERSION}" >> $GITHUB_ENV
+          echo "TAG_LATEST=${REGISTRY}/${GITHUB_REPOSITORY_OWNER@L}/${IMAGE_NAME}:latest" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -308,15 +319,25 @@ jobs:
           username: ${{ steps.get-info.outputs.OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download binaries
+      - name: Download binaries amd64
         uses: actions/download-artifact@v4
         with:
           name: x86_64-unknown-linux-musl
           path: ./clash-rs
 
+      - name: Download binaries arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: aarch64-unknown-linux-musl
+          path: ./clash-rs
+
+      - name: Rename binary
+        run: |
+          mv ./clash-rs/clash-x86_64-unknown-linux-musl ./clash-rs/clash-amd64
+          mv ./clash-rs/clash-aarch64-unknown-linux-musl ./clash-rs/clash-arm64
+
       - name: Build and push latest
         uses: docker/build-push-action@v5
-        if: startsWith(github.ref, 'refs/heads/dev')
         with:
           context: .
           file: .github/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ concurrency:
 
 env:
   PACKAGE: "clash"
-  DOCKER_REGUSTRY: "ghcr.io"
-  IMAGE_NAME: "watfaq/clash-rs"
 
 jobs:
   compile:
@@ -228,7 +226,7 @@ jobs:
         with:
           name: ${{ matrix.release-name || matrix.target }}
           path: ${{ env.PACKAGE }}-${{ matrix.release-name || matrix.target }}${{ matrix.postfix }}
-          
+
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
@@ -236,11 +234,11 @@ jobs:
           detached: true
           timeout-minutes: 15
           limit-access-to-actor: true
-          
+
   release:
     name: Release
 
-    needs: [compile]
+    needs: [ compile ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -281,57 +279,66 @@ jobs:
             packages/*
             LICENSE
   docker-image:
-    needs: [compile]
+    needs: [ compile ]
     name: Docker Image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
       - name: Get the current Git commit hash
+        id: get-info
         run: |
-          if [ "${{ github.ref_type }}" == "tag" ]; then
-            echo "TAG_VERSION=${{ env.DOCKER_REGUSTRY }}/${{ env.IMAGE_NAME }}:${TAG_NAME#v}" >> $GITHUB_ENV
-            echo "TAG_LATEST=${{ env.DOCKER_REGUSTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_ENV
-          fi
-          echo "TAG=${{ env.DOCKER_REGUSTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          echo "TAG_VERSION=ghcr.io/${GITHUB_REPOSITORY_OWNER@L}/clash-rs:${VERSION}" >> $GITHUB_ENV
+          echo "TAG_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER@L}/clash-rs:latest" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Log in to Docker Hub
+
+      - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.DOCKER_REGUSTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ steps.get-info.outputs.OWNER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:
           name: x86_64-unknown-linux-musl
           path: ./clash-rs
-      - name: Install UPX
-        uses: crazy-max/ghaction-upx@v3
-        with:
-          install-only: true
-      - name: Optimize Binary by UPX
-        run: |
-          chmod +x ./clash-rs/clash-x86_64-unknown-linux-musl
-          upx '--strip-relocs=0' --best -f -o clash-rs-upx ./clash-rs/clash-x86_64-unknown-linux-musl
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ env.TAG }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        if: github.ref_type == 'tag'
-        with:
-          context: .
-          push: true
-          tags: ${{ env.TAG_VERSION }},${{ env.TAG_LATEST }}
 
+      - name: Build and push latest
+        uses: docker/build-push-action@v5
+        if: startsWith(github.ref, 'refs/heads/dev')
+        with:
+          context: .
+          file: .github/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.TAG_LATEST }}
+
+      - name: Build and push release
+        uses: docker/build-push-action@v5
+        if: startsWith(github.ref, 'refs/heads/v')
+        with:
+          context: .
+          file: .github/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.TAG_VERSION }}
+
+      - name: Delete all images from package without tags
+        uses: pcasteran/ghcr-cleaning-action@v1
+        with:
+          user: ${{ steps.get-info.outputs.OWNER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          package: clash-rs
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 
 env:
   PACKAGE: "clash"
+  DOCKER_REGUSTRY: "ghcr.io"
+  IMAGE_NAME: "watfaq/clash-rs"
 
 jobs:
   compile:
@@ -52,6 +54,12 @@ jobs:
             cross: true
             extra-args: "--all-features"
             rustflags: "-Ctarget-feature=+crt-static --cfg tokio_unstable"
+          # Linux x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            release-name: x86_64-unknown-linux-musl
+            cross: true
+            extra-args: "--all-features"
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             release-name: i686-unknown-linux-gnu-static-crt
@@ -272,3 +280,58 @@ jobs:
           files: |
             packages/*
             LICENSE
+  docker-image:
+    needs: [compile]
+    name: Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Get the current Git commit hash
+        run: |
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "TAG_VERSION=${{ env.DOCKER_REGUSTRY }}/${{ env.IMAGE_NAME }}:${TAG_NAME#v}" >> $GITHUB_ENV
+            echo "TAG_LATEST=${{ env.DOCKER_REGUSTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_ENV
+          fi
+          echo "TAG=${{ env.DOCKER_REGUSTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGUSTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: x86_64-unknown-linux-musl
+          path: ./clash-rs
+      - name: Install UPX
+        uses: crazy-max/ghaction-upx@v3
+        with:
+          install-only: true
+      - name: Optimize Binary by UPX
+        run: |
+          chmod +x ./clash-rs/clash-x86_64-unknown-linux-musl
+          upx '--strip-relocs=0' --best -f -o clash-rs-upx ./clash-rs/clash-x86_64-unknown-linux-musl
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.TAG }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        if: github.ref_type == 'tag'
+        with:
+          context: .
+          push: true
+          tags: ${{ env.TAG_VERSION }},${{ env.TAG_LATEST }}
+
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,11 +346,5 @@ jobs:
           push: true
           tags: ${{ env.TAG_VERSION }},${{ env.TAG_LATEST }}
 
-      - name: Delete all images from package without tags
-        uses: pcasteran/ghcr-cleaning-action@v1
-        with:
-          user: ${{ steps.get-info.outputs.OWNER }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          package: clash-rs
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
     needs: [ compile ]
     name: Docker Image
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       packages: write
@@ -336,24 +337,14 @@ jobs:
           mv ./clash-rs/clash-x86_64-unknown-linux-musl ./clash-rs/clash-amd64
           mv ./clash-rs/clash-aarch64-unknown-linux-musl ./clash-rs/clash-arm64
 
-      - name: Build and push latest
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: .github/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.TAG_LATEST }}
-
       - name: Build and push release
         uses: docker/build-push-action@v5
-        if: startsWith(github.ref, 'refs/heads/v')
         with:
           context: .
           file: .github/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.TAG_VERSION }}
+          tags: ${{ env.TAG_VERSION }},${{ env.TAG_LATEST }}
 
       - name: Delete all images from package without tags
         uses: pcasteran/ghcr-cleaning-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
 name = "caret"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4811,8 +4821,11 @@ dependencies = [
  "aes-gcm",
  "blake3",
  "bytes",
+ "camellia",
  "cfg-if",
+ "chacha20",
  "chacha20poly1305",
+ "ctr",
  "hkdf",
  "md-5",
  "rand",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# A base image built by an ops bigwig, open source
+FROM wener/base:latest
+COPY ./clash-rs-upx /usr/local/bin/clash
+RUN apk add --no-cache -f yq && mkdir -p /root/.config/clash/
+WORKDIR /root
+CMD ["/usr/local/bin/clash","-d", "/root/.config/clash/"]

--- a/clash_lib/Cargo.toml
+++ b/clash_lib/Cargo.toml
@@ -105,7 +105,7 @@ tracing-oslog = { branch = "main", git = "https://github.com/Absolucy/tracing-os
 tracing-appender = "0.2.3"
 
 
-shadowsocks = { version = "1.20.2", optional = true, features=["aead-cipher-2022"] }
+shadowsocks = { version = "1.20.2", optional = true, features=["aead-cipher-2022","stream-cipher"] }
 maxminddb = "0.24.0"
 public-suffix = "0.1.0"
 murmur3 = "0.5.2"


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [x] Other (CI script)

### 🔗 Related issue link

None

### 💡 Background and solution


1. I need to deploy the clash proxy in a containerized environment.
2. Some proxy service providers only support rc4-md5 cipher.

### 📝 Changelog

Tweaked CI build to add x86_64-unknown-linux-musl target
Added docker image based on x86_64-unknown-linux-musl package.
Added rc4-md5 cipher parsing.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed

**You need to add two action secrets: DOCKER_USERNAME and DOCKER_PASSWORD.**
