### PR TITLE
feat: snafu error with better stack trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,10 @@ dependencies = [
  "sha2",
  "shadowsocks",
  "smoltcp 0.12.0",
+ "snafu",
  "socket2 0.5.8",
+ "stack-error",
+ "stack-error-macro",
  "tempfile",
  "thiserror 2.0.11",
  "time",
@@ -1728,7 +1731,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "strum",
+ "strum 0.26.3",
  "syn 2.0.96",
  "void",
 ]
@@ -5647,6 +5650,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5747,6 +5771,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stack-error"
+version = "0.1.0"
+dependencies = [
+ "snafu",
+ "strum 0.25.0",
+]
+
+[[package]]
+name = "stack-error-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5766,11 +5808,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6385,7 +6449,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_ignored",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "toml",
  "tor-basic-utils",
@@ -6481,7 +6545,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "signature",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "time",
  "tor-async-utils",
@@ -6514,7 +6578,7 @@ dependencies = [
  "paste",
  "retry-error",
  "static_assertions",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "tracing",
  "void",
@@ -6555,7 +6619,7 @@ dependencies = [
  "rand 0.8.5",
  "safelog",
  "serde",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "tor-async-utils",
  "tor-basic-utils",
@@ -6592,7 +6656,7 @@ dependencies = [
  "retry-error",
  "safelog",
  "slotmap-careful",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "tor-async-utils",
  "tor-basic-utils",
@@ -6719,7 +6783,7 @@ dependencies = [
  "safelog",
  "serde",
  "serde_with",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "tor-basic-utils",
  "tor-bytes",
@@ -6825,7 +6889,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "static_assertions",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "time",
  "tor-basic-utils",
@@ -7036,7 +7100,7 @@ dependencies = [
  "pin-project",
  "priority-queue",
  "slotmap-careful",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "tor-error",
  "tor-general-addr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "clash",
     "clash_lib",
     "clash_doc",
+    "crates/stack-error-macro",
+    "crates/stack-error",
     "clash_ffi",
 ]
 

--- a/clash_lib/Cargo.toml
+++ b/clash_lib/Cargo.toml
@@ -17,6 +17,11 @@ zero_copy = []
 tokio-console = ["tokio/tracing"]
 
 [dependencies]
+
+stack-error-macro = { path = "../crates/stack-error-macro" }
+stack-error =  { path = "../crates/stack-error" }
+snafu = "0.8"
+
 # Async
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["net", "codec", "io", "compat"] }

--- a/clash_lib/src/app/dns/config.rs
+++ b/clash_lib/src/app/dns/config.rs
@@ -149,7 +149,7 @@ impl Config {
 
     pub fn parse_fallback_ip_cidr(
         ipcidr: &[String],
-    ) -> anyhow::Result<Vec<ipnet::IpNet>> {
+    ) -> std::result::Result<Vec<ipnet::IpNet>, crate::Error> {
         let mut output = vec![];
 
         for ip in ipcidr.iter() {
@@ -164,7 +164,7 @@ impl Config {
 
     pub fn parse_hosts(
         hosts_mapping: &HashMap<String, String>,
-    ) -> anyhow::Result<trie::StringTrie<IpAddr>> {
+    ) -> std::result::Result<trie::StringTrie<IpAddr>, crate::Error> {
         let mut tree = trie::StringTrie::new();
         tree.insert(
             "localhost",
@@ -172,7 +172,7 @@ impl Config {
         );
 
         for (host, ip_str) in hosts_mapping.iter() {
-            let ip = ip_str.parse::<IpAddr>()?;
+            let ip = ip_str.parse::<IpAddr>().map_err(Error::StdNet)?;
             tree.insert(host.as_str(), Arc::new(ip));
         }
 

--- a/clash_lib/src/app/dns/mod.rs
+++ b/clash_lib/src/app/dns/mod.rs
@@ -28,7 +28,10 @@ pub use server::get_dns_listener;
 pub trait Client: Sync + Send + Debug {
     /// used to identify the client for logging
     fn id(&self) -> String;
-    async fn exchange(&self, msg: &op::Message) -> anyhow::Result<op::Message>;
+    async fn exchange(
+        &self,
+        msg: &op::Message,
+    ) -> crate::error::DnsResult<op::Message>;
 }
 
 type ThreadSafeDNSClient = Arc<dyn Client>;
@@ -51,22 +54,25 @@ pub trait ClashResolver: Sync + Send {
         &self,
         host: &str,
         enhanced: bool,
-    ) -> anyhow::Result<Option<std::net::IpAddr>>;
+    ) -> std::result::Result<Option<std::net::IpAddr>, crate::error::DnsError>;
     async fn resolve_v4(
         &self,
         host: &str,
         enhanced: bool,
-    ) -> anyhow::Result<Option<std::net::Ipv4Addr>>;
+    ) -> std::result::Result<Option<std::net::Ipv4Addr>, crate::error::DnsError>;
     async fn resolve_v6(
         &self,
         host: &str,
         enhanced: bool,
-    ) -> anyhow::Result<Option<std::net::Ipv6Addr>>;
+    ) -> std::result::Result<Option<std::net::Ipv6Addr>, crate::error::DnsError>;
 
     async fn cached_for(&self, ip: std::net::IpAddr) -> Option<String>;
 
     /// Used for DNS Server
-    async fn exchange(&self, message: &op::Message) -> anyhow::Result<op::Message>;
+    async fn exchange(
+        &self,
+        message: &op::Message,
+    ) -> std::result::Result<op::Message, crate::error::DnsError>;
 
     /// Only used for look up fake IP
     async fn reverse_lookup(&self, ip: std::net::IpAddr) -> Option<String>;

--- a/clash_lib/src/app/router/mod.rs
+++ b/clash_lib/src/app/router/mod.rs
@@ -343,8 +343,6 @@ pub fn map_rule_type(
 mod tests {
     use std::sync::Arc;
 
-    use anyhow::Ok;
-
     use crate::{
         app::dns::{MockClashResolver, SystemResolver},
         common::{geodata::GeoData, http::new_http_client, mmdb::Mmdb},

--- a/clash_lib/src/error/dns.rs
+++ b/clash_lib/src/error/dns.rs
@@ -1,0 +1,144 @@
+use snafu::{Location, Snafu};
+use stack_error_macro::stack_trace_debug;
+
+#[derive(Snafu)]
+#[snafu(visibility(pub))]
+#[stack_trace_debug]
+pub enum DnsError {
+    #[snafu(display("invalid domain: {domain}"))]
+    InvaldDomain {
+        domain: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("no record: {host}"))]
+    NoRecord {
+        host: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("invalid query: {queries:?}"))]
+    InvalidQuery {
+        queries: Vec<hickory_proto::op::Query>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("dns timeout"))]
+    Timeout {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("hickory proto"))]
+    Proto {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: hickory_proto::ProtoError,
+    },
+    #[snafu(display("hickory resolve"))]
+    ResolveError {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: hickory_resolver::ResolveError,
+    },
+    #[snafu(display("unsupported operation"))]
+    Unsupported {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("ipv6 disabled"))]
+    IPV6Disabled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("empty dns"))]
+    EmptyDns {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("dns timeout"))]
+    ClientTimeout {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: tokio::time::error::Elapsed,
+    },
+    #[snafu(display("io error"))]
+    Io {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: std::io::Error,
+    },
+}
+
+pub type DnsResult<T> = std::result::Result<T, DnsError>;
+
+#[cfg(test)]
+mod tests {
+
+    use snafu::{Location, ResultExt, Snafu};
+    use stack_error_macro::stack_trace_debug;
+
+    // layer 1
+    #[derive(Snafu)]
+    #[snafu(visibility(pub))]
+    #[stack_trace_debug]
+    pub enum RustError {
+        #[snafu(display("Failed to call Java"))]
+        Rust {
+            #[snafu(implicit)]
+            location: Location,
+            #[snafu(source)]
+            source: JavaError,
+        },
+    }
+
+    // layer 2
+    #[derive(Snafu)]
+    #[snafu(visibility(pub))]
+    #[stack_trace_debug]
+    pub enum JavaError {
+        #[snafu(display("Failed to call Python"))]
+        Python {
+            #[snafu(implicit)]
+            location: Location,
+            #[snafu(source)]
+            source: PythonError,
+        },
+    }
+
+    // layer 3
+    #[derive(Snafu)]
+    #[snafu(visibility(pub))]
+    #[stack_trace_debug]
+    pub enum PythonError {
+        #[snafu(display("IO Error"))]
+        IO {
+            #[snafu(implicit)]
+            location: Location,
+            #[snafu(source)]
+            source: std::io::Error,
+        },
+    }
+
+    fn fn1() -> Result<(), RustError> {
+        fn2().context(RustSnafu)
+    }
+
+    fn fn2() -> Result<(), JavaError> {
+        fn3().context(PythonSnafu)
+    }
+
+    fn fn3() -> Result<(), PythonError> {
+        let res = Err(std::io::Error::new(std::io::ErrorKind::Other, "error"));
+        res.context(IOSnafu)
+    }
+
+    #[test]
+    fn test_snafu_error() {
+        let res = fn1();
+        println!("{:?}", res);
+    }
+}

--- a/clash_lib/src/error/mod.rs
+++ b/clash_lib/src/error/mod.rs
@@ -1,0 +1,25 @@
+pub mod dns;
+
+pub use dns::{DnsError, DnsResult};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    StdNet(#[from] std::net::AddrParseError),
+    #[error(transparent)]
+    IpNet(#[from] ipnet::AddrParseError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
+    #[error("profile error: {0}")]
+    ProfileError(String),
+    #[error("dns error: {0}")]
+    DNSError(String),
+    #[error(transparent)]
+    DNSServerError(#[from] watfaq_dns::DNSError),
+    #[error("crypto error: {0}")]
+    Crypto(String),
+    #[error("operation error: {0}")]
+    Operation(String),
+}

--- a/clash_lib/src/lib.rs
+++ b/clash_lib/src/lib.rs
@@ -26,7 +26,7 @@ use config::def::LogLevel;
 use once_cell::sync::OnceCell;
 use proxy::tun::get_tun_runner;
 
-use std::{io, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use thiserror::Error;
 use tokio::{
     sync::{broadcast, mpsc, oneshot, Mutex},
@@ -37,6 +37,7 @@ use tracing::{debug, error, info};
 mod app;
 mod common;
 mod config;
+pub mod error;
 mod proxy;
 mod session;
 
@@ -46,24 +47,15 @@ pub use config::{
     DNSListen as ClashDNSListen, RuntimeConfig as ClashRuntimeConfig,
 };
 
+pub use error::Error;
+
 #[derive(Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
-    IpNet(#[from] ipnet::AddrParseError),
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error("invalid config: {0}")]
-    InvalidConfig(String),
-    #[error("profile error: {0}")]
-    ProfileError(String),
-    #[error("dns error: {0}")]
-    DNSError(String),
-    #[error(transparent)]
-    DNSServerError(#[from] watfaq_dns::DNSError),
-    #[error("crypto error: {0}")]
-    Crypto(String),
-    #[error("operation error: {0}")]
-    Operation(String),
+pub struct DnsError(pub String);
+
+impl std::fmt::Display for DnsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "dns error: {}", self.0)
+    }
 }
 
 pub type Runner = futures::future::BoxFuture<'static, Result<(), Error>>;

--- a/clash_lib/src/proxy/hysteria2/error.rs
+++ b/clash_lib/src/proxy/hysteria2/error.rs
@@ -1,0 +1,72 @@
+use snafu::{Location, Snafu};
+use stack_error_macro::stack_trace_debug;
+
+#[derive(Snafu)]
+#[snafu(visibility(pub))]
+#[stack_trace_debug]
+pub enum Error {
+    #[snafu(display("Failed to call Dns"))]
+    Dns {
+        #[snafu(implicit)]
+        location: Location,
+        source: crate::error::DnsError,
+    },
+    #[snafu(display("empty dns"))]
+    DsnEmpty {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to call Io"))]
+    Io {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: std::io::Error,
+    },
+    #[snafu(display("Failed to call Quinn"))]
+    QuinnConnect {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: quinn::ConnectError,
+    },
+    #[snafu(display("Failed to call Quinn"))]
+    QuinnConnection {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: quinn::ConnectionError,
+    },
+    #[snafu(display("Failed to call H3"))]
+    H3 {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: h3::Error,
+    },
+    #[snafu(display("Failed to call Auth, status code: {status}"))]
+    Auth { status: u16 },
+    #[snafu(display("Failed to call Auth, msg: {msg}"))]
+    AuthOther { msg: String },
+    #[snafu(display("Failed to call to_str"))]
+    ToStr {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: http::header::ToStrError,
+    },
+    #[snafu(display("Failed to call ParseInt"))]
+    ParseInt {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: std::num::ParseIntError,
+    },
+    #[snafu(display("Failed to call ParseInt"))]
+    ParseBool {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: core::str::ParseBoolError,
+    },
+}

--- a/clash_lib/src/proxy/utils/test_utils/noop.rs
+++ b/clash_lib/src/proxy/utils/test_utils/noop.rs
@@ -8,6 +8,7 @@ use crate::{
         dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
         dns::{ClashResolver, ResolverKind, ThreadSafeDNSResolver},
     },
+    error::dns::UnsupportedSnafu,
     proxy::{ConnectorType, DialWithConnector, OutboundHandler, OutboundType},
     session::Session,
 };
@@ -20,7 +21,7 @@ impl ClashResolver for NoopResolver {
         &self,
         _host: &str,
         _enhanced: bool,
-    ) -> anyhow::Result<Option<std::net::IpAddr>> {
+    ) -> crate::error::DnsResult<Option<std::net::IpAddr>> {
         Ok(None)
     }
 
@@ -28,7 +29,7 @@ impl ClashResolver for NoopResolver {
         &self,
         _host: &str,
         _enhanced: bool,
-    ) -> anyhow::Result<Option<std::net::Ipv4Addr>> {
+    ) -> crate::error::DnsResult<Option<std::net::Ipv4Addr>> {
         Ok(None)
     }
 
@@ -36,7 +37,7 @@ impl ClashResolver for NoopResolver {
         &self,
         _host: &str,
         _enhanced: bool,
-    ) -> anyhow::Result<Option<std::net::Ipv6Addr>> {
+    ) -> crate::error::DnsResult<Option<std::net::Ipv6Addr>> {
         Ok(None)
     }
 
@@ -45,8 +46,11 @@ impl ClashResolver for NoopResolver {
     }
 
     /// Used for DNS Server
-    async fn exchange(&self, _message: &op::Message) -> anyhow::Result<op::Message> {
-        Err(anyhow::anyhow!("unsupported"))
+    async fn exchange(
+        &self,
+        _message: &op::Message,
+    ) -> crate::error::DnsResult<op::Message> {
+        UnsupportedSnafu {}.fail()
     }
 
     /// Only used for look up fake IP

--- a/crates/stack-error-macro/Cargo.toml
+++ b/crates/stack-error-macro/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "stack-error-macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.66"
+quote = "1.0"
+syn = "1.0"
+syn2 = { version = "2.0", package = "syn", features = [
+    "derive",
+    "parsing",
+    "printing",
+    "clone-impls",
+    "proc-macro",
+    "extra-traits",
+    "full",
+] }

--- a/crates/stack-error-macro/src/lib.rs
+++ b/crates/stack-error-macro/src/lib.rs
@@ -1,0 +1,286 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! implement `::stack_error::ext::StackError`
+
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{quote, quote_spanned};
+use syn2::spanned::Spanned;
+use syn2::{parenthesized, Attribute, Ident, ItemEnum, Variant};
+
+#[proc_macro_attribute]
+pub fn stack_trace_debug(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    stack_trace_style_impl(args.into(), input.into()).into()
+}
+
+fn stack_trace_style_impl(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let input_cloned: TokenStream2 = input.clone();
+
+    let error_enum_definition: ItemEnum = syn2::parse2(input_cloned).unwrap();
+    let enum_name = error_enum_definition.ident;
+
+    let mut variants = vec![];
+
+    for error_variant in error_enum_definition.variants {
+        let variant = ErrorVariant::from_enum_variant(error_variant);
+        variants.push(variant);
+    }
+
+    let debug_fmt_fn = build_debug_fmt_impl(enum_name.clone(), variants.clone());
+    let next_fn = build_next_impl(enum_name.clone(), variants);
+    let debug_impl = build_debug_impl(enum_name.clone());
+
+    quote! {
+        #args
+        #input
+
+        impl ::stack_error::ext::StackError for #enum_name {
+            #debug_fmt_fn
+            #next_fn
+        }
+
+        #debug_impl
+    }
+}
+
+/// Generate `debug_fmt` fn.
+///
+/// The generated fn will be like:
+/// ```rust, ignore
+/// fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>);
+/// ```
+fn build_debug_fmt_impl(enum_name: Ident, variants: Vec<ErrorVariant>) -> TokenStream2 {
+    let match_arms = variants
+        .iter()
+        .map(|v| v.to_debug_match_arm())
+        .collect::<Vec<_>>();
+
+    quote! {
+        fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+            use #enum_name::*;
+            match self {
+                #(#match_arms)*
+            }
+        }
+    }
+}
+
+/// Generate `next` fn.
+///
+/// The generated fn will be like:
+/// ```rust, ignore
+/// fn next(&self) -> Option<&dyn ::stack_error::ext::StackError>;
+/// ```
+fn build_next_impl(enum_name: Ident, variants: Vec<ErrorVariant>) -> TokenStream2 {
+    let match_arms = variants
+        .iter()
+        .map(|v| v.to_next_match_arm())
+        .collect::<Vec<_>>();
+
+    quote! {
+        fn next(&self) -> Option<&dyn ::stack_error::ext::StackError> {
+            use #enum_name::*;
+            match self {
+                #(#match_arms)*
+            }
+        }
+    }
+}
+
+/// Implement [std::fmt::Debug] via `debug_fmt`
+fn build_debug_impl(enum_name: Ident) -> TokenStream2 {
+    quote! {
+        impl std::fmt::Debug for #enum_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use ::stack_error::ext::StackError;
+                let mut buf = vec![];
+                self.debug_fmt(0, &mut buf);
+                write!(f, "{}", buf.join("\n"))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ErrorVariant {
+    name: Ident,
+    fields: Vec<Ident>,
+    has_location: bool,
+    has_source: bool,
+    has_external_cause: bool,
+    display: TokenStream2,
+    span: Span,
+    cfg_attr: Option<Attribute>,
+}
+
+impl ErrorVariant {
+    /// Construct self from [Variant]
+    fn from_enum_variant(variant: Variant) -> Self {
+        let span = variant.span();
+        let mut has_location = false;
+        let mut has_source = false;
+        let mut has_external_cause = false;
+
+        for field in &variant.fields {
+            if let Some(ident) = &field.ident {
+                if ident == "location" {
+                    has_location = true;
+                } else if ident == "source" {
+                    has_source = true;
+                } else if ident == "error" {
+                    has_external_cause = true;
+                }
+            }
+        }
+
+        let mut display = None;
+        let mut cfg_attr = None;
+        for attr in variant.attrs {
+            if attr.path().is_ident("snafu") {
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("display") {
+                        let content;
+                        parenthesized!(content in meta.input);
+                        let display_ts: TokenStream2 = content.parse()?;
+                        display = Some(display_ts);
+                        Ok(())
+                    } else {
+                        Err(meta.error("unrecognized repr"))
+                    }
+                })
+                .expect("Each error should contains a display attribute");
+            }
+
+            if attr.path().is_ident("cfg") {
+                cfg_attr = Some(attr);
+            }
+        }
+
+        let field_ident = variant
+            .fields
+            .iter()
+            .map(|f| f.ident.clone().unwrap_or_else(|| Ident::new("_", f.span())))
+            .collect();
+
+        Self {
+            name: variant.ident,
+            fields: field_ident,
+            has_location,
+            has_source,
+            has_external_cause,
+            display: display.unwrap(),
+            span,
+            cfg_attr,
+        }
+    }
+
+    /// Convert self into an match arm that will be used in [build_debug_impl].
+    ///
+    /// The generated match arm will be like:
+    /// ```rust, ignore
+    ///     ErrorKindWithSource { source, .. } => {
+    ///         debug_fmt(source, layer + 1, buf);
+    ///     },
+    ///     ErrorKindWithoutSource { .. } => {
+    ///        buf.push(format!("{layer}: {}, at {}", format!(#display), location)));
+    ///     }
+    /// ```
+    ///
+    /// The generated code assumes fn `debug_fmt`, var `layer`, var `buf` are in scope.
+    fn to_debug_match_arm(&self) -> TokenStream2 {
+        let name = &self.name;
+        let fields = &self.fields;
+        let display = &self.display;
+        let cfg = if let Some(cfg) = &self.cfg_attr {
+            quote_spanned!(cfg.span() => #cfg)
+        } else {
+            quote! {}
+        };
+
+        match (self.has_location, self.has_source, self.has_external_cause) {
+            (true, true, _) => quote_spanned! {
+               self.span => #cfg #[allow(unused_variables)] #name { #(#fields),*, } => {
+                    buf.push(format!("{layer}: {}, at {}", format!(#display), location));
+                    source.debug_fmt(layer + 1, buf);
+                },
+            },
+            (true, false, true) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}, at {}", format!(#display), location));
+                    buf.push(format!("{}: {:?}", layer + 1, error));
+                },
+            },
+            (true, false, false) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}, at {}", format!(#display), location));
+                },
+            },
+            (false, true, _) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}", format!(#display)));
+                    source.debug_fmt(layer + 1, buf);
+                },
+            },
+            (false, false, true) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}", format!(#display)));
+                    buf.push(format!("{}: {:?}", layer + 1, error));
+                },
+            },
+            (false, false, false) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}", format!(#display)));
+                },
+            },
+        }
+    }
+
+    /// Convert self into an match arm that will be used in [build_next_impl].
+    ///
+    /// The generated match arm will be like:
+    /// ```rust, ignore
+    ///     ErrorKindWithSource { source, .. } => {
+    ///         Some(source)
+    ///     },
+    ///     ErrorKindWithoutSource { .. } => {
+    ///        None
+    ///     }
+    /// ```
+    fn to_next_match_arm(&self) -> TokenStream2 {
+        let name = &self.name;
+        let fields = &self.fields;
+        let cfg = if let Some(cfg) = &self.cfg_attr {
+            quote_spanned!(cfg.span() => #cfg)
+        } else {
+            quote! {}
+        };
+
+        if self.has_source {
+            quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    Some(source)
+                },
+            }
+        } else {
+            quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } =>{
+                    None
+                }
+            }
+        }
+    }
+}

--- a/crates/stack-error/Cargo.toml
+++ b/crates/stack-error/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "stack-error"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+snafu = "0.8"
+strum = { version = "0.25", features = ["derive"] }

--- a/crates/stack-error/src/ext.rs
+++ b/crates/stack-error/src/ext.rs
@@ -1,0 +1,211 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::status_code::StatusCode;
+
+/// Extension to [`Error`](std::error::Error) in std.
+pub trait ErrorExt: StackError {
+    /// Map this error to [StatusCode].
+    fn status_code(&self) -> StatusCode {
+        StatusCode::Unknown
+    }
+
+    /// Returns the error as [Any](std::any::Any) so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
+    fn output_msg(&self) -> String
+    where
+        Self: Sized,
+    {
+        match self.status_code() {
+            StatusCode::Unknown | StatusCode::Internal => {
+                // masks internal error from end user
+                format!("Internal error: {}", self.status_code() as u32)
+            }
+            _ => {
+                let error = self.last();
+                if let Some(external_error) = error.source() {
+                    let external_root = external_error.sources().last().unwrap();
+
+                    if error.to_string().is_empty() {
+                        format!("{external_root}")
+                    } else {
+                        format!("{error}: {external_root}")
+                    }
+                } else {
+                    format!("{error}")
+                }
+            }
+        }
+    }
+}
+
+pub trait StackError: std::error::Error {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>);
+
+    fn next(&self) -> Option<&dyn StackError>;
+
+    fn last(&self) -> &dyn StackError
+    where
+        Self: Sized,
+    {
+        let Some(mut result) = self.next() else {
+            return self;
+        };
+        while let Some(err) = result.next() {
+            result = err;
+        }
+        result
+    }
+}
+
+impl<T: ?Sized + StackError> StackError for Arc<T> {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        self.as_ref().debug_fmt(layer, buf)
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        self.as_ref().next()
+    }
+}
+
+impl<T: StackError> StackError for Box<T> {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        self.as_ref().debug_fmt(layer, buf)
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        self.as_ref().next()
+    }
+}
+
+/// An opaque boxed error based on errors that implement [ErrorExt] trait.
+pub struct BoxedError {
+    inner: Box<dyn crate::ext::ErrorExt + Send + Sync>,
+}
+
+impl BoxedError {
+    pub fn new<E: crate::ext::ErrorExt + Send + Sync + 'static>(err: E) -> Self {
+        Self {
+            inner: Box::new(err),
+        }
+    }
+}
+
+impl std::fmt::Debug for BoxedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut buf = vec![];
+        self.debug_fmt(0, &mut buf);
+        write!(f, "{}", buf.join("\n"))
+    }
+}
+
+impl std::fmt::Display for BoxedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::error::Error for BoxedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl crate::ext::ErrorExt for BoxedError {
+    fn status_code(&self) -> crate::status_code::StatusCode {
+        self.inner.status_code()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_any()
+    }
+}
+
+// Implement ErrorCompat for this opaque error so the backtrace is also available
+// via `ErrorCompat::backtrace()`.
+impl crate::snafu::ErrorCompat for BoxedError {
+    fn backtrace(&self) -> Option<&crate::snafu::Backtrace> {
+        None
+    }
+}
+
+impl StackError for BoxedError {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        self.inner.debug_fmt(layer, buf)
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        self.inner.next()
+    }
+}
+
+/// Error type with plain error message
+#[derive(Debug)]
+pub struct PlainError {
+    msg: String,
+    status_code: StatusCode,
+}
+
+impl PlainError {
+    pub fn new(msg: String, status_code: StatusCode) -> Self {
+        Self { msg, status_code }
+    }
+}
+
+impl std::fmt::Display for PlainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl std::error::Error for PlainError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl crate::ext::ErrorExt for PlainError {
+    fn status_code(&self) -> crate::status_code::StatusCode {
+        self.status_code
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self as _
+    }
+}
+
+impl StackError for PlainError {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        buf.push(format!("{}: {}", layer, self.msg))
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        None
+    }
+}
+
+impl StackError for std::io::Error {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        buf.push(format!("{}: {}", layer, self))
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        None
+    }
+}

--- a/crates/stack-error/src/lib.rs
+++ b/crates/stack-error/src/lib.rs
@@ -1,0 +1,26 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(error_iter)]
+
+pub mod ext;
+pub mod mock;
+pub mod status_code;
+
+pub use snafu;
+
+// HACK - these headers are here for shared in gRPC services. For common HTTP headers,
+// please define in `src/servers/src/http/header.rs`.
+pub const GREPTIME_DB_HEADER_ERROR_CODE: &str = "x-greptime-err-code";
+pub const GREPTIME_DB_HEADER_ERROR_MSG: &str = "x-greptime-err-msg";

--- a/crates/stack-error/src/mock.rs
+++ b/crates/stack-error/src/mock.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utils for mock.
+
+use std::any::Any;
+use std::fmt;
+
+use crate::ext::{ErrorExt, StackError};
+use crate::status_code::StatusCode;
+
+/// A mock error mainly for test.
+#[derive(Debug)]
+pub struct MockError {
+    pub code: StatusCode,
+    source: Option<Box<MockError>>,
+}
+
+impl MockError {
+    /// Create a new [MockError] without backtrace.
+    pub fn new(code: StatusCode) -> MockError {
+        MockError { code, source: None }
+    }
+
+    /// Create a new [MockError] with source.
+    pub fn with_source(source: MockError) -> MockError {
+        MockError {
+            code: source.code,
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl fmt::Display for MockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.code)
+    }
+}
+
+impl std::error::Error for MockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e as _)
+    }
+}
+
+impl ErrorExt for MockError {
+    fn status_code(&self) -> StatusCode {
+        self.code
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl StackError for MockError {
+    fn debug_fmt(&self, _: usize, _: &mut Vec<String>) {}
+
+    fn next(&self) -> Option<&dyn StackError> {
+        None
+    }
+}

--- a/crates/stack-error/src/status_code.rs
+++ b/crates/stack-error/src/status_code.rs
@@ -1,0 +1,239 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use strum::{AsRefStr, EnumIter, EnumString, FromRepr};
+
+/// Common status code for public API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, AsRefStr, EnumIter, FromRepr)]
+pub enum StatusCode {
+    // ====== Begin of common status code ==============
+    /// Success.
+    Success = 0,
+
+    /// Unknown error.
+    Unknown = 1000,
+    /// Unsupported operation.
+    Unsupported = 1001,
+    /// Unexpected error, maybe there is a BUG.
+    Unexpected = 1002,
+    /// Internal server error.
+    Internal = 1003,
+    /// Invalid arguments.
+    InvalidArguments = 1004,
+    /// The task is cancelled.
+    Cancelled = 1005,
+    // ====== End of common status code ================
+
+    // ====== Begin of SQL related status code =========
+    /// SQL Syntax error.
+    InvalidSyntax = 2000,
+    // ====== End of SQL related status code ===========
+
+    // ====== Begin of query related status code =======
+    /// Fail to create a plan for the query.
+    PlanQuery = 3000,
+    /// The query engine fail to execute query.
+    EngineExecuteQuery = 3001,
+    // ====== End of query related status code =========
+
+    // ====== Begin of catalog related status code =====
+    /// Table already exists.
+    TableAlreadyExists = 4000,
+    TableNotFound = 4001,
+    TableColumnNotFound = 4002,
+    TableColumnExists = 4003,
+    DatabaseNotFound = 4004,
+    RegionNotFound = 4005,
+    RegionAlreadyExists = 4006,
+    RegionReadonly = 4007,
+    /// Region is not in a proper state to handle specific request.
+    RegionNotReady = 4008,
+    // If mutually exclusive operations are reached at the same time,
+    // only one can be executed, another one will get region busy.
+    RegionBusy = 4009,
+    // ====== End of catalog related status code =======
+
+    // ====== Begin of storage related status code =====
+    /// Storage is temporarily unable to handle the request
+    StorageUnavailable = 5000,
+    /// Request is outdated, e.g., version mismatch
+    RequestOutdated = 5001,
+    // ====== End of storage related status code =======
+
+    // ====== Begin of server related status code =====
+    /// Runtime resources exhausted, like creating threads failed.
+    RuntimeResourcesExhausted = 6000,
+
+    /// Rate limit exceeded
+    RateLimited = 6001,
+    // ====== End of server related status code =======
+
+    // ====== Begin of auth related status code =====
+    /// User not exist
+    UserNotFound = 7000,
+    /// Unsupported password type
+    UnsupportedPasswordType = 7001,
+    /// Username and password does not match
+    UserPasswordMismatch = 7002,
+    /// Not found http authorization header
+    AuthHeaderNotFound = 7003,
+    /// Invalid http authorization header
+    InvalidAuthHeader = 7004,
+    /// Illegal request to connect catalog-schema
+    AccessDenied = 7005,
+    /// User is not authorized to perform the operation
+    PermissionDenied = 7006,
+    // ====== End of auth related status code =====
+
+    // ====== Begin of flow related status code =====
+    FlowAlreadyExists = 8000,
+    FlowNotFound = 8001,
+    // ====== End of flow related status code =====
+}
+
+impl StatusCode {
+    /// Returns `true` if `code` is success.
+    pub fn is_success(code: u32) -> bool {
+        Self::Success as u32 == code
+    }
+
+    /// Returns `true` if the error with this code is retryable.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            StatusCode::StorageUnavailable
+            | StatusCode::RuntimeResourcesExhausted
+            | StatusCode::Internal
+            | StatusCode::RegionNotReady
+            | StatusCode::RegionBusy => true,
+
+            StatusCode::Success
+            | StatusCode::Unknown
+            | StatusCode::Unsupported
+            | StatusCode::Unexpected
+            | StatusCode::InvalidArguments
+            | StatusCode::Cancelled
+            | StatusCode::InvalidSyntax
+            | StatusCode::PlanQuery
+            | StatusCode::EngineExecuteQuery
+            | StatusCode::TableAlreadyExists
+            | StatusCode::TableNotFound
+            | StatusCode::RegionAlreadyExists
+            | StatusCode::RegionNotFound
+            | StatusCode::FlowAlreadyExists
+            | StatusCode::FlowNotFound
+            | StatusCode::RegionReadonly
+            | StatusCode::TableColumnNotFound
+            | StatusCode::TableColumnExists
+            | StatusCode::DatabaseNotFound
+            | StatusCode::RateLimited
+            | StatusCode::UserNotFound
+            | StatusCode::UnsupportedPasswordType
+            | StatusCode::UserPasswordMismatch
+            | StatusCode::AuthHeaderNotFound
+            | StatusCode::InvalidAuthHeader
+            | StatusCode::AccessDenied
+            | StatusCode::PermissionDenied
+            | StatusCode::RequestOutdated => false,
+        }
+    }
+
+    /// Returns `true` if we should print an error log for an error with
+    /// this status code.
+    pub fn should_log_error(&self) -> bool {
+        match self {
+            StatusCode::Unknown
+            | StatusCode::Unexpected
+            | StatusCode::Internal
+            | StatusCode::Cancelled
+            | StatusCode::PlanQuery
+            | StatusCode::EngineExecuteQuery
+            | StatusCode::StorageUnavailable
+            | StatusCode::RuntimeResourcesExhausted => true,
+            StatusCode::Success
+            | StatusCode::Unsupported
+            | StatusCode::InvalidArguments
+            | StatusCode::InvalidSyntax
+            | StatusCode::TableAlreadyExists
+            | StatusCode::TableNotFound
+            | StatusCode::RegionAlreadyExists
+            | StatusCode::RegionNotFound
+            | StatusCode::FlowAlreadyExists
+            | StatusCode::FlowNotFound
+            | StatusCode::RegionNotReady
+            | StatusCode::RegionBusy
+            | StatusCode::RegionReadonly
+            | StatusCode::TableColumnNotFound
+            | StatusCode::TableColumnExists
+            | StatusCode::DatabaseNotFound
+            | StatusCode::RateLimited
+            | StatusCode::UserNotFound
+            | StatusCode::UnsupportedPasswordType
+            | StatusCode::UserPasswordMismatch
+            | StatusCode::AuthHeaderNotFound
+            | StatusCode::InvalidAuthHeader
+            | StatusCode::AccessDenied
+            | StatusCode::PermissionDenied
+            | StatusCode::RequestOutdated => false,
+        }
+    }
+
+    pub fn from_u32(value: u32) -> Option<Self> {
+        StatusCode::from_repr(value as usize)
+    }
+}
+
+impl fmt::Display for StatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The current debug format is suitable to display.
+        write!(f, "{self:?}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    fn assert_status_code_display(code: StatusCode, msg: &str) {
+        let code_msg = format!("{code}");
+        assert_eq!(msg, code_msg);
+    }
+
+    #[test]
+    fn test_display_status_code() {
+        assert_status_code_display(StatusCode::Unknown, "Unknown");
+        assert_status_code_display(StatusCode::TableAlreadyExists, "TableAlreadyExists");
+    }
+
+    #[test]
+    fn test_from_u32() {
+        for code in StatusCode::iter() {
+            let num = code as u32;
+            assert_eq!(StatusCode::from_u32(num), Some(code));
+        }
+
+        assert_eq!(StatusCode::from_u32(10000), None);
+    }
+
+    #[test]
+    fn test_is_success() {
+        assert!(StatusCode::is_success(0));
+        assert!(!StatusCode::is_success(1));
+        assert!(!StatusCode::is_success(2));
+        assert!(!StatusCode::is_success(3));
+    }
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] Refactoring
- [x] Code style optimization

