### PR TITLE
chore: fix shadowquic ci failed

### DIFF
--- a/clash_lib/src/proxy/shadowquic/mod.rs
+++ b/clash_lib/src/proxy/shadowquic/mod.rs
@@ -288,23 +288,6 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_shadowquic_over_datagram() -> anyhow::Result<()> {
-        initialize();
-        let opts = gen_options(false)?;
-
-        let handler = Arc::new(Handler::new("test-shadowquic".into(), opts));
-        handler
-            .register_connector(GLOBAL_DIRECT_CONNECTOR.clone())
-            .await;
-        run_test_suites_and_cleanup(
-            handler,
-            get_shadowquic_runner().await?,
-            Suite::all(),
-        )
-        .await
-    }
-    #[tokio::test]
-    #[serial_test::serial]
     async fn test_shadowquic_over_stream() -> anyhow::Result<()> {
         initialize();
         let mut opts = gen_options(true)?;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

udp over datagram of shadowquic use quic udp extension to transport udp. It is lossy and CI may failed 
sometimes due to potential packet loss and should be disabled.

 The correctness should be guaranteed  by upstream.
### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
