### PR TITLE
fix: use watfaq-rustls instead of patched one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
+dependencies = [
+ "aws-lc-sys",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +662,29 @@ dependencies = [
  "blowfish",
  "pbkdf2",
  "sha2",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.96",
+ "which",
 ]
 
 [[package]]
@@ -955,6 +1003,8 @@ version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1235,6 +1285,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tokio-util",
+ "tokio-watfaq-rustls",
  "tor-rtcompat",
  "totp-rs",
  "tower 0.5.2",
@@ -1251,8 +1302,18 @@ dependencies = [
  "url",
  "uuid",
  "watfaq-dns",
+ "watfaq-rustls",
  "webpki-roots",
  "windows 0.60.0",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1920,6 +1981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,6 +2391,12 @@ dependencies = [
  "thiserror 2.0.11",
  "walkdir",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -3425,6 +3498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,6 +3553,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -5123,8 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
-source = "git+https://github.com/Watfaq/rustls.git?rev=a7d217bf235aeb3ca8d123352d90a27c1ca0f41b#a7d217bf235aeb3ca8d123352d90a27c1ca0f41b"
+version = "0.23.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
@@ -5159,6 +5248,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -6081,11 +6171,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
-source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=6b9af8ac7bb5abc159d9a67e9ddbf84127559a4a#6b9af8ac7bb5abc159d9a67e9ddbf84127559a4a"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -6155,6 +6245,16 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-watfaq-rustls"
+version = "0.26.0"
+source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=712cd2f707db2284653db3799a4b25c47cb57329#712cd2f707db2284653db3799a4b25c47cb57329"
+dependencies = [
+ "rustls-pki-types",
+ "tokio",
+ "watfaq-rustls",
 ]
 
 [[package]]
@@ -7276,7 +7376,7 @@ name = "tracing-oslog"
 version = "0.2.0"
 source = "git+https://github.com/Absolucy/tracing-oslog.git?branch=main#b44d62871464e332249ae79e000dad9ebeb06434"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "cfg-if",
  "once_cell",
@@ -7795,6 +7895,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "watfaq-rustls"
+version = "0.23.21"
+source = "git+https://github.com/Watfaq/rustls.git?rev=98d6b2e52f1791690c4c4f5f0bc832924be8c0cb#98d6b2e52f1791690c4c4f5f0bc832924be8c0cb"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "weak-table"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7827,6 +7941,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,31 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
-dependencies = [
- "aws-lc-sys",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
-dependencies = [
- "bindgen 0.69.5",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "paste",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,29 +637,6 @@ dependencies = [
  "blowfish",
  "pbkdf2",
  "sha2",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.8.0",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.96",
- "which",
 ]
 
 [[package]]
@@ -1003,8 +955,6 @@ version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1305,15 +1255,6 @@ dependencies = [
  "watfaq-rustls",
  "webpki-roots",
  "windows 0.60.0",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1981,12 +1922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,12 +2326,6 @@ dependencies = [
  "thiserror 2.0.11",
  "walkdir",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -3498,15 +3427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3553,12 +3473,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -5248,7 +5162,6 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -6250,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "tokio-watfaq-rustls"
 version = "0.26.0"
-source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=712cd2f707db2284653db3799a4b25c47cb57329#712cd2f707db2284653db3799a4b25c47cb57329"
+source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=638db32084d7ecf9c2660847b55d48d1186b4055#638db32084d7ecf9c2660847b55d48d1186b4055"
 dependencies = [
  "rustls-pki-types",
  "tokio",
@@ -7376,7 +7289,7 @@ name = "tracing-oslog"
 version = "0.2.0"
 source = "git+https://github.com/Absolucy/tracing-oslog.git?branch=main#b44d62871464e332249ae79e000dad9ebeb06434"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "cc",
  "cfg-if",
  "once_cell",
@@ -7897,11 +7810,11 @@ dependencies = [
 [[package]]
 name = "watfaq-rustls"
 version = "0.23.21"
-source = "git+https://github.com/Watfaq/rustls.git?rev=98d6b2e52f1791690c4c4f5f0bc832924be8c0cb#98d6b2e52f1791690c4c4f5f0bc832924be8c0cb"
+source = "git+https://github.com/Watfaq/rustls.git?rev=4cae3aa2e84ea29d8a74b495793773bdb0a72206#4cae3aa2e84ea29d8a74b495793773bdb0a72206"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -7941,18 +7854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,3 @@ codegen-units = 1
 lto = true
 strip = true
 debug = 1
-
-[patch.crates-io]
-tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "6b9af8ac7bb5abc159d9a67e9ddbf84127559a4a"}
-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "a7d217bf235aeb3ca8d123352d90a27c1ca0f41b"}

--- a/clash_lib/Cargo.toml
+++ b/clash_lib/Cargo.toml
@@ -42,8 +42,8 @@ rustls-pemfile = "2"
 webpki-roots = "0.26"
 
 # shadow-tls
-tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "712cd2f707db2284653db3799a4b25c47cb57329"}
-watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "98d6b2e52f1791690c4c4f5f0bc832924be8c0cb"}
+tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "638db32084d7ecf9c2660847b55d48d1186b4055", default-features = false, features = ["logging", "tls12"]}
+watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "4cae3aa2e84ea29d8a74b495793773bdb0a72206", default-features = false, features=["ring"] }
 
 # Error handing & logging
 thiserror = "2"

--- a/clash_lib/Cargo.toml
+++ b/clash_lib/Cargo.toml
@@ -41,6 +41,10 @@ rustls = { version  = "0.23", default-features = false, features=["ring"] }
 rustls-pemfile = "2"
 webpki-roots = "0.26"
 
+# shadow-tls
+tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "712cd2f707db2284653db3799a4b25c47cb57329"}
+watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "98d6b2e52f1791690c4c4f5f0bc832924be8c0cb"}
+
 # Error handing & logging
 thiserror = "2"
 anyhow = "1"

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
@@ -16,8 +16,7 @@ use super::{
     utils::Hmac,
 };
 
-pub static ROOT_STORE: Lazy<Arc<RootCertStore>> =
-    Lazy::new(root_store);
+static ROOT_STORE: Lazy<Arc<RootCertStore>> = Lazy::new(root_store);
 
 fn root_store() -> Arc<RootCertStore> {
     let root_store = webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect();

--- a/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
+++ b/clash_lib/src/proxy/shadowsocks/shadow_tls/connector.rs
@@ -1,10 +1,11 @@
-use std::{io, ptr::copy_nonoverlapping, sync::Arc};
-
+use once_cell::sync::Lazy;
 use rand::Rng;
+use std::{io, ptr::copy_nonoverlapping, sync::Arc};
 
 use rand::distr::Distribution;
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tokio_rustls::{TlsConnector, client::TlsStream};
+use tokio_watfaq_rustls::{TlsConnector, client::TlsStream};
+use watfaq_rustls::RootCertStore;
 
 use crate::proxy::{AnyStream, shadowsocks::ShadowTlsOption};
 
@@ -14,6 +15,14 @@ use super::{
     stream::{ProxyTlsStream, VerifiedStream},
     utils::Hmac,
 };
+
+pub static ROOT_STORE: Lazy<Arc<RootCertStore>> =
+    Lazy::new(root_store);
+
+fn root_store() -> Arc<RootCertStore> {
+    let root_store = webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect();
+    Arc::new(root_store)
+}
 
 #[derive(Clone, Debug)]
 #[allow(unused)]
@@ -27,10 +36,8 @@ pub struct Connector;
 
 impl Connector {
     fn connector() -> TlsConnector {
-        use crate::common::tls::GLOBAL_ROOT_STORE;
-
-        let tls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(GLOBAL_ROOT_STORE.clone())
+        let tls_config = watfaq_rustls::ClientConfig::builder()
+            .with_root_certificates(ROOT_STORE.clone())
             .with_no_client_auth();
 
         TlsConnector::from(Arc::new(tls_config.clone()))
@@ -43,8 +50,9 @@ impl Connector {
         let proxy_stream = ProxyTlsStream::new(stream, &opts.password);
 
         let hamc_handshake = Hmac::new(&opts.password, (&[], &[]));
-        let sni_name = rustls::pki_types::ServerName::try_from(opts.host.clone())
-            .unwrap_or_else(|_| panic!("invalid server name: {}", opts.host));
+        let sni_name =
+            watfaq_rustls::pki_types::ServerName::try_from(opts.host.clone())
+                .unwrap_or_else(|_| panic!("invalid server name: {}", opts.host));
         let session_id_generator =
             move |data: &_| generate_session_id(&hamc_handshake, data);
         let connector = Self::connector();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] Code style optimization

### 🔗 Related issue link

https://github.com/Watfaq/clash-rs/issues/733

### 💡 Background and solution

- rename rustls into watfaq-rustls, rename tokio-rustls into tokio-watfaq-rustls
