### PR TITLE
feat: compatiable with mihomo `icon` field

### DIFF
--- a/clash_lib/src/app/outbound/manager.rs
+++ b/clash_lib/src/app/outbound/manager.rs
@@ -651,9 +651,7 @@ impl OutboundManager {
             selector::HandlerOptions {
                 name: PROXY_GLOBAL.to_owned(),
                 udp: true,
-                shared_opts: crate::proxy::HandlerSharedOptions {
-                    icon: None,
-                },
+                shared_opts: crate::proxy::HandlerSharedOptions { icon: None },
             },
             vec![pd.clone()],
             stored_selection,

--- a/clash_lib/src/config/internal/proxy.rs
+++ b/clash_lib/src/config/internal/proxy.rs
@@ -349,6 +349,7 @@ pub struct OutboundGroupRelay {
     pub proxies: Option<Vec<String>>,
     #[serde(rename = "use")]
     pub use_provider: Option<Vec<String>>,
+    pub icon: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
@@ -364,6 +365,7 @@ pub struct OutboundGroupUrlTest {
     pub interval: u64,
     pub lazy: Option<bool>,
     pub tolerance: Option<u16>,
+    pub icon: Option<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 pub struct OutboundGroupFallback {
@@ -377,6 +379,7 @@ pub struct OutboundGroupFallback {
     #[serde(deserialize_with = "utils::deserialize_u64")]
     pub interval: u64,
     pub lazy: Option<bool>,
+    pub icon: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
@@ -392,6 +395,7 @@ pub struct OutboundGroupLoadBalance {
     pub interval: u64,
     pub lazy: Option<bool>,
     pub strategy: Option<LoadBalanceStrategy>,
+    pub icon: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, Default)]
@@ -411,6 +415,7 @@ pub struct OutboundGroupSelect {
     #[serde(rename = "use")]
     pub use_provider: Option<Vec<String>>,
     pub udp: Option<bool>,
+    pub icon: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/clash_lib/src/proxy/fallback/mod.rs
+++ b/clash_lib/src/proxy/fallback/mod.rs
@@ -22,6 +22,7 @@ use super::{
 
 #[derive(Default, Clone)]
 pub struct HandlerOptions {
+    pub shared_opts: super::options::HandlerSharedOptions,
     pub name: String,
     pub udp: bool,
 }
@@ -146,5 +147,9 @@ impl OutboundHandler for Handler {
                 as _,
         );
         m
+    }
+
+    fn icon(&self) -> Option<String> {
+        self.opts.shared_opts.icon.clone()
     }
 }

--- a/clash_lib/src/proxy/loadbalance/mod.rs
+++ b/clash_lib/src/proxy/loadbalance/mod.rs
@@ -26,6 +26,7 @@ use super::{
 
 #[derive(Default, Clone)]
 pub struct HandlerOptions {
+    pub shared_opts: super::options::HandlerSharedOptions,
     pub name: String,
     pub udp: bool,
     pub strategy: LoadBalanceStrategy,
@@ -153,5 +154,9 @@ impl OutboundHandler for Handler {
                 as _,
         );
         m
+    }
+
+    fn icon(&self) -> Option<String> {
+        self.opts.shared_opts.icon.clone()
     }
 }

--- a/clash_lib/src/proxy/mod.rs
+++ b/clash_lib/src/proxy/mod.rs
@@ -52,6 +52,7 @@ pub mod urltest;
 
 mod common;
 mod options;
+pub use options::HandlerSharedOptions;
 mod transport;
 
 #[cfg(test)]
@@ -229,6 +230,10 @@ pub trait OutboundHandler: Sync + Send + Unpin + DialWithConnector + Debug {
         m.insert("type".to_string(), Box::new(self.proto()) as _);
 
         m
+    }
+
+    fn icon(&self) -> Option<String> {
+        None
     }
 }
 pub type AnyOutboundHandler = Arc<dyn OutboundHandler>;

--- a/clash_lib/src/proxy/options.rs
+++ b/clash_lib/src/proxy/options.rs
@@ -23,3 +23,9 @@ pub struct WsOption {
     pub max_early_data: usize,
     pub early_data_header_name: String,
 }
+
+
+#[derive(Clone, Default)]
+pub struct HandlerSharedOptions {
+    pub icon: Option<String>,
+}

--- a/clash_lib/src/proxy/options.rs
+++ b/clash_lib/src/proxy/options.rs
@@ -24,6 +24,7 @@ pub struct WsOption {
     pub early_data_header_name: String,
 }
 
+// TODO: merge this with CommonOptions
 #[derive(Clone, Default)]
 pub struct HandlerSharedOptions {
     pub icon: Option<String>,

--- a/clash_lib/src/proxy/options.rs
+++ b/clash_lib/src/proxy/options.rs
@@ -24,7 +24,6 @@ pub struct WsOption {
     pub early_data_header_name: String,
 }
 
-
 #[derive(Clone, Default)]
 pub struct HandlerSharedOptions {
     pub icon: Option<String>,

--- a/clash_lib/src/proxy/relay/mod.rs
+++ b/clash_lib/src/proxy/relay/mod.rs
@@ -29,6 +29,7 @@ use super::{
 
 #[derive(Default)]
 pub struct HandlerOptions {
+    pub shared_opts: super::options::HandlerSharedOptions,
     pub name: String,
 }
 
@@ -188,6 +189,10 @@ impl OutboundHandler for Handler {
         );
 
         m
+    }
+
+    fn icon(&self) -> Option<String> {
+        self.opts.shared_opts.icon.clone()
     }
 }
 

--- a/clash_lib/src/proxy/selector/mod.rs
+++ b/clash_lib/src/proxy/selector/mod.rs
@@ -35,6 +35,7 @@ struct HandlerInner {
 
 #[derive(Default, Clone)]
 pub struct HandlerOptions {
+    pub shared_opts: super::options::HandlerSharedOptions,
     pub name: String,
     pub udp: bool,
 }
@@ -198,6 +199,10 @@ impl OutboundHandler for Handler {
                 as _,
         );
         m
+    }
+
+    fn icon(&self) -> Option<String> {
+        self.opts.shared_opts.icon.clone()
     }
 }
 

--- a/clash_lib/src/proxy/selector/mod.rs
+++ b/clash_lib/src/proxy/selector/mod.rs
@@ -236,6 +236,7 @@ mod tests {
             super::HandlerOptions {
                 name: "test".to_owned(),
                 udp: false,
+                ..Default::default()
             },
             vec![Arc::new(RwLock::new(mock_provider))],
             None,

--- a/clash_lib/src/proxy/urltest/mod.rs
+++ b/clash_lib/src/proxy/urltest/mod.rs
@@ -24,6 +24,7 @@ use super::{
 
 #[derive(Default)]
 pub struct HandlerOptions {
+    pub shared_opts: super::options::HandlerSharedOptions,
     pub name: String,
     pub udp: bool,
 }
@@ -224,5 +225,9 @@ impl OutboundHandler for Handler {
                 as _,
         );
         m
+    }
+
+    fn icon(&self) -> Option<String> {
+        self.opts.shared_opts.icon.clone()
     }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Nope

### 💡 Background and solution

Mihomo introduce the `icon` field for showing a custom icon processed by GUI.
Doc link: <https://wiki.metacubex.one/config/proxy-groups/?h=icon#icon>

What's more, it seems that:
* we could introduce the [enumflags2](https://crates.io/crates/enumflags2) for better group match(reducing duplicate code).
* we could shared the opts and serialize via `serde(flatten)`. The behavior should be similar to the anonymous field of golang. Doc ref: <https://serde.rs/attr-flatten.html>

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is not needed
- [x] Changelog is not needed
