### PR TITLE
Cargo.lock: fix version of tuic[-quinn]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6544,7 +6544,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuic"
-version = "1.3.1"
+version = "1.3.2"
 source = "git+https://github.com/Itsusinn/tuic.git?tag=v1.3.2#dea187c83da1c769668dfe1f1f12c6bf1e3e9521"
 dependencies = [
  "bytes",
@@ -6557,7 +6557,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-quinn"
-version = "1.3.1"
+version = "1.3.2"
 source = "git+https://github.com/Itsusinn/tuic.git?tag=v1.3.2#dea187c83da1c769668dfe1f1f12c6bf1e3e9521"
 dependencies = [
  "bytes",


### PR DESCRIPTION
The source of `tuic` and `tuic-quinn` was updated by a recent `dependabot` PR but the version was not updated:
https://github.com/Watfaq/clash-rs/pull/635#pullrequestreview-2423325700

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
