### PR TITLE
fix: executable privilege

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 ARG TARGETARCH
 COPY ./clash-rs/clash-${TARGETARCH} /usr/bin/clash
 # The yq library installed here is used to rewrite the config.yaml configuration file for clash, merge it, and other related operations.
-RUN apk update && apk add --no-cache -f yq && mkdir -p /root/.config/clash/
+RUN apk update && apk add --no-cache -f yq && mkdir -p /root/.config/clash/ && chmod +x /usr/bin/clash
 WORKDIR /root
 ENTRYPOINT [ "/usr/bin/clash" ]
 CMD [ "-d", "/root/.config/clash/" ]


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Bug fix


### 💡 Background and solution

After testing and using the containerized environment, I found that I forgot to give executable permissions to the clash binary file inside the container, so I'll adjust it.

### 📝 Changelog

Fixing `/usr/bin/clash` not having executable permissions in the image



