### PR TITLE
refactor(dispatcher): use `RwLock<RunMode>` instead of `Mutex<RunMode>`

### DIFF
--- a/clash_lib/src/proxy/socks/inbound/stream.rs
+++ b/clash_lib/src/proxy/socks/inbound/stream.rs
@@ -187,7 +187,8 @@ pub async fn handle_tcp<'a>(
 
             tokio::spawn(async move {
                 let handle = dispatcher_cloned
-                    .dispatch_datagram(sess, Box::new(InboundUdp::new(framed))).await;
+                    .dispatch_datagram(sess, Box::new(InboundUdp::new(framed)))
+                    .await;
                 close_listener.await.ok();
                 handle.send(0).ok();
             });

--- a/clash_lib/src/proxy/socks/inbound/stream.rs
+++ b/clash_lib/src/proxy/socks/inbound/stream.rs
@@ -187,7 +187,7 @@ pub async fn handle_tcp<'a>(
 
             tokio::spawn(async move {
                 let handle = dispatcher_cloned
-                    .dispatch_datagram(sess, Box::new(InboundUdp::new(framed)));
+                    .dispatch_datagram(sess, Box::new(InboundUdp::new(framed))).await;
                 close_listener.await.ok();
                 handle.send(0).ok();
             });

--- a/clash_lib/src/proxy/tproxy/mod.rs
+++ b/clash_lib/src/proxy/tproxy/mod.rs
@@ -122,7 +122,9 @@ async fn handle_inbound_datagram(
         ..Default::default()
     };
 
-    let closer = dispatcher.dispatch_datagram(sess, Box::new(udp_stream));
+    let closer = dispatcher
+        .dispatch_datagram(sess, Box::new(udp_stream))
+        .await;
 
     // dispatcher -> tproxy
     let responder = socket.clone();

--- a/clash_lib/src/proxy/tun/inbound.rs
+++ b/clash_lib/src/proxy/tun/inbound.rs
@@ -88,7 +88,9 @@ async fn handle_inbound_datagram(
         ..Default::default()
     };
 
-    let closer = dispatcher.dispatch_datagram(sess, Box::new(udp_stream)).await;
+    let closer = dispatcher
+        .dispatch_datagram(sess, Box::new(udp_stream))
+        .await;
 
     // dispatcher -> tun
     let fut1 = tokio::spawn(async move {

--- a/clash_lib/src/proxy/tun/inbound.rs
+++ b/clash_lib/src/proxy/tun/inbound.rs
@@ -88,7 +88,7 @@ async fn handle_inbound_datagram(
         ..Default::default()
     };
 
-    let closer = dispatcher.dispatch_datagram(sess, Box::new(udp_stream));
+    let closer = dispatcher.dispatch_datagram(sess, Box::new(udp_stream)).await;
 
     // dispatcher -> tun
     let fut1 = tokio::spawn(async move {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Performance optimization

### 💡 Background and solution

use tokio::sync::RwLock<RunMode> instead of std::sync::Mutex<RunMode>, change dispatch_datagram function to async function.