### PR TITLE
style: make poll_read_exact a general trait

### DIFF
--- a/clash_lib/src/common/io.rs
+++ b/clash_lib/src/common/io.rs
@@ -2,11 +2,13 @@
 use std::future::Future;
 use std::{
     io,
+    mem::MaybeUninit,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
 };
 
+use bytes::BytesMut;
 use futures::ready;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
@@ -351,4 +353,57 @@ where
         b_to_a_timeout_duration,
     }
     .await
+}
+
+pub trait ReadExactBase {
+    /// inner stream to be polled
+    type I: AsyncRead + Unpin;
+    /// prepare the inner stream, read buffer and read position
+    fn decompose(&mut self) -> (&mut Self::I, &mut BytesMut, &mut usize);
+}
+
+pub trait ReadExt: ReadExactBase {
+    fn poll_read_exact(
+        &mut self,
+        cx: &mut std::task::Context,
+        size: usize,
+    ) -> Poll<std::io::Result<()>>;
+}
+
+impl<T: ReadExactBase> ReadExt for T {
+    fn poll_read_exact(
+        &mut self,
+        cx: &mut std::task::Context,
+        size: usize,
+    ) -> Poll<std::io::Result<()>> {
+        let (raw, read_buf, read_pos) = self.decompose();
+        read_buf.reserve(size);
+        // # safety: read_buf has reserved `size`
+        unsafe { read_buf.set_len(size) }
+        loop {
+            if *read_pos < size {
+                // # safety: read_pos<size==read_buf.len(), and
+                // read_buf[0..read_pos] is initialized
+                let dst = unsafe {
+                    &mut *((&mut read_buf[*read_pos..size]) as *mut _
+                        as *mut [MaybeUninit<u8>])
+                };
+                let mut buf = ReadBuf::uninit(dst);
+                let ptr = buf.filled().as_ptr();
+                ready!(Pin::new(&mut *raw).poll_read(cx, &mut buf))?;
+                assert_eq!(ptr, buf.filled().as_ptr());
+                if buf.filled().is_empty() {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "unexpected eof",
+                    )));
+                }
+                *read_pos += buf.filled().len();
+            } else {
+                assert!(*read_pos == size);
+                *read_pos = 0;
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

re-open of https://github.com/Watfaq/clash-rs/pull/675

### 🤔 This is a ...

- [x] Code style optimization

### 💡 Background and solution

there exists some similar code in vmess and shadowtls stream, which i found when i re-read the code. 

the `poll_read_exact` method is especially useful for poll based packet decoding, many proxy projects have their own implement, but there are some ways to make it a general method with a base trait to provide the (inner stream,  BytesMut, read_pos). 
so here comes the base trait `ReadExactBase`, and `ReadExact` trait is automatically implemented for all types which have implemented `ReadExactBase`

```rust
pub trait ReadExactBase {
    /// inner stream to be polled
    type I: AsyncRead + Unpin;
    /// prepare the inner stream, read buffer and read position
    fn decompose(&mut self) -> (&mut Self::I, &mut BytesMut, &mut usize);
}

pub trait ReadExt: ReadExactBase {
    fn poll_read_exact(
        &mut self,
        cx: &mut std::task::Context,
        size: usize,
    ) -> Poll<std::io::Result<()>>;
}
```
