### PR TITLE
ci: enable riscv64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
             extra-args: -F "shadowsocks, tuic, onion"
             rustflags: "-Ctarget-feature=+crt-static --cfg tokio_unstable"
           # Linux RISC-V gnu
-          # - os: ubuntu-latest
-          #   target: riscv64gc-unknown-linux-gnu
-          #   cross: true
-          #   extra-args: "--all-features"
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            cross: true
+            extra-args: -F "shadowsocks, tuic"
           # Windows
           - os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/Watfaq/clash-rs/issues/655

### 💡 Background and solution

I need a clash-rs binary for my RISC-V dev board so I don't have to manually build the binary every time a new version is released.

### 📝 Changelog

Enable RISC-V arch in the test & release GH action, removed it's onion support as per author's instruction.

Note due to cross-rs lacks support for [riscv64gc-unknown-linux-musl](https://doc.rust-lang.org/nightly/rustc/platform-support/riscv64gc-unknown-linux-musl.html), so only the gun version can be built for now.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed
