### PR TITLE
fix: remove android target SO_MARK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,12 @@ jobs:
             target: i686-unknown-freebsd
             tool: cross
             extra-args: --no-default-features -F "bsd"
+          # Android (no release)
+          - os: ubuntu-latest
+            target: x86_64-linux-android
+            tool: cross
+            extra-args: --no-default-features -F "android"
+            no-release: true
           # Linux mips: tier-3, pity
           # Windows gnu: tokio dont work
           # Windows aarch: todo
@@ -313,6 +319,7 @@ jobs:
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
+        if: ${{ !matrix.no-release }}
         with:
           name: ${{ matrix.release-name || matrix.target }}
           path: ${{ env.PACKAGE }}-${{ matrix.release-name || matrix.target }}${{ matrix.postfix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,24 +196,6 @@ jobs:
             target: i686-unknown-freebsd
             tool: cross
             extra-args: --no-default-features -F "bsd"
-
-          # Android
-          - os: ubuntu-latest
-            target: aarch64-linux-android
-            tool: cross
-            extra-args: --no-default-features -F "android"
-          - os: ubuntu-latest
-            target: armv7-linux-androideabi
-            tool: cross
-            extra-args: --no-default-features -F "android"
-          - os: ubuntu-latest
-            target: x86_64-linux-android
-            tool: cross
-            extra-args: --no-default-features -F "android"
-          - os: ubuntu-latest
-            target: i686-linux-android
-            tool: cross
-            extra-args: --no-default-features -F "android"
           # Linux mips: tier-3, pity
           # Windows gnu: tokio dont work
           # Windows aarch: todo

--- a/clash_lib/src/app/dns/dhcp.rs
+++ b/clash_lib/src/app/dns/dhcp.rs
@@ -188,7 +188,7 @@ async fn listen_dhcp_client(iface: &str) -> io::Result<UdpSocket> {
     new_udp_socket(
         Some(listen_addr.parse().expect("must parse")),
         Some(Interface::Name(iface.to_string())),
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(target_os = "linux")]
         None,
     )
     .await

--- a/clash_lib/src/app/dns/dns_client.rs
+++ b/clash_lib/src/app/dns/dns_client.rs
@@ -353,7 +353,7 @@ async fn dns_stream_builder(
             let fut = new_tcp_stream(
                 *addr,
                 iface.clone(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 None,
             )
             .map_ok(AsyncIoTokioAsStd);

--- a/clash_lib/src/app/dns/runtime.rs
+++ b/clash_lib/src/app/dns/runtime.rs
@@ -49,7 +49,7 @@ impl RuntimeProvider for DnsRuntimeProvider {
             new_tcp_stream(
                 server_addr,
                 iface,
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 None,
             )
             .await
@@ -72,7 +72,7 @@ impl RuntimeProvider for DnsRuntimeProvider {
             new_udp_socket(
                 None,
                 iface.clone(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 None,
             )
             .await

--- a/clash_lib/src/common/http/client.rs
+++ b/clash_lib/src/common/http/client.rs
@@ -67,7 +67,7 @@ impl Service<Uri> for LocalConnector {
             new_tcp_stream(
                 (remote_ip, remote_port).into(),
                 None,
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 None,
             )
             .await

--- a/clash_lib/src/proxy/direct/mod.rs
+++ b/clash_lib/src/proxy/direct/mod.rs
@@ -73,7 +73,7 @@ impl OutboundHandler for Handler {
         let s = new_tcp_stream(
             (remote_ip, sess.destination.port()).into(),
             sess.iface.clone(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             sess.so_mark,
         )
         .await?;
@@ -91,7 +91,7 @@ impl OutboundHandler for Handler {
         let d = new_udp_socket(
             None,
             sess.iface.clone(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             sess.so_mark,
         )
         .await
@@ -118,7 +118,7 @@ impl OutboundHandler for Handler {
                 sess.destination.host().as_str(),
                 sess.destination.port(),
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;
@@ -139,7 +139,7 @@ impl OutboundHandler for Handler {
                 None,
                 sess.destination.clone(),
                 sess.iface.clone(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;

--- a/clash_lib/src/proxy/hysteria2/mod.rs
+++ b/clash_lib/src/proxy/hysteria2/mod.rs
@@ -274,7 +274,7 @@ impl Handler {
                 new_udp_socket(
                     Some((Ipv6Addr::UNSPECIFIED, 0).into()),
                     sess.iface.clone(),
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    #[cfg(target_os = "linux")]
                     sess.so_mark,
                 )
                 .await
@@ -282,7 +282,7 @@ impl Handler {
                 new_udp_socket(
                     Some((Ipv4Addr::UNSPECIFIED, 0).into()),
                     sess.iface.clone(),
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    #[cfg(target_os = "linux")]
                     sess.so_mark,
                 )
                 .await
@@ -324,7 +324,7 @@ impl Handler {
                     new_udp_socket(
                         Some((Ipv6Addr::UNSPECIFIED, 0).into()),
                         sess.iface.clone(),
-                        #[cfg(any(target_os = "linux", target_os = "android"))]
+                        #[cfg(target_os = "linux")]
                         sess.so_mark,
                     )
                     .await?
@@ -332,7 +332,7 @@ impl Handler {
                     new_udp_socket(
                         Some((Ipv4Addr::UNSPECIFIED, 0).into()),
                         sess.iface.clone(),
-                        #[cfg(any(target_os = "linux", target_os = "android"))]
+                        #[cfg(target_os = "linux")]
                         sess.so_mark,
                     )
                     .await?

--- a/clash_lib/src/proxy/shadowsocks/mod.rs
+++ b/clash_lib/src/proxy/shadowsocks/mod.rs
@@ -248,7 +248,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;
@@ -274,7 +274,7 @@ impl OutboundHandler for Handler {
                 None,
                 (self.opts.server.clone(), self.opts.port).try_into()?,
                 sess.iface.as_ref().cloned(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;

--- a/clash_lib/src/proxy/socks/inbound/stream.rs
+++ b/clash_lib/src/proxy/socks/inbound/stream.rs
@@ -155,7 +155,7 @@ pub async fn handle_tcp<'a>(
             let udp_inbound = new_udp_socket(
                 Some(udp_addr),
                 None,
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 None,
             )
             .await?;

--- a/clash_lib/src/proxy/socks/outbound/mod.rs
+++ b/clash_lib/src/proxy/socks/outbound/mod.rs
@@ -150,7 +150,7 @@ impl Handler {
         let udp_socket = new_udp_socket(
             None,
             sess.iface.clone(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             None,
         )
         .await?;
@@ -239,7 +239,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;
@@ -263,7 +263,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;

--- a/clash_lib/src/proxy/trojan/mod.rs
+++ b/clash_lib/src/proxy/trojan/mod.rs
@@ -216,7 +216,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;
@@ -239,7 +239,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;

--- a/clash_lib/src/proxy/tuic/mod.rs
+++ b/clash_lib/src/proxy/tuic/mod.rs
@@ -201,15 +201,15 @@ impl Handler {
                 new_udp_socket(
                     Some((Ipv6Addr::UNSPECIFIED, 0).into()),
                     sess.iface.clone(),
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    #[cfg(target_os = "linux")]
                     sess.so_mark,
                 )
                 .await?
             } else {
                 new_udp_socket(
                     Some((Ipv4Addr::UNSPECIFIED, 0).into()),
-                    sess.iface.clone(),
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    None,
+                    #[cfg(target_os = "linux")]
                     sess.so_mark,
                 )
                 .await?

--- a/clash_lib/src/proxy/tuic/types.rs
+++ b/clash_lib/src/proxy/tuic/types.rs
@@ -51,7 +51,7 @@ impl TuicEndpoint {
                     new_udp_socket(
                         None,
                         iface.map(|x| Interface::Name(x.name)),
-                        #[cfg(any(target_os = "linux", target_os = "android"))]
+                        #[cfg(target_os = "linux")]
                         None,
                     )
                     .await?

--- a/clash_lib/src/proxy/utils/platform/unix.rs
+++ b/clash_lib/src/proxy/utils/platform/unix.rs
@@ -2,6 +2,7 @@ use std::{io, net::SocketAddr};
 
 use crate::proxy::utils::Interface;
 
+#[allow(dead_code)]
 pub(crate) fn must_bind_socket_on_interface(
     socket: &socket2::Socket,
     iface: &Interface,

--- a/clash_lib/src/proxy/utils/proxy_connector.rs
+++ b/clash_lib/src/proxy/utils/proxy_connector.rs
@@ -31,9 +31,7 @@ pub trait RemoteConnector: Send + Sync + Debug {
         address: &str,
         port: u16,
         iface: Option<&Interface>,
-        #[cfg(any(target_os = "linux", target_os = "android"))] packet_mark: Option<
-            u32,
-        >,
+        #[cfg(target_os = "linux")] packet_mark: Option<u32>,
     ) -> std::io::Result<AnyStream>;
 
     async fn connect_datagram(
@@ -42,9 +40,7 @@ pub trait RemoteConnector: Send + Sync + Debug {
         src: Option<SocketAddr>,
         destination: SocksAddr,
         iface: Option<Interface>,
-        #[cfg(any(target_os = "linux", target_os = "android"))] packet_mark: Option<
-            u32,
-        >,
+        #[cfg(target_os = "linux")] packet_mark: Option<u32>,
     ) -> std::io::Result<AnyOutboundDatagram>;
 }
 
@@ -72,7 +68,7 @@ impl RemoteConnector for DirectConnector {
         address: &str,
         port: u16,
         iface: Option<&Interface>,
-        #[cfg(any(target_os = "linux", target_os = "android"))] so_mark: Option<u32>,
+        #[cfg(target_os = "linux")] so_mark: Option<u32>,
     ) -> std::io::Result<AnyStream> {
         let dial_addr = resolver
             .resolve(address, false)
@@ -83,7 +79,7 @@ impl RemoteConnector for DirectConnector {
         new_tcp_stream(
             (dial_addr, port).into(),
             iface.cloned(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             so_mark,
         )
         .await
@@ -96,12 +92,12 @@ impl RemoteConnector for DirectConnector {
         src: Option<SocketAddr>,
         _destination: SocksAddr,
         iface: Option<Interface>,
-        #[cfg(any(target_os = "linux", target_os = "android"))] so_mark: Option<u32>,
+        #[cfg(target_os = "linux")] so_mark: Option<u32>,
     ) -> std::io::Result<AnyOutboundDatagram> {
         let dgram = new_udp_socket(
             src,
             iface,
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             so_mark,
         )
         .await
@@ -143,14 +139,14 @@ impl RemoteConnector for ProxyConnector {
         address: &str,
         port: u16,
         iface: Option<&Interface>,
-        #[cfg(any(target_os = "linux", target_os = "android"))] so_mark: Option<u32>,
+        #[cfg(target_os = "linux")] so_mark: Option<u32>,
     ) -> std::io::Result<AnyStream> {
         let sess = Session {
             network: Network::Tcp,
             typ: Type::Ignore,
             destination: crate::session::SocksAddr::Domain(address.to_owned(), port),
             iface: iface.cloned(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             so_mark,
             ..Default::default()
         };
@@ -178,14 +174,14 @@ impl RemoteConnector for ProxyConnector {
         _src: Option<SocketAddr>,
         destination: SocksAddr,
         iface: Option<Interface>,
-        #[cfg(any(target_os = "linux", target_os = "android"))] so_mark: Option<u32>,
+        #[cfg(target_os = "linux")] so_mark: Option<u32>,
     ) -> std::io::Result<AnyOutboundDatagram> {
         let sess = Session {
             network: Network::Udp,
             typ: Type::Ignore,
             iface,
             destination: destination.clone(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(target_os = "linux")]
             so_mark,
             ..Default::default()
         };

--- a/clash_lib/src/proxy/utils/socket_helpers.rs
+++ b/clash_lib/src/proxy/utils/socket_helpers.rs
@@ -58,6 +58,7 @@ pub async fn new_tcp_stream(
         ),
     };
 
+    #[cfg(not(target_os = "android"))]
     if let Some(iface) = iface {
         debug!("binding tcp socket to interface: {:?}", iface);
         must_bind_socket_on_interface(&socket, &iface, family)?;
@@ -112,6 +113,7 @@ pub async fn new_udp_socket(
         ),
     };
 
+    #[cfg(not(target_os = "android"))]
     match (src, iface) {
         (Some(_), Some(iface)) => {
             debug!("both src and iface are set, iface will be used: {:?}", src);

--- a/clash_lib/src/proxy/utils/socket_helpers.rs
+++ b/clash_lib/src/proxy/utils/socket_helpers.rs
@@ -37,7 +37,7 @@ pub fn apply_tcp_options(s: TcpStream) -> std::io::Result<TcpStream> {
 pub async fn new_tcp_stream(
     endpoint: SocketAddr,
     iface: Option<Interface>,
-    #[cfg(any(target_os = "linux", target_os = "android"))] so_mark: Option<u32>,
+    #[cfg(target_os = "linux")] so_mark: Option<u32>,
 ) -> io::Result<TcpStream> {
     let (socket, family) = match endpoint {
         SocketAddr::V4(_) => (
@@ -63,7 +63,7 @@ pub async fn new_tcp_stream(
         must_bind_socket_on_interface(&socket, &iface, family)?;
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     if let Some(so_mark) = so_mark {
         socket.set_mark(so_mark)?;
     }
@@ -82,7 +82,7 @@ pub async fn new_tcp_stream(
 pub async fn new_udp_socket(
     src: Option<SocketAddr>,
     iface: Option<Interface>,
-    #[cfg(any(target_os = "linux", target_os = "android"))] so_mark: Option<u32>,
+    #[cfg(target_os = "linux")] so_mark: Option<u32>,
 ) -> io::Result<UdpSocket> {
     let (socket, family) = match src {
         Some(src) => {
@@ -138,7 +138,7 @@ pub async fn new_udp_socket(
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     if let Some(so_mark) = so_mark {
         socket.set_mark(so_mark)?;
     }

--- a/clash_lib/src/proxy/utils/socket_helpers.rs
+++ b/clash_lib/src/proxy/utils/socket_helpers.rs
@@ -34,6 +34,7 @@ pub fn apply_tcp_options(s: TcpStream) -> std::io::Result<TcpStream> {
     }
 }
 
+#[allow(unused_variables)]
 pub async fn new_tcp_stream(
     endpoint: SocketAddr,
     iface: Option<Interface>,
@@ -80,6 +81,7 @@ pub async fn new_tcp_stream(
     .await?
 }
 
+#[allow(unused_variables)]
 pub async fn new_udp_socket(
     src: Option<SocketAddr>,
     iface: Option<Interface>,

--- a/clash_lib/src/proxy/utils/socket_helpers.rs
+++ b/clash_lib/src/proxy/utils/socket_helpers.rs
@@ -7,9 +7,9 @@ use tokio::{
 };
 
 #[allow(unused_imports)]
-use tracing::{debug, error};
-#[allow(unused_imports)]
 use super::{platform::must_bind_socket_on_interface, Interface};
+#[allow(unused_imports)]
+use tracing::{debug, error};
 
 pub fn apply_tcp_options(s: TcpStream) -> std::io::Result<TcpStream> {
     #[cfg(not(target_os = "windows"))]

--- a/clash_lib/src/proxy/utils/socket_helpers.rs
+++ b/clash_lib/src/proxy/utils/socket_helpers.rs
@@ -6,8 +6,9 @@ use tokio::{
     time::timeout,
 };
 
+#[allow(unused_imports)]
 use tracing::{debug, error};
-
+#[allow(unused_imports)]
 use super::{platform::must_bind_socket_on_interface, Interface};
 
 pub fn apply_tcp_options(s: TcpStream) -> std::io::Result<TcpStream> {

--- a/clash_lib/src/proxy/vmess/mod.rs
+++ b/clash_lib/src/proxy/vmess/mod.rs
@@ -248,7 +248,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;
@@ -271,7 +271,7 @@ impl OutboundHandler for Handler {
                 self.opts.server.as_str(),
                 self.opts.port,
                 sess.iface.as_ref(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;

--- a/clash_lib/src/proxy/wg/wireguard.rs
+++ b/clash_lib/src/proxy/wg/wireguard.rs
@@ -103,7 +103,7 @@ impl WireguardTunnel {
                 None,
                 remote_endpoint.into(),
                 sess.iface.clone(),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(target_os = "linux")]
                 sess.so_mark,
             )
             .await?;


### PR DESCRIPTION
### 🤔 Bug fix

SO_MARK and SO_BINDTODEVICE are not usable when targting android.
