### PR TITLE
fix: allow lan

### DIFF
--- a/clash_lib/src/app/inbound/manager.rs
+++ b/clash_lib/src/app/inbound/manager.rs
@@ -136,7 +136,7 @@ impl InboundManager {
                     dispatcher: self.dispatcher.clone(),
                     authenticator: self.authenticator.clone(),
                     listener: inbound.clone(),
-                    allow_lan: self.allow_lan
+                    allow_lan: self.allow_lan,
                 },
             );
         }

--- a/clash_lib/src/app/inbound/manager.rs
+++ b/clash_lib/src/app/inbound/manager.rs
@@ -33,6 +33,7 @@ type TaskHandle = RwLock<Option<(JoinHandle<Result<()>>, oneshot::Sender<()>)>>;
 
 pub struct InboundManager {
     dispatcher: Arc<Dispatcher>,
+    allow_lan: bool,
     bind_address: ArcSwap<BindAddress>,
     authenticator: ThreadSafeAuthenticator,
 
@@ -44,6 +45,7 @@ pub struct InboundManager {
 
 impl InboundManager {
     pub async fn new(
+        allow_lan: bool,
         bind_address: BindAddress,
         _authentication: Vec<String>, // TODO
         dispatcher: Arc<Dispatcher>,
@@ -57,6 +59,7 @@ impl InboundManager {
             authenticator,
             inbounds_opt: inbounds_opt.into(),
             task_handle: RwLock::new(None),
+            allow_lan,
         };
         s.build_handlers().await;
         Ok(s)
@@ -132,7 +135,8 @@ impl InboundManager {
                     name: name.to_string(),
                     dispatcher: self.dispatcher.clone(),
                     authenticator: self.authenticator.clone(),
-                    listener: inbound.clone(), // TODO use Arc
+                    listener: inbound.clone(),
+                    allow_lan: self.allow_lan
                 },
             );
         }

--- a/clash_lib/src/app/inbound/network_listener.rs
+++ b/clash_lib/src/app/inbound/network_listener.rs
@@ -24,6 +24,7 @@ pub struct NetworkInboundHandler {
     pub listener: InboundOpts,
     pub dispatcher: Arc<Dispatcher>,
     pub authenticator: ThreadSafeAuthenticator,
+    pub allow_lan: bool
 }
 
 impl NetworkInboundHandler {
@@ -41,21 +42,21 @@ impl NetworkInboundHandler {
         let handler: InboudHandler = match &self.listener {
             InboundOpts::Http { common_opts, .. } => HttpInbound::new(
                 (common_opts.listen.0, common_opts.port).into(),
-                common_opts.allow_lan,
+                common_opts.allow_lan.unwrap_or(self.allow_lan),
                 self.dispatcher.clone(),
                 self.authenticator.clone(),
             )
             .into(),
             InboundOpts::Socks { common_opts, .. } => SocksInbound::new(
                 (common_opts.listen.0, common_opts.port).into(),
-                common_opts.allow_lan,
+                common_opts.allow_lan.unwrap_or(self.allow_lan),
                 self.dispatcher.clone(),
                 self.authenticator.clone(),
             )
             .into(),
             InboundOpts::Mixed { common_opts, .. } => MixedInbound::new(
                 (common_opts.listen.0, common_opts.port).into(),
-                common_opts.allow_lan,
+                common_opts.allow_lan.unwrap_or(self.allow_lan),
                 self.dispatcher.clone(),
                 self.authenticator.clone(),
             )
@@ -66,7 +67,7 @@ impl NetworkInboundHandler {
                 {
                     TproxyInbound::new(
                         (common_opts.listen.0, common_opts.port).into(),
-                        common_opts.allow_lan,
+                        common_opts.allow_lan.unwrap_or(self.allow_lan),
                         self.dispatcher.clone(),
                     )
                     .into()

--- a/clash_lib/src/app/inbound/network_listener.rs
+++ b/clash_lib/src/app/inbound/network_listener.rs
@@ -24,7 +24,7 @@ pub struct NetworkInboundHandler {
     pub listener: InboundOpts,
     pub dispatcher: Arc<Dispatcher>,
     pub authenticator: ThreadSafeAuthenticator,
-    pub allow_lan: bool
+    pub allow_lan: bool,
 }
 
 impl NetworkInboundHandler {

--- a/clash_lib/src/config/internal/config.rs
+++ b/clash_lib/src/config/internal/config.rs
@@ -57,6 +57,7 @@ impl Config {
 }
 
 pub struct General {
+    pub allow_lan: bool,
     pub authentication: Vec<String>,
     pub bind_address: BindAddress,
     pub(crate) controller: Controller,

--- a/clash_lib/src/config/internal/convert/general.rs
+++ b/clash_lib/src/config/internal/convert/general.rs
@@ -10,6 +10,7 @@ use crate::{
 
 pub(super) fn convert(c: &def::Config) -> Result<General, crate::Error> {
     Ok(General {
+        allow_lan: c.allow_lan.unwrap_or_default(),
         authentication: c.authentication.clone(),
         controller: Controller {
             external_controller: c.external_controller.clone(),

--- a/clash_lib/src/config/internal/listener.rs
+++ b/clash_lib/src/config/internal/listener.rs
@@ -93,7 +93,8 @@ pub struct CommonInboundOpts {
     pub name: String,
     pub listen: BindAddress,
     // TODO: make this reloadable in inbound listeners
-    pub allow_lan: bool,
+    #[educe(Default = None)]
+    pub allow_lan: Option<bool>,
     #[educe(Default = 0)]
     pub port: u16,
 }

--- a/clash_lib/src/lib.rs
+++ b/clash_lib/src/lib.rs
@@ -442,6 +442,7 @@ async fn create_components(
     debug!("initializing inbound manager");
     let inbound_manager = Arc::new(
         InboundManager::new(
+            config.general.allow_lan,
             config.general.bind_address,
             config.general.authentication,
             dispatcher.clone(),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/Watfaq/clash-rs/issues/778

### 💡 Background and solution

We didn't respect top level `allow-lan`. This PR deliver the allow-lan to inbound manager.

I thought this can be done in `clash_lib/src/proxy/converters`. But i found I have to copy `InboundOpts` and `CommonInboundOpts`, define new `InboundOptsDef` and `CommonInboundOptsDef` in `clash_lib/src/config/def.rs`

Therefore I just used lazy way

