### PR TITLE
perf(throughput): large buffer for copy bidirectional

### DIFF
--- a/clash_lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash_lib/src/app/dispatcher/dispatcher_impl.rs
@@ -27,13 +27,15 @@ use crate::app::dns::ThreadSafeDNSResolver;
 
 use super::statistics_manager::Manager;
 
+const DEFAULT_BUFFER_SIZE: usize = 16 * 1024;
+
 pub struct Dispatcher {
     outbound_manager: ThreadSafeOutboundManager,
     router: ThreadSafeRouter,
     resolver: ThreadSafeDNSResolver,
     mode: Arc<RwLock<RunMode>>,
-
     manager: Arc<Manager>,
+    tcp_buffer_size: usize,
 }
 
 impl Debug for Dispatcher {
@@ -48,8 +50,8 @@ impl Dispatcher {
         router: ThreadSafeRouter,
         resolver: ThreadSafeDNSResolver,
         mode: RunMode,
-
         statistics_manager: Arc<Manager>,
+        tcp_buffer_size: Option<usize>,
     ) -> Self {
         Self {
             outbound_manager,
@@ -57,6 +59,7 @@ impl Dispatcher {
             resolver,
             mode: Arc::new(RwLock::new(mode)),
             manager: statistics_manager,
+            tcp_buffer_size: tcp_buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE),
         }
     }
 
@@ -149,7 +152,7 @@ impl Dispatcher {
                 match copy_bidirectional(
                     lhs,
                     rhs,
-                    4096,
+                    self.tcp_buffer_size,
                     Duration::from_secs(10),
                     Duration::from_secs(10),
                 )

--- a/clash_lib/src/config/def.rs
+++ b/clash_lib/src/config/def.rs
@@ -575,7 +575,11 @@ impl Default for FallbackFilter {
 }
 
 #[derive(Serialize, Deserialize, Default)]
-pub struct Experimental {}
+#[serde(rename_all = "kebab-case")]
+pub struct Experimental {
+    /// buffer size for tcp stream bidirectional copy
+    pub tcp_buffer_size: Option<usize>,
+}
 
 #[derive(Serialize, Deserialize)]
 #[serde(default)]

--- a/clash_lib/src/lib.rs
+++ b/clash_lib/src/lib.rs
@@ -432,6 +432,7 @@ async fn create_components(
         dns_resolver.clone(),
         config.general.mode,
         statistics_manager.clone(),
+        config.experimental.and_then(|e| e.tcp_buffer_size),
     ));
 
     debug!("initializing authenticator");


### PR DESCRIPTION
enlarge copy bidrectional buffer size for tcp stream support experimental config of `tcp-buffer-size`

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] Performance optimization

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

`tokio::io::copy_bidirectional` uses buffer size of 10k; mihomo uses buffer size of 16k/32k (with low/high memory flag)
we currently use buffer size of 4096, and it significantly slowed down the proxy program, especially in direct outbound, where most time was spent on memcpy. 

so we set the buffer size default value to be 16k, this is still a convervative value, but we support more radical value through `expeirment -> tcp-buffer-size`

### tests

baseline: iperf3 local to local, without proxy, throughput: 34Gb/s

#### config

clash config:

```yaml
mixed-port: 7891
external-controller: 127.0.0.1:19091
log-level: trace

experimental:
  tcp-buffer-size: 4096 # change into 16000/32000/50000

rules:
  - MATCH,DIRECT
```

proxychain config

```conf
strict_chain
[ProxyList]
socks5  127.0.0.1 7891
```

#### test commands

in terminal1, run `iperf3 -s`

in terminal2, run `/path/to/clash-rs -d /tmp -f /path/to/config`

in terminal3, run `proxychains iperf3 -t 10 -c 127.0.0.1 -i 0`

#### results

```text

buffer size: 4096, throughput:

[  9]   0.00-10.00  sec  4.40 GBytes  3.78 Gbits/sec    0             sender

buffer size: 16000, throughput:

[  9]   0.00-10.00  sec  12.4 GBytes  10.6 Gbits/sec    0             sender

buffer size: 32000, throughput:

[  9]   0.00-10.98  sec  19.9 GBytes  15.6 Gbits/sec    0             sender

buffer size: 50000, throughput:

[  9]   0.00-10.00  sec  22.3 GBytes  19.0 Gbits/sec    0             sender

```



### 📝 Changelog

- change default tcp buffer size to be 16k(original: 4k), a moderate size
- support experimental tcp buffer size config

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed

### TODOs

- [ ] fix docs