### 🔗 Related issue link

https://github.com/Watfaq/clash-rs/issues/405

### 💡 Background and solution

#### background

greptimedb has done a great job in engineerizing error handling in rust. currently, we are in great debt of error-handlings, it's inconvenient for debugging(i had a deep feeling about that when implementing zero-copy). 

so i tried a POC project in https://github.com/VendettaReborn/better-error-experiment, and it worked as expected, with NOT TOO MUCH overhead added. 

And i just tried it our project, removing `anyhow` in both ClashDnsResolver and Hysteria protocol implementation, i think it may serve as a draft and better POC now. 

#### solution

1. use snafu instead of thiserror/anyhow

```rust
#[derive(Snafu)]
#[snafu(visibility(pub))]
#[stack_trace_debug]
pub enum DnsError {
    #[snafu(display("invalid domain: {domain}"))]
    InvaldDomain {
        domain: String,
        #[snafu(implicit)]
        location: Location,
    },
    #[snafu(display("hickory proto"))]
    Proto {
        #[snafu(implicit)]
        location: Location,
        #[snafu(source)]
        error: hickory_proto::ProtoError,
    },
}
```
2. implement(copied from greptimedb) `stack_trace_debug` macro, which will take the `location` field as the file location in backtrace, and will take `error` field as the external error field. it's important that the two field name, 'location' and 'error' is hardcoded, but that's enough for now.

3. as you can see, with the propagate of Snafu Error, the `Location` is accumulated as a list, which will serve as the virtual error stack at the end. 

4. overhead: **after defining all error kinds properly**, the only overhead is adding `.context(xxxSnafu)` before using `?` or `xxxSnafu.fail()` for rust-style error propagate.
 

### TODOs 

- [ ] discuss if we should adopt this error handling approach (the cost of migrating .etc)
- [ ] move snafu stack trace related code to properer positions instead of `crates/...`
- [ ] register StatusCode for each unique error type
- [ ] migrate legacy code' error handling logic to Snafu, adjust workspace structure


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
