### PR TITLE
feat: introduce Smart proxy group for intelligent proxy selection

### DIFF
--- a/clash/tests/data/config/rules.yaml
+++ b/clash/tests/data/config/rules.yaml
@@ -80,6 +80,7 @@ asn-mmdb: Country-asn.mmdb
 profile:
   store-selected: true
   store-fake-ip: false
+  store-smart-stats: true
 
 proxy-groups:
   - name: "relay"

--- a/clash/tests/data/config/rules.yaml
+++ b/clash/tests/data/config/rules.yaml
@@ -92,6 +92,7 @@ proxy-groups:
       - "auto"
       - "fallback-auto"
       - "load-balance"
+      - "smart"
       - "select"
       - "wg"
       - DIRECT
@@ -109,6 +110,7 @@ proxy-groups:
       # - "auto"
       # - "fallback-auto"
       # - "load-balance"
+      # - "smart"
       # - "select"
       # - "wg"
       # - DIRECT
@@ -143,6 +145,15 @@ proxy-groups:
     proxies:
       - DIRECT
     strategy: round-robin
+    url: "http://www.gstatic.com/generate_204"
+    interval: 300
+
+  - name: "smart"
+    type: smart
+    use:
+      - "file-provider-uot"
+    proxies:
+      - DIRECT
     url: "http://www.gstatic.com/generate_204"
     interval: 300
 

--- a/clash_lib/src/app/dns/config.rs
+++ b/clash_lib/src/app/dns/config.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub fake_ip_range: ipnet::IpNet,
     pub fake_ip_filter: Vec<String>,
     pub store_fake_ip: bool,
+    pub store_smart_stats: bool,
     pub hosts: Option<trie::StringTrie<IpAddr>>,
     pub nameserver_policy: HashMap<String, NameServer>,
 }
@@ -354,6 +355,7 @@ impl TryFrom<&crate::config::def::Config> for Config {
             )?,
             fake_ip_filter: dc.fake_ip_filter.clone(),
             store_fake_ip: c.profile.store_fake_ip,
+            store_smart_stats: c.profile.store_smart_stats,
             hosts: if dc.user_hosts && !c.hosts.is_empty() {
                 Config::parse_hosts(&c.hosts).ok()
             } else {

--- a/clash_lib/src/app/outbound/manager.rs
+++ b/clash_lib/src/app/outbound/manager.rs
@@ -669,17 +669,22 @@ impl OutboundManager {
                         &mut providers,
                     );
 
-                    let smart_handler = smart::Handler::new(
+                    let smart_handler = smart::Handler::new_with_cache(
                         smart::HandlerOptions {
                             name: proto.name.clone(),
                             common_opts: crate::proxy::HandlerCommonOptions {
                                 icon: proto.icon.clone(),
                                 ..Default::default()
                             },
-                            ..Default::default()
+                            udp: proto.udp.unwrap_or(true),
+                            max_retries: proto.max_retries,
+                            site_stickiness: proto.site_stickiness,
+                            bandwidth_weight: proto.bandwidth_weight,
+                            // policy_priority is now handled by cache_store
                         },
                         providers,
                         proxy_manager.clone(),
+                        cache_store.clone(),
                     );
 
                     handlers.insert(proto.name.clone(), Arc::new(smart_handler));

--- a/clash_lib/src/app/outbound/manager.rs
+++ b/clash_lib/src/app/outbound/manager.rs
@@ -17,7 +17,6 @@ use crate::app::{
     },
 };
 
-use crate::proxy::group::smart;
 use crate::{
     app::remote_content_manager::providers::proxy_provider::{
         PlainProvider, ProxySetProvider, ThreadSafeProxyProvider,
@@ -27,7 +26,9 @@ use crate::{
     },
     print_and_exit,
     proxy::{
-        OutboundType, fallback, loadbalance, selector, socks, trojan,
+        OutboundType, fallback,
+        group::smart,
+        loadbalance, selector, socks, trojan,
         utils::{DirectConnector, ProxyConnector},
         vmess, wg,
     },

--- a/clash_lib/src/app/outbound/manager.rs
+++ b/clash_lib/src/app/outbound/manager.rs
@@ -654,7 +654,7 @@ impl OutboundManager {
                         providers.push(make_provider_from_proxies(
                             &proto.name,
                             proxies,
-                            proto.interval,
+                            0,
                             proto.lazy.unwrap_or_default(),
                             handlers,
                             proxy_manager.clone(),

--- a/clash_lib/src/app/outbound/manager.rs
+++ b/clash_lib/src/app/outbound/manager.rs
@@ -680,7 +680,6 @@ impl OutboundManager {
                             max_retries: proto.max_retries,
                             site_stickiness: proto.site_stickiness,
                             bandwidth_weight: proto.bandwidth_weight,
-                            // policy_priority is now handled by cache_store
                         },
                         providers,
                         proxy_manager.clone(),

--- a/clash_lib/src/app/outbound/utils.rs
+++ b/clash_lib/src/app/outbound/utils.rs
@@ -173,8 +173,9 @@ pub fn proxy_groups_dag_sort(
 #[cfg(test)]
 mod tests {
     use crate::config::internal::proxy::{
-        OutboundGroupFallback, OutboundGroupLoadBalance, OutboundGroupSmart, OutboundGroupProtocol,
-        OutboundGroupRelay, OutboundGroupSelect, OutboundGroupUrlTest,
+        OutboundGroupFallback, OutboundGroupLoadBalance, OutboundGroupProtocol,
+        OutboundGroupRelay, OutboundGroupSelect, OutboundGroupSmart,
+        OutboundGroupUrlTest,
     };
 
     #[test]

--- a/clash_lib/src/app/outbound/utils.rs
+++ b/clash_lib/src/app/outbound/utils.rs
@@ -173,7 +173,7 @@ pub fn proxy_groups_dag_sort(
 #[cfg(test)]
 mod tests {
     use crate::config::internal::proxy::{
-        OutboundGroupFallback, OutboundGroupLoadBalance, OutboundGroupProtocol,
+        OutboundGroupFallback, OutboundGroupLoadBalance, OutboundGroupSmart, OutboundGroupProtocol,
         OutboundGroupRelay, OutboundGroupSelect, OutboundGroupUrlTest,
     };
 
@@ -186,6 +186,7 @@ mod tests {
                 "auto".to_owned(),
                 "fallback-auto".to_owned(),
                 "load-balance".to_owned(),
+                "smart".to_owned(),
                 "select".to_owned(),
                 "DIRECT".to_owned(),
             ]),
@@ -206,7 +207,12 @@ mod tests {
             proxies: Some(vec!["ss".to_owned(), "DIRECT".to_owned()]),
             ..Default::default()
         };
-        let g5 = OutboundGroupSelect {
+        let g5 = OutboundGroupSmart {
+            name: "smart".to_owned(),
+            proxies: Some(vec!["ss".to_owned(), "DIRECT".to_owned()]),
+            ..Default::default()
+        };
+        let g6 = OutboundGroupSelect {
             name: "select".to_owned(),
             proxies: Some(vec![
                 "ss".to_owned(),
@@ -221,7 +227,8 @@ mod tests {
             OutboundGroupProtocol::UrlTest(g2),
             OutboundGroupProtocol::Fallback(g3),
             OutboundGroupProtocol::LoadBalance(g4),
-            OutboundGroupProtocol::Select(g5),
+            OutboundGroupProtocol::Smart(g5),
+            OutboundGroupProtocol::Select(g6),
         ];
 
         super::proxy_groups_dag_sort(&mut groups).unwrap();

--- a/clash_lib/src/app/profile/mod.rs
+++ b/clash_lib/src/app/profile/mod.rs
@@ -206,10 +206,6 @@ impl CacheFile {
         self.db.smart_stats.get(group_name).cloned()
     }
 
-    // pub fn set_smart_policy_priority(&mut self, group_name: &str, priority: String) {
-    //     self.db.smart_policy_priority.insert(group_name.to_string(), priority);
-    // }
-
     pub fn get_smart_policy_priority(&self, group_name: &str) -> Option<String> {
         self.db.smart_policy_priority.get(group_name).cloned()
     }

--- a/clash_lib/src/app/profile/mod.rs
+++ b/clash_lib/src/app/profile/mod.rs
@@ -105,19 +105,29 @@ impl ThreadSafeCacheFile {
     }
 
     /// Store smart proxy group statistics
-    pub async fn set_smart_stats(&self, group_name: &str, stats: crate::proxy::group::smart::state::SmartStateData) {
+    pub async fn set_smart_stats(
+        &self,
+        group_name: &str,
+        stats: crate::proxy::group::smart::state::SmartStateData,
+    ) {
         let mut g = self.0.write().await;
         g.set_smart_stats(group_name, stats);
     }
 
     /// Get smart proxy group statistics
-    pub async fn get_smart_stats(&self, group_name: &str) -> Option<crate::proxy::group::smart::state::SmartStateData> {
+    pub async fn get_smart_stats(
+        &self,
+        group_name: &str,
+    ) -> Option<crate::proxy::group::smart::state::SmartStateData> {
         let g = self.0.read().await;
         g.get_smart_stats(group_name)
     }
 
     /// Get smart proxy group policy priority
-    pub async fn get_smart_policy_priority(&self, group_name: &str) -> Option<String> {
+    pub async fn get_smart_policy_priority(
+        &self,
+        group_name: &str,
+    ) -> Option<String> {
         let g = self.0.read().await;
         g.get_smart_policy_priority(group_name)
     }
@@ -198,11 +208,18 @@ impl CacheFile {
         self.db.host_to_ip.remove(host);
     }
 
-    pub fn set_smart_stats(&mut self, group_name: &str, stats: crate::proxy::group::smart::state::SmartStateData) {
+    pub fn set_smart_stats(
+        &mut self,
+        group_name: &str,
+        stats: crate::proxy::group::smart::state::SmartStateData,
+    ) {
         self.db.smart_stats.insert(group_name.to_string(), stats);
     }
 
-    pub fn get_smart_stats(&self, group_name: &str) -> Option<crate::proxy::group::smart::state::SmartStateData> {
+    pub fn get_smart_stats(
+        &self,
+        group_name: &str,
+    ) -> Option<crate::proxy::group::smart::state::SmartStateData> {
         self.db.smart_stats.get(group_name).cloned()
     }
 

--- a/clash_lib/src/app/profile/mod.rs
+++ b/clash_lib/src/app/profile/mod.rs
@@ -5,9 +5,16 @@ use tracing::{error, trace, warn};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct Db {
+    #[serde(default)]
     selected: HashMap<String, String>,
+    #[serde(default)]
     ip_to_host: HashMap<String, String>,
+    #[serde(default)]
     host_to_ip: HashMap<String, String>,
+    #[serde(default)]
+    smart_stats: HashMap<String, crate::proxy::group::smart::state::SmartStateData>,
+    #[serde(default)]
+    smart_policy_priority: HashMap<String, String>,
 }
 
 #[derive(Clone)]
@@ -96,6 +103,24 @@ impl ThreadSafeCacheFile {
     pub async fn delete_fake_ip_pair(&self, ip: &str, host: &str) {
         self.0.write().await.delete_fake_ip_pair(ip, host);
     }
+
+    /// Store smart proxy group statistics
+    pub async fn set_smart_stats(&self, group_name: &str, stats: crate::proxy::group::smart::state::SmartStateData) {
+        let mut g = self.0.write().await;
+        g.set_smart_stats(group_name, stats);
+    }
+
+    /// Get smart proxy group statistics
+    pub async fn get_smart_stats(&self, group_name: &str) -> Option<crate::proxy::group::smart::state::SmartStateData> {
+        let g = self.0.read().await;
+        g.get_smart_stats(group_name)
+    }
+
+    /// Get smart proxy group policy priority
+    pub async fn get_smart_policy_priority(&self, group_name: &str) -> Option<String> {
+        let g = self.0.read().await;
+        g.get_smart_policy_priority(group_name)
+    }
 }
 
 struct CacheFile {
@@ -118,6 +143,8 @@ impl CacheFile {
                         selected: HashMap::new(),
                         ip_to_host: HashMap::new(),
                         host_to_ip: HashMap::new(),
+                        smart_stats: HashMap::new(),
+                        smart_policy_priority: HashMap::new(),
                     }
                 }
             },
@@ -127,6 +154,8 @@ impl CacheFile {
                     selected: HashMap::new(),
                     ip_to_host: HashMap::new(),
                     host_to_ip: HashMap::new(),
+                    smart_stats: HashMap::new(),
+                    smart_policy_priority: HashMap::new(),
                 }
             }
         };
@@ -167,5 +196,21 @@ impl CacheFile {
     pub fn delete_fake_ip_pair(&mut self, ip: &str, host: &str) {
         self.db.ip_to_host.remove(ip);
         self.db.host_to_ip.remove(host);
+    }
+
+    pub fn set_smart_stats(&mut self, group_name: &str, stats: crate::proxy::group::smart::state::SmartStateData) {
+        self.db.smart_stats.insert(group_name.to_string(), stats);
+    }
+
+    pub fn get_smart_stats(&self, group_name: &str) -> Option<crate::proxy::group::smart::state::SmartStateData> {
+        self.db.smart_stats.get(group_name).cloned()
+    }
+
+    // pub fn set_smart_policy_priority(&mut self, group_name: &str, priority: String) {
+    //     self.db.smart_policy_priority.insert(group_name.to_string(), priority);
+    // }
+
+    pub fn get_smart_policy_priority(&self, group_name: &str) -> Option<String> {
+        self.db.smart_policy_priority.get(group_name).cloned()
     }
 }

--- a/clash_lib/src/config/def.rs
+++ b/clash_lib/src/config/def.rs
@@ -544,7 +544,11 @@ pub struct Profile {
     /// Store the `select` results in $CWD/cache.db
     pub store_selected: bool,
     /// persistence fakeip
+    #[serde(rename = "store-fake-ip")]
     pub store_fake_ip: bool,
+    /// Store smart proxy group statistics and preferences
+    #[serde(rename = "store-smart-stats")]
+    pub store_smart_stats: bool,
 }
 
 impl Default for Profile {
@@ -552,6 +556,7 @@ impl Default for Profile {
         Self {
             store_selected: true,
             store_fake_ip: false,
+            store_smart_stats: true,
         }
     }
 }

--- a/clash_lib/src/config/internal/config.rs
+++ b/clash_lib/src/config/internal/config.rs
@@ -76,6 +76,7 @@ pub struct General {
 
 pub struct Profile {
     pub store_selected: bool,
+    pub store_smart_stats: bool,
     // this is read to dns config directly
     // store_fake_ip: bool,
 }

--- a/clash_lib/src/config/internal/convert/mod.rs
+++ b/clash_lib/src/config/internal/convert/mod.rs
@@ -56,6 +56,7 @@ pub(super) fn convert(mut c: def::Config) -> Result<config::Config, crate::Error
         tun: tun::convert(c.tun.take())?,
         profile: Profile {
             store_selected: c.profile.store_selected,
+            store_smart_stats: c.profile.store_smart_stats,
         },
         rules: c
             .rule

--- a/clash_lib/src/config/internal/proxy.rs
+++ b/clash_lib/src/config/internal/proxy.rs
@@ -493,31 +493,25 @@ pub struct OutboundGroupSmart {
     pub name: String,
 
     pub proxies: Option<Vec<String>>,
+    pub udp: Option<bool>,
     #[serde(rename = "use")]
     pub use_provider: Option<Vec<String>>,
 
     pub lazy: Option<bool>,
     pub icon: Option<String>,
     
-    /// Custom weight expressions for proxy priority tuning
-    /// Format: "ProxyNamePattern:weight;AnotherPattern:weight"
-    /// Example: "Premium:0.9;SG:1.3"
-    #[serde(rename = "policy-priority")]
-    pub policy_priority: Option<String>,
-    
     /// Maximum retries for failed connections (default: 3)
+    #[serde(rename = "max-retries")]
     pub max_retries: Option<u32>,
-    
-    /// Intelligent testing optimization mode
-    /// When true, only subset of proxies are tested based on usage patterns
-    pub smart_testing: Option<bool>,
     
     /// Site stickiness factor (0.0-1.0, default: 0.8)
     /// Higher values make the same site more likely to use the same proxy
+    #[serde(rename = "site-stickiness")]
     pub site_stickiness: Option<f64>,
     
     /// Bandwidth consideration weight (default: 0.0 - disabled)
     /// When > 0, bandwidth metrics are included in selection algorithm
+    #[serde(rename = "bandwidth-weight")]
     pub bandwidth_weight: Option<f64>,
 }
 

--- a/clash_lib/src/config/internal/proxy.rs
+++ b/clash_lib/src/config/internal/proxy.rs
@@ -379,6 +379,8 @@ pub enum OutboundGroupProtocol {
     Fallback(OutboundGroupFallback),
     #[serde(rename = "load-balance")]
     LoadBalance(OutboundGroupLoadBalance),
+    #[serde(rename = "smart")]
+    Smart(OutboundGroupSmart),
     #[serde(rename = "select")]
     Select(OutboundGroupSelect),
 }
@@ -390,6 +392,7 @@ impl OutboundGroupProtocol {
             OutboundGroupProtocol::UrlTest(g) => &g.name,
             OutboundGroupProtocol::Fallback(g) => &g.name,
             OutboundGroupProtocol::LoadBalance(g) => &g.name,
+            OutboundGroupProtocol::Smart(g) => &g.name,
             OutboundGroupProtocol::Select(g) => &g.name,
         }
     }
@@ -400,6 +403,7 @@ impl OutboundGroupProtocol {
             OutboundGroupProtocol::UrlTest(g) => g.proxies.as_ref(),
             OutboundGroupProtocol::Fallback(g) => g.proxies.as_ref(),
             OutboundGroupProtocol::LoadBalance(g) => g.proxies.as_ref(),
+            OutboundGroupProtocol::Smart(g) => g.proxies.as_ref(),
             OutboundGroupProtocol::Select(g) => g.proxies.as_ref(),
         }
     }
@@ -413,6 +417,7 @@ impl Display for OutboundGroupProtocol {
             OutboundGroupProtocol::Fallback(g) => write!(f, "{}", g.name),
             OutboundGroupProtocol::LoadBalance(g) => write!(f, "{}", g.name),
             OutboundGroupProtocol::Select(g) => write!(f, "{}", g.name),
+            OutboundGroupProtocol::Smart(g) => write!(f, "{}", g.name),
         }
     }
 }
@@ -481,6 +486,21 @@ pub enum LoadBalanceStrategy {
     RoundRobin,
     #[serde(rename = "sticky-session")]
     StickySession,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
+pub struct OutboundGroupSmart {
+    pub name: String,
+
+    pub proxies: Option<Vec<String>>,
+    #[serde(rename = "use")]
+    pub use_provider: Option<Vec<String>>,
+
+    pub url: String,
+    #[serde(deserialize_with = "utils::deserialize_u64")]
+    pub interval: u64,
+    pub lazy: Option<bool>,
+    pub icon: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]

--- a/clash_lib/src/config/internal/proxy.rs
+++ b/clash_lib/src/config/internal/proxy.rs
@@ -498,6 +498,27 @@ pub struct OutboundGroupSmart {
 
     pub lazy: Option<bool>,
     pub icon: Option<String>,
+    
+    /// Custom weight expressions for proxy priority tuning
+    /// Format: "ProxyNamePattern:weight;AnotherPattern:weight"
+    /// Example: "Premium:0.9;SG:1.3"
+    #[serde(rename = "policy-priority")]
+    pub policy_priority: Option<String>,
+    
+    /// Maximum retries for failed connections (default: 3)
+    pub max_retries: Option<u32>,
+    
+    /// Intelligent testing optimization mode
+    /// When true, only subset of proxies are tested based on usage patterns
+    pub smart_testing: Option<bool>,
+    
+    /// Site stickiness factor (0.0-1.0, default: 0.8)
+    /// Higher values make the same site more likely to use the same proxy
+    pub site_stickiness: Option<f64>,
+    
+    /// Bandwidth consideration weight (default: 0.0 - disabled)
+    /// When > 0, bandwidth metrics are included in selection algorithm
+    pub bandwidth_weight: Option<f64>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]

--- a/clash_lib/src/config/internal/proxy.rs
+++ b/clash_lib/src/config/internal/proxy.rs
@@ -499,16 +499,16 @@ pub struct OutboundGroupSmart {
 
     pub lazy: Option<bool>,
     pub icon: Option<String>,
-    
+
     /// Maximum retries for failed connections (default: 3)
     #[serde(rename = "max-retries")]
     pub max_retries: Option<u32>,
-    
+
     /// Site stickiness factor (0.0-1.0, default: 0.8)
     /// Higher values make the same site more likely to use the same proxy
     #[serde(rename = "site-stickiness")]
     pub site_stickiness: Option<f64>,
-    
+
     /// Bandwidth consideration weight (default: 0.0 - disabled)
     /// When > 0, bandwidth metrics are included in selection algorithm
     #[serde(rename = "bandwidth-weight")]

--- a/clash_lib/src/config/internal/proxy.rs
+++ b/clash_lib/src/config/internal/proxy.rs
@@ -496,9 +496,6 @@ pub struct OutboundGroupSmart {
     #[serde(rename = "use")]
     pub use_provider: Option<Vec<String>>,
 
-    pub url: String,
-    #[serde(deserialize_with = "utils::deserialize_u64")]
-    pub interval: u64,
     pub lazy: Option<bool>,
     pub icon: Option<String>,
 }

--- a/clash_lib/src/proxy/group/mod.rs
+++ b/clash_lib/src/proxy/group/mod.rs
@@ -2,4 +2,5 @@ pub mod fallback;
 pub mod loadbalance;
 pub mod relay;
 pub mod selector;
+pub mod smart;
 pub mod urltest;

--- a/clash_lib/src/proxy/group/smart/config.rs
+++ b/clash_lib/src/proxy/group/smart/config.rs
@@ -14,8 +14,6 @@ pub struct HandlerOptions {
     pub name: String,
     /// Whether UDP is supported
     pub udp: bool,
-    /// Custom weight expressions for proxy priority tuning
-    pub policy_priority: Option<String>,
     /// Maximum retries for failed connections
     pub max_retries: Option<u32>,
     /// Site stickiness factor (0.0-1.0)

--- a/clash_lib/src/proxy/group/smart/config.rs
+++ b/clash_lib/src/proxy/group/smart/config.rs
@@ -47,8 +47,9 @@ pub struct WeightConfig {
 impl WeightConfig {
     /// Parse policy priority string into weight rules
     ///
-    /// The policy priority string format is: "pattern1:weight1;pattern2:weight2;..."
-    /// where patterns are regex expressions and weights are floating point numbers.
+    /// The policy priority string format is:
+    /// "pattern1:weight1;pattern2:weight2;..." where patterns are regex
+    /// expressions and weights are floating point numbers.
     ///
     /// # Arguments
     /// * `policy_priority` - The policy priority configuration string
@@ -63,7 +64,7 @@ impl WeightConfig {
     /// ```
     pub fn parse(policy_priority: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let mut rules = Vec::new();
-        
+
         for rule_str in policy_priority.split(';') {
             let parts: Vec<&str> = rule_str.splitn(2, ':').collect();
             if parts.len() == 2 {
@@ -72,10 +73,10 @@ impl WeightConfig {
                 rules.push(WeightRule { pattern, weight });
             }
         }
-        
+
         Ok(WeightConfig { rules })
     }
-    
+
     /// Get weight multiplier for a proxy name
     ///
     /// Iterates through all weight rules and returns the weight
@@ -104,7 +105,7 @@ mod tests {
     fn test_weight_config_parse() {
         let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2").unwrap();
         assert_eq!(config.rules.len(), 2);
-        
+
         assert_eq!(config.get_weight("US-Server-1"), 0.8);
         assert_eq!(config.get_weight("HK-Server-1"), 1.2);
         assert_eq!(config.get_weight("JP-Server-1"), 1.0);

--- a/clash_lib/src/proxy/group/smart/config.rs
+++ b/clash_lib/src/proxy/group/smart/config.rs
@@ -57,13 +57,6 @@ impl WeightConfig {
     /// # Returns
     /// * `Ok(WeightConfig)` - Successfully parsed configuration
     /// * `Err(Box<dyn std::error::Error>)` - Parse error
-    ///
-    /// # Example
-    /// ```
-    /// use crate::proxy::group::smart::config::WeightConfig;
-    ///
-    /// let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2").unwrap();
-    /// ```
     pub fn parse(policy_priority: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let mut rules = Vec::new();
 

--- a/clash_lib/src/proxy/group/smart/config.rs
+++ b/clash_lib/src/proxy/group/smart/config.rs
@@ -60,7 +60,9 @@ impl WeightConfig {
     ///
     /// # Example
     /// ```
-    /// let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2")?;
+    /// use super::WeightConfig;
+    ///
+    /// let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2").unwrap();
     /// ```
     pub fn parse(policy_priority: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let mut rules = Vec::new();

--- a/clash_lib/src/proxy/group/smart/config.rs
+++ b/clash_lib/src/proxy/group/smart/config.rs
@@ -1,0 +1,120 @@
+//! Configuration management for smart proxy group
+//!
+//! This module handles configuration options, weight rules, and
+//! policy priority parsing for the smart proxy group.
+
+use crate::proxy::HandlerCommonOptions;
+
+/// Configuration options for the smart proxy group handler
+#[derive(Default, Clone)]
+pub struct HandlerOptions {
+    /// Common proxy handler options
+    pub common_opts: HandlerCommonOptions,
+    /// Name of this proxy group
+    pub name: String,
+    /// Whether UDP is supported
+    pub udp: bool,
+    /// Custom weight expressions for proxy priority tuning
+    pub policy_priority: Option<String>,
+    /// Maximum retries for failed connections
+    pub max_retries: Option<u32>,
+    /// Site stickiness factor (0.0-1.0)
+    pub site_stickiness: Option<f64>,
+    /// Bandwidth consideration weight
+    pub bandwidth_weight: Option<f64>,
+}
+
+/// Custom weight rule for proxy selection
+///
+/// Weight rules allow fine-tuning of proxy selection by applying
+/// multipliers to specific proxies based on regex patterns.
+#[derive(Debug, Clone)]
+pub struct WeightRule {
+    /// Regex pattern to match proxy names
+    pub pattern: regex::Regex,
+    /// Weight multiplier (< 1.0 increases priority, > 1.0 decreases)
+    pub weight: f64,
+}
+
+/// Parsed weight configuration container
+///
+/// This structure holds all parsed weight rules and provides
+/// methods to calculate weights for specific proxy names.
+#[derive(Debug, Default)]
+pub struct WeightConfig {
+    /// List of weight rules to apply
+    pub rules: Vec<WeightRule>,
+}
+
+impl WeightConfig {
+    /// Parse policy priority string into weight rules
+    ///
+    /// The policy priority string format is: "pattern1:weight1;pattern2:weight2;..."
+    /// where patterns are regex expressions and weights are floating point numbers.
+    ///
+    /// # Arguments
+    /// * `policy_priority` - The policy priority configuration string
+    ///
+    /// # Returns
+    /// * `Ok(WeightConfig)` - Successfully parsed configuration
+    /// * `Err(Box<dyn std::error::Error>)` - Parse error
+    ///
+    /// # Example
+    /// ```
+    /// let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2")?;
+    /// ```
+    pub fn parse(policy_priority: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut rules = Vec::new();
+        
+        for rule_str in policy_priority.split(';') {
+            let parts: Vec<&str> = rule_str.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let pattern = regex::Regex::new(parts[0].trim())?;
+                let weight: f64 = parts[1].trim().parse()?;
+                rules.push(WeightRule { pattern, weight });
+            }
+        }
+        
+        Ok(WeightConfig { rules })
+    }
+    
+    /// Get weight multiplier for a proxy name
+    ///
+    /// Iterates through all weight rules and returns the weight
+    /// of the first matching rule, or 1.0 if no rules match.
+    ///
+    /// # Arguments
+    /// * `proxy_name` - The name of the proxy to get weight for
+    ///
+    /// # Returns
+    /// Weight multiplier for the proxy (default: 1.0)
+    pub fn get_weight(&self, proxy_name: &str) -> f64 {
+        for rule in &self.rules {
+            if rule.pattern.is_match(proxy_name) {
+                return rule.weight;
+            }
+        }
+        1.0 // Default weight
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_weight_config_parse() {
+        let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2").unwrap();
+        assert_eq!(config.rules.len(), 2);
+        
+        assert_eq!(config.get_weight("US-Server-1"), 0.8);
+        assert_eq!(config.get_weight("HK-Server-1"), 1.2);
+        assert_eq!(config.get_weight("JP-Server-1"), 1.0);
+    }
+
+    #[test]
+    fn test_weight_config_invalid() {
+        let result = WeightConfig::parse("invalid:pattern");
+        assert!(result.is_err());
+    }
+}

--- a/clash_lib/src/proxy/group/smart/config.rs
+++ b/clash_lib/src/proxy/group/smart/config.rs
@@ -60,7 +60,7 @@ impl WeightConfig {
     ///
     /// # Example
     /// ```
-    /// use super::WeightConfig;
+    /// use crate::proxy::group::smart::config::WeightConfig;
     ///
     /// let config = WeightConfig::parse("US.*:0.8;.*HK.*:1.2").unwrap();
     /// ```

--- a/clash_lib/src/proxy/group/smart/mod.rs
+++ b/clash_lib/src/proxy/group/smart/mod.rs
@@ -129,14 +129,8 @@ impl Handler {
             SmartState::new_with_imported_data(stored_data, weight_config)
         };
 
-        let smart_state = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => handle.block_on(load_smart_state()),
-            Err(_) => {
-                let rt = tokio::runtime::Runtime::new()
-                    .expect("Failed to create runtime");
-                rt.block_on(load_smart_state())
-            }
-        };
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+        let smart_state = rt.block_on(load_smart_state());
 
         let handler = Self {
             opts,

--- a/clash_lib/src/proxy/group/smart/mod.rs
+++ b/clash_lib/src/proxy/group/smart/mod.rs
@@ -652,7 +652,7 @@ impl Handler {
         if configured_max > 0 {
             configured_max
         } else {
-            calculated_max.max(2).min(6) // Reasonable bounds
+            calculated_max.clamp(2, 6) // Reasonable bounds
         }
     }
 

--- a/clash_lib/src/proxy/group/smart/mod.rs
+++ b/clash_lib/src/proxy/group/smart/mod.rs
@@ -1,0 +1,649 @@
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    time::Instant,
+};
+
+use erased_serde::Serialize;
+use tracing::debug;
+
+use crate::{
+    app::{
+        dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
+        dns::ThreadSafeDNSResolver,
+        remote_content_manager::{
+            ProxyManager, providers::proxy_provider::ThreadSafeProxyProvider,
+        },
+    },
+    proxy::{
+        AnyOutboundHandler, ConnectorType, DialWithConnector, HandlerCommonOptions,
+        OutboundHandler, OutboundType,
+        utils::{RemoteConnector, provider_helper::get_proxies_from_providers},
+    },
+    session::Session,
+};
+
+/// Error type for smart group failures
+#[derive(Debug)]
+enum SmartError {
+    NoProxy,
+    AllProxiesFailed(Vec<String>),
+}
+
+impl std::fmt::Display for SmartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoProxy => write!(f, "no available proxy in smart group"),
+            Self::AllProxiesFailed(names) => {
+                write!(f, "all proxies failed: {:?}", names)
+            }
+        }
+    }
+}
+
+impl SmartError {
+    fn log_error(&self) {
+        match self {
+            Self::NoProxy => debug!("no available proxy in smart group"),
+            Self::AllProxiesFailed(names) => {
+                debug!("all proxies failed: {:?}", names)
+            }
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct HandlerOptions {
+    /// Common proxy handler options
+    pub common_opts: HandlerCommonOptions,
+    /// Name of this proxy group
+    pub name: String,
+    /// Whether UDP is supported
+    pub udp: bool,
+}
+
+/// Tracks and manages the penalty score for a proxy
+/// Higher penalty values indicate worse performance
+struct ProxyPenalty {
+    /// Current penalty value
+    value: f64,
+    /// When the penalty was last updated
+    last_update: Instant,
+}
+
+impl ProxyPenalty {
+    /// Create a new ProxyPenalty with initial score 0
+    #[inline]
+    fn new() -> Self {
+        Self {
+            value: 0.0,
+            last_update: Instant::now(),
+        }
+    }
+
+    /// Increase penalty exponentially after a failure
+    /// Penalty grows more severely with consecutive failures
+    #[inline]
+    fn add_penalty(&mut self) {
+        self.value = (self.value + 1.0) * 2.0; // Exponential growth
+        self.last_update = Instant::now();
+    }
+
+    /// Decay penalty over time when not used
+    /// Uses exponential decay based on elapsed time
+    #[inline]
+    fn decay(&mut self) {
+        let elapsed = self.last_update.elapsed().as_secs_f64();
+        if self.value > 0.0 && elapsed > 0.0 {
+            // Half-life of ~10 seconds
+            self.value *= 0.5f64.powf(elapsed / 10.0);
+        }
+        self.last_update = Instant::now();
+    }
+
+    /// Reduce penalty significantly after a success
+    /// Quick recovery to allow retrying previously failed proxies
+    #[inline]
+    fn reward(&mut self) {
+        self.value *= 0.2; // 80% reduction
+        self.last_update = Instant::now();
+    }
+}
+
+/// Track statistics and performance metrics for a proxy per site
+struct SiteStats {
+    /// History of connection delays
+    delay_history: Vec<f64>,
+    /// Track connection success/failure history
+    success_history: Vec<bool>,
+    /// Last time this site was accessed
+    last_attempt: Instant,
+    /// Maximum history size to prevent unbounded growth
+    max_history: usize,
+}
+
+impl SiteStats {
+    fn new() -> Self {
+        Self {
+            delay_history: Vec::with_capacity(10),
+            success_history: Vec::with_capacity(10),
+            last_attempt: Instant::now(),
+            max_history: 10,
+        }
+    }
+
+    /// Calculate success rate for this site
+    fn success_rate(&self) -> f64 {
+        if self.success_history.is_empty() {
+            return 0.0;
+        }
+        self.success_history.iter().filter(|&&x| x).count() as f64
+            / self.success_history.len() as f64
+    }
+
+    /// Add a new connection result
+    fn add_result(&mut self, delay: f64, success: bool) {
+        // Update delay history
+        if success {
+            if self.delay_history.len() >= self.max_history {
+                self.delay_history.remove(0);
+            }
+            self.delay_history.push(delay);
+        }
+
+        // Update success history
+        if self.success_history.len() >= self.max_history {
+            self.success_history.remove(0);
+        }
+        self.success_history.push(success);
+
+        self.last_attempt = Instant::now();
+    }
+
+    /// Check if stats are stale
+    fn is_stale(&self) -> bool {
+        self.last_attempt.elapsed().as_secs() > 300 // 5 minutes
+    }
+
+    /// Calculate weighted delay score considering recent history and success
+    /// rate
+    fn get_delay_score(&self) -> f64 {
+        if self.delay_history.is_empty() {
+            return 9999.0;
+        }
+
+        let mut sum = 0.0;
+        let mut weight_sum = 0.0;
+        let now = Instant::now();
+
+        for delay in self.delay_history.iter() {
+            let age = now.duration_since(self.last_attempt).as_secs_f64();
+            // Faster decay for older samples and higher delays
+            let time_weight = (-0.1 * age).exp();
+            let delay_weight = (-0.001 * delay).exp(); // Higher delays get less weight
+            let weight = time_weight * delay_weight;
+
+            sum += delay * weight;
+            weight_sum += weight;
+        }
+
+        let avg_delay = if weight_sum > 0.0 {
+            sum / weight_sum
+        } else {
+            9999.0
+        };
+
+        // Adjust based on success rate
+        let success_rate = self.success_rate();
+        avg_delay * (2.0 - success_rate) // Higher success rate reduces effective delay
+    }
+}
+
+pub struct SmartState {
+    penalty: HashMap<String, ProxyPenalty>,
+    site_stats: HashMap<String, HashMap<String, SiteStats>>, /* Proxy name ->
+                                                              * Site -> Stats */
+}
+
+impl SmartState {
+    fn new() -> Self {
+        Self {
+            penalty: HashMap::new(),
+            site_stats: HashMap::new(),
+        }
+    }
+
+    fn cleanup_stale(&mut self) {
+        for stats in self.site_stats.values_mut() {
+            stats.retain(|_, site_stat| !site_stat.is_stale());
+        }
+    }
+}
+
+pub struct Handler {
+    opts: HandlerOptions,
+    providers: Vec<ThreadSafeProxyProvider>,
+    proxy_manager: ProxyManager,
+    smart_state: tokio::sync::Mutex<SmartState>,
+}
+
+impl std::fmt::Debug for Handler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Smart")
+            .field("name", &self.opts.name)
+            .finish()
+    }
+}
+
+impl Handler {
+    pub fn new(
+        opts: HandlerOptions,
+        providers: Vec<ThreadSafeProxyProvider>,
+        proxy_manager: ProxyManager,
+    ) -> Self {
+        Self {
+            opts,
+            providers,
+            proxy_manager,
+            smart_state: tokio::sync::Mutex::new(SmartState::new()),
+        }
+    }
+
+    async fn get_proxies(&self, touch: bool) -> Vec<AnyOutboundHandler> {
+        get_proxies_from_providers(&self.providers, touch).await
+    }
+
+    /// Smart selection considering all available metrics
+    async fn pick_smart(&self, sess: &Session) -> Option<AnyOutboundHandler> {
+        let proxies = self.get_proxies(false).await;
+        if proxies.is_empty() {
+            debug!("{} no proxies available", self.name());
+            return None;
+        }
+
+        let site = sess.destination.host();
+        let dest_ip = sess.destination.ip().map(|ip| ip.to_string());
+
+        debug!(
+            "{} selecting proxy for site: {}, ip: {:?}",
+            self.name(),
+            site,
+            dest_ip
+        );
+
+        let mut best: Option<(f64, AnyOutboundHandler, String)> = None;
+        let mut state_guard = self.smart_state.lock().await;
+        state_guard.cleanup_stale();
+
+        for proxy in proxies {
+            let name = proxy.name().to_string();
+
+            // Get basic metrics
+            let delay = self.proxy_manager.get_delay(&name).await.unwrap_or(9999.0);
+            let packet_loss = self
+                .proxy_manager
+                .get_packet_loss(&name)
+                .await
+                .unwrap_or(1.0);
+            let rtt = self.proxy_manager.get_rtt(&name).await.unwrap_or(9999.0);
+            let alive = self.proxy_manager.alive(&name).await;
+
+            debug!(
+                "{} proxy {} metrics - delay: {:.1}ms, loss: {:.1}%, rtt: {:.1}ms, \
+                 alive: {}",
+                self.name(),
+                name,
+                delay,
+                packet_loss * 100.0,
+                rtt,
+                alive
+            );
+
+            // Get site-specific tuning
+            let site_tuning = self.proxy_manager.get_site_tuning(&site).await;
+            let delay_weight = site_tuning.delay_weight.unwrap_or(1.0);
+            let packet_loss_weight =
+                site_tuning.packet_loss_weight.unwrap_or(1000.0);
+            let rtt_weight = site_tuning.rtt_weight.unwrap_or(1.0);
+            let alive_penalty = site_tuning.alive_penalty.unwrap_or(5000.0);
+
+            // Get historical performance
+            let site_stats = state_guard
+                .site_stats
+                .get(&name)
+                .and_then(|m| m.get(&site))
+                .map(|s| (s.get_delay_score(), s.success_rate()));
+
+            let ip_stats = dest_ip.as_ref().and_then(|ip| {
+                state_guard
+                    .site_stats
+                    .get(&name)
+                    .and_then(|m| m.get(ip))
+                    .map(|s| (s.get_delay_score(), s.success_rate()))
+            });
+
+            if let Some((sd, sr)) = site_stats {
+                debug!(
+                    "{} proxy {} site history - avg delay: {:.1}ms, success rate: \
+                     {:.1}%",
+                    self.name(),
+                    name,
+                    sd,
+                    sr * 100.0
+                );
+            }
+
+            if let Some((id, ir)) = ip_stats {
+                debug!(
+                    "{} proxy {} IP history - avg delay: {:.1}ms, success rate: \
+                     {:.1}%",
+                    self.name(),
+                    name,
+                    id,
+                    ir * 100.0
+                );
+            }
+
+            // Apply penalties
+            let penalty = state_guard
+                .penalty
+                .entry(name.clone())
+                .or_insert_with(ProxyPenalty::new);
+            penalty.decay();
+            let penalty_score = penalty.value;
+
+            debug!(
+                "{} proxy {} current penalty score: {:.1}",
+                self.name(),
+                name,
+                penalty_score
+            );
+
+            // Calculate composite score
+            let site_delay = site_stats.map(|(d, r)| d * (2.0 - r)).unwrap_or(delay);
+            let ip_delay = ip_stats.map(|(d, r)| d * (2.0 - r)).unwrap_or(delay);
+
+            let weight = ((site_delay + ip_delay) / 2.0) * delay_weight
+                + packet_loss * packet_loss_weight
+                + rtt * rtt_weight
+                + if alive { 0.0 } else { alive_penalty }
+                + penalty_score;
+
+            debug!(
+                "{} proxy {} final weight score: {:.1}",
+                self.name(),
+                name,
+                weight
+            );
+
+            if best.is_none() || weight < best.as_ref().unwrap().0 {
+                debug!(
+                    "{} new best proxy: {} (score: {:.1})",
+                    self.name(),
+                    name,
+                    weight
+                );
+                best = Some((weight, proxy.clone(), name));
+            }
+        }
+
+        best.map(|(_, p, name)| {
+            debug!("{} selected proxy: {}", self.name(), name);
+            p
+        })
+    }
+
+    /// Adaptive retry with exponential backoff and state updates
+    async fn adaptive_retry(
+        &self,
+        sess: &Session,
+        resolver: &ThreadSafeDNSResolver,
+    ) -> io::Result<BoxedChainedStream> {
+        let site = sess.destination.host();
+        let dest_ip = sess.destination.ip().map(|ip| ip.to_string());
+        let mut tried = HashSet::new();
+        let mut retry_delay = 100; // Initial retry delay in ms
+
+        // Dynamic retry config based on site history
+        let mut state_guard = self.smart_state.lock().await;
+        state_guard.cleanup_stale();
+        let site_stats = state_guard
+            .site_stats
+            .values()
+            .filter_map(|stats| stats.get(&site))
+            .collect::<Vec<_>>();
+
+        // Calculate max retries based on site success rate
+        let avg_success_rate = if !site_stats.is_empty() {
+            site_stats.iter().map(|s| s.success_rate()).sum::<f64>()
+                / site_stats.len() as f64
+        } else {
+            0.5 // Default to middle ground
+        };
+
+        drop(state_guard); // Release the lock early
+
+        // More retries for historically problematic sites
+        let max_retries = (3.0 * (2.0 - avg_success_rate)).round() as u32;
+        let mut retries = 0;
+
+        debug!(
+            "{} starting adaptive retry for {}, max_retries: {}",
+            self.name(),
+            site,
+            max_retries
+        );
+
+        while retries < max_retries {
+            match self.pick_smart(sess).await {
+                Some(proxy) => {
+                    let name = proxy.name().to_string();
+                    if tried.contains(&name) {
+                        continue;
+                    }
+                    tried.insert(name.clone());
+
+                    let start = Instant::now();
+                    match proxy.connect_stream(sess, resolver.clone()).await {
+                        Ok(stream) => {
+                            let delay = start.elapsed().as_secs_f64() * 1000.0;
+                            let mut state = self.smart_state.lock().await;
+
+                            // Update success metrics
+                            if let Some(penalty) = state.penalty.get_mut(&name) {
+                                penalty.reward();
+                            }
+
+                            // Update site stats
+                            let site_stats =
+                                state.site_stats.entry(name.clone()).or_default();
+                            let stats = site_stats
+                                .entry(site.to_string())
+                                .or_insert_with(SiteStats::new);
+                            stats.add_result(delay, true);
+
+                            // Update IP stats
+                            if let Some(ip) = &dest_ip {
+                                let ip_stats = site_stats
+                                    .entry(ip.to_string())
+                                    .or_insert_with(SiteStats::new);
+                                ip_stats.add_result(delay, true);
+                            }
+
+                            debug!(
+                                "{} successfully connected to {} via {}, delay: \
+                                 {:.2}ms, attempts: {}",
+                                self.name(),
+                                site,
+                                name,
+                                delay,
+                                retries + 1
+                            );
+                            return Ok(stream);
+                        }
+                        Err(e) => {
+                            debug!(
+                                "{} proxy {} connection failed: {}",
+                                self.name(),
+                                name,
+                                e
+                            );
+                            let mut state = self.smart_state.lock().await;
+
+                            // Update failure metrics
+                            if let Some(penalty) = state.penalty.get_mut(&name) {
+                                penalty.add_penalty();
+                            }
+
+                            let site_stats =
+                                state.site_stats.entry(name.clone()).or_default();
+
+                            // Update site stats for failure
+                            let stats = site_stats
+                                .entry(site.to_string())
+                                .or_insert_with(SiteStats::new);
+                            stats.add_result(9999.0, false);
+
+                            // Update IP stats for failure
+                            if let Some(ip) = &dest_ip {
+                                let ip_stats = site_stats
+                                    .entry(ip.to_string())
+                                    .or_insert_with(SiteStats::new);
+                                ip_stats.add_result(9999.0, false);
+                            }
+
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                retry_delay,
+                            ))
+                            .await;
+                            retry_delay *= 2; // Exponential backoff
+                            retries += 1;
+                            debug!(
+                                "{} retry {} of {} for {}, next delay: {}ms",
+                                self.name(),
+                                retries,
+                                max_retries,
+                                site,
+                                retry_delay
+                            );
+                            continue;
+                        }
+                    }
+                }
+                None => {
+                    let error = SmartError::NoProxy;
+                    error.log_error();
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "no available proxy in smart group",
+                    ));
+                }
+            }
+        }
+
+        let error = SmartError::AllProxiesFailed(tried.into_iter().collect());
+        error.log_error();
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "smart proxy selection failed",
+        ))
+    }
+}
+
+impl DialWithConnector for Handler {}
+
+#[async_trait::async_trait]
+impl OutboundHandler for Handler {
+    fn name(&self) -> &str {
+        &self.opts.name
+    }
+
+    fn proto(&self) -> OutboundType {
+        OutboundType::Smart
+    }
+
+    async fn support_udp(&self) -> bool {
+        self.opts.udp
+    }
+
+    async fn connect_stream(
+        &self,
+        sess: &Session,
+        resolver: ThreadSafeDNSResolver,
+    ) -> io::Result<BoxedChainedStream> {
+        debug!("{} starting smart proxy selection", self.name());
+        match self.adaptive_retry(sess, &resolver).await {
+            Ok(stream) => {
+                debug!(
+                    "{} successfully connected using smart selection",
+                    self.name()
+                );
+                Ok(stream)
+            }
+            Err(e) => {
+                debug!(
+                    "{} failed to connect with all available proxies: {:?}",
+                    self.name(),
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+
+    async fn connect_datagram(
+        &self,
+        sess: &Session,
+        resolver: ThreadSafeDNSResolver,
+    ) -> io::Result<BoxedChainedDatagram> {
+        // For UDP we just use the best proxy without retries
+        if let Some(proxy) = self.pick_smart(sess).await {
+            debug!("{} use proxy {} (smart)", self.name(), proxy.name());
+            proxy.connect_datagram(sess, resolver).await
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "no available proxy in smart group",
+            ))
+        }
+    }
+
+    async fn support_connector(&self) -> ConnectorType {
+        ConnectorType::Tcp
+    }
+
+    async fn connect_stream_with_connector(
+        &self,
+        sess: &Session,
+        resolver: ThreadSafeDNSResolver,
+        connector: &dyn RemoteConnector,
+    ) -> io::Result<BoxedChainedStream> {
+        if let Some(proxy) = self.pick_smart(sess).await {
+            debug!("{} use proxy {} (smart)", self.name(), proxy.name());
+            proxy
+                .connect_stream_with_connector(sess, resolver, connector)
+                .await
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "no available proxy in smart group",
+            ))
+        }
+    }
+
+    async fn as_map(&self) -> HashMap<String, Box<dyn Serialize + Send>> {
+        let all = get_proxies_from_providers(&self.providers, false).await;
+        let mut m = HashMap::new();
+        m.insert("type".to_string(), Box::new(self.proto()) as _);
+        m.insert(
+            "all".to_string(),
+            Box::new(all.iter().map(|x| x.name().to_owned()).collect::<Vec<_>>())
+                as _,
+        );
+        m
+    }
+
+    fn icon(&self) -> Option<String> {
+        self.opts.common_opts.icon.clone()
+    }
+}

--- a/clash_lib/src/proxy/group/smart/penalty.rs
+++ b/clash_lib/src/proxy/group/smart/penalty.rs
@@ -1,0 +1,153 @@
+//! Penalty mechanism for smart proxy group
+//!
+//! This module implements a penalty system that tracks proxy performance
+//! and applies exponential penalties for failures with time-based decay.
+
+use std::time::Instant;
+
+/// Tracks and manages the penalty score for a proxy
+///
+/// The penalty system uses exponential growth for failures and exponential
+/// decay over time to allow recovery. Higher penalty values indicate worse
+/// performance and lower selection priority.
+pub struct ProxyPenalty {
+    /// Current penalty value (higher = worse performance)
+    value: f64,
+    /// When the penalty was last updated
+    last_update: Instant,
+}
+
+impl ProxyPenalty {
+    /// Create a new ProxyPenalty with initial score 0
+    ///
+    /// # Returns
+    /// A new penalty tracker with zero penalty
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            value: 0.0,
+            last_update: Instant::now(),
+        }
+    }
+
+    /// Get the current penalty value
+    ///
+    /// # Returns
+    /// Current penalty score
+    #[inline]
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    /// Increase penalty exponentially after a failure
+    ///
+    /// Penalty grows more severely with consecutive failures to quickly
+    /// identify and deprioritize problematic proxies. Uses exponential
+    /// growth: penalty = (penalty + 1) * 2
+    #[inline]
+    pub fn add_penalty(&mut self) {
+        self.value = (self.value + 1.0) * 2.0; // Exponential growth
+        self.last_update = Instant::now();
+    }
+
+    /// Decay penalty over time when not used
+    ///
+    /// Uses exponential decay based on elapsed time to allow proxies
+    /// to recover from temporary issues. The half-life is approximately
+    /// 10 seconds, meaning penalty is halved every 10 seconds.
+    #[inline]
+    pub fn decay(&mut self) {
+        let elapsed = self.last_update.elapsed().as_secs_f64();
+        if self.value > 0.0 && elapsed > 0.0 {
+            // Half-life of ~10 seconds
+            self.value *= 0.5f64.powf(elapsed / 10.0);
+        }
+        self.last_update = Instant::now();
+    }
+
+    /// Reduce penalty significantly after a success
+    ///
+    /// Quick recovery mechanism to allow retrying previously failed
+    /// proxies. Reduces penalty by 80% to rapidly restore confidence
+    /// in recovering proxies.
+    #[inline]
+    pub fn reward(&mut self) {
+        self.value *= 0.2; // 80% reduction
+        self.last_update = Instant::now();
+    }
+
+    /// Check if penalty has decayed to negligible levels
+    ///
+    /// # Returns
+    /// `true` if penalty is effectively zero (< 0.01)
+    pub fn is_negligible(&self) -> bool {
+        self.value < 0.01
+    }
+
+    /// Get the age of the last penalty update
+    ///
+    /// # Returns
+    /// Duration since last penalty update
+    pub fn age(&self) -> std::time::Duration {
+        self.last_update.elapsed()
+    }
+}
+
+impl Default for ProxyPenalty {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_penalty_creation() {
+        let penalty = ProxyPenalty::new();
+        assert_eq!(penalty.value(), 0.0);
+        assert!(penalty.is_negligible());
+    }
+
+    #[test]
+    fn test_penalty_growth() {
+        let mut penalty = ProxyPenalty::new();
+        
+        penalty.add_penalty();
+        assert_eq!(penalty.value(), 2.0); // (0 + 1) * 2
+        
+        penalty.add_penalty();
+        assert_eq!(penalty.value(), 6.0); // (2 + 1) * 2
+        
+        penalty.add_penalty();
+        assert_eq!(penalty.value(), 14.0); // (6 + 1) * 2
+    }
+
+    #[test]
+    fn test_penalty_reward() {
+        let mut penalty = ProxyPenalty::new();
+        penalty.add_penalty(); // value = 2.0
+        penalty.add_penalty(); // value = 6.0
+        
+        penalty.reward();
+        assert_eq!(penalty.value(), 1.2); // 6.0 * 0.2
+        
+        penalty.reward();
+        assert_eq!(penalty.value(), 0.24); // 1.2 * 0.2
+    }
+
+    #[test]
+    fn test_penalty_decay() {
+        let mut penalty = ProxyPenalty::new();
+        penalty.add_penalty(); // value = 2.0
+        
+        // Simulate time passage by manually setting last_update
+        penalty.last_update = Instant::now() - Duration::from_secs(10);
+        penalty.decay();
+        
+        // After 10 seconds (one half-life), penalty should be ~1.0
+        assert!((penalty.value() - 1.0).abs() < 0.1);
+    }
+}

--- a/clash_lib/src/proxy/group/smart/penalty.rs
+++ b/clash_lib/src/proxy/group/smart/penalty.rs
@@ -149,15 +149,15 @@ mod tests {
 
     #[test]
     fn test_penalty_reward() {
-        let mut penalty = ProxyPenalty::new();
+        let mut penalty: ProxyPenalty = ProxyPenalty::new();
         penalty.add_penalty(); // value = 2.0
         penalty.add_penalty(); // value = 6.0
         
         penalty.reward();
-        assert_eq!(penalty.value(), 1.2); // 6.0 * 0.2
+        assert!((penalty.value() - 1.2).abs() < 1e-6); // 6.0 * 0.2
         
         penalty.reward();
-        assert_eq!(penalty.value(), 0.24); // 1.2 * 0.2
+        assert!((penalty.value() - 0.24).abs() < 1e-6); // 1.2 * 0.2
     }
 
     #[test]

--- a/clash_lib/src/proxy/group/smart/preference.rs
+++ b/clash_lib/src/proxy/group/smart/preference.rs
@@ -1,0 +1,44 @@
+//! Site preference tracking for smart proxy group
+//!
+//! This module implements simple site stickiness functionality.
+
+use std::time::Instant;
+
+/// Simple site preference tracking for sticky behavior
+#[derive(Debug, Clone)]
+pub struct SitePreference {
+    /// Preferred proxy name for this site
+    pub preferred_proxy: String,
+    /// Last used time
+    pub last_used: Instant,
+    /// Success rate with this proxy (0.0 - 1.0)
+    pub success_rate: f64,
+    /// Total connection attempts
+    pub total_attempts: u32,
+}
+
+impl SitePreference {
+    /// Create a new site preference for a proxy
+    pub fn new(proxy_name: String) -> Self {
+        Self {
+            preferred_proxy: proxy_name,
+            last_used: Instant::now(),
+            success_rate: 1.0,
+            total_attempts: 1,
+        }
+    }
+
+    /// Update preference with a new connection result
+    pub fn update_success(&mut self, success: bool) {
+        self.total_attempts += 1;
+        let success_count = (self.success_rate * (self.total_attempts - 1) as f64) + if success { 1.0 } else { 0.0 };
+        self.success_rate = success_count / self.total_attempts as f64;
+        self.last_used = Instant::now();
+    }
+
+    /// Check if preference is still valid
+    pub fn is_valid(&self, min_success_rate: f64, max_age_secs: u64) -> bool {
+        self.success_rate >= min_success_rate
+            && self.last_used.elapsed().as_secs() < max_age_secs
+    }
+}

--- a/clash_lib/src/proxy/group/smart/state.rs
+++ b/clash_lib/src/proxy/group/smart/state.rs
@@ -351,13 +351,9 @@ mod tests {
     #[test]
     fn test_smart_state_creation() {
         let state = SmartState::new();
-        // Original test called get_statistics, which was removed.
-        // We now assert that the internal HashMaps are empty upon creation.
         assert!(state.penalty.is_empty());
         assert!(state.site_stats.is_empty());
         assert!(state.site_preferences.is_empty());
-        // traffic_collector is initialized internally and is not directly checked here,
-        // but its successful initialization is part of SmartState::new().
     }
 
     #[test]

--- a/clash_lib/src/proxy/group/smart/state.rs
+++ b/clash_lib/src/proxy/group/smart/state.rs
@@ -1,0 +1,375 @@
+//! State management for smart proxy group
+//!
+//! This module provides centralized state management for the smart proxy
+//! group, coordinating between different components like penalties,
+//! statistics, and preferences.
+
+use std::{
+    collections::HashMap,
+    time::Instant,
+};
+use tracing::debug;
+
+use crate::{
+    app::remote_content_manager::TrafficStats,
+    session::Session,
+};
+
+use super::{
+    config::WeightConfig,
+    penalty::ProxyPenalty,
+    preference::SitePreference,
+    stats::{SiteStats, TrafficStatsCollector},
+};
+
+/// Centralized state manager for smart proxy group
+///
+/// Coordinates all stateful components of the smart proxy group including
+/// penalties, site statistics, traffic monitoring, and preferences.
+pub struct SmartState {
+    /// Penalty tracking per proxy
+    penalty: HashMap<String, ProxyPenalty>,
+    /// Site-specific statistics per proxy
+    pub site_stats: HashMap<String, HashMap<String, SiteStats>>, // Proxy name -> Site -> Stats
+    /// Real-time traffic statistics collector
+    traffic_collector: TrafficStatsCollector,
+    /// Site preferences for sticky behavior
+    site_preferences: HashMap<String, SitePreference>, // Site -> Preference
+    /// Parsed weight configuration for custom proxy priorities
+    weight_config: WeightConfig,
+}
+
+impl SmartState {
+    /// Create a new SmartState with default configuration
+    ///
+    /// # Returns
+    /// New SmartState instance with default settings
+    pub fn new() -> Self {
+        Self {
+            penalty: HashMap::new(),
+            site_stats: HashMap::new(),
+            traffic_collector: TrafficStatsCollector::new(),
+            site_preferences: HashMap::new(),
+            weight_config: WeightConfig::default(),
+        }
+    }
+    
+    /// Create a new SmartState with weight configuration
+    ///
+    /// # Arguments
+    /// * `policy_priority` - Optional policy priority configuration string
+    ///
+    /// # Returns
+    /// New SmartState instance with specified weight configuration
+    pub fn new_with_weight_config(policy_priority: Option<&str>) -> Self {
+        let weight_config = if let Some(priority) = policy_priority {
+            WeightConfig::parse(priority).unwrap_or_default()
+        } else {
+            WeightConfig::default()
+        };
+        
+        Self {
+            penalty: HashMap::new(),
+            site_stats: HashMap::new(),
+            traffic_collector: TrafficStatsCollector::new(),
+            site_preferences: HashMap::new(),
+            weight_config,
+        }
+    }
+
+    /// Get or create penalty tracker for a proxy
+    ///
+    /// # Arguments
+    /// * `proxy_name` - Name of the proxy
+    ///
+    /// # Returns
+    /// Mutable reference to the proxy's penalty tracker
+    pub fn get_penalty_mut(&mut self, proxy_name: &str) -> &mut ProxyPenalty {
+        self.penalty.entry(proxy_name.to_string()).or_default()
+    }
+
+    /// Get penalty tracker for a proxy (read-only)
+    ///
+    /// # Arguments
+    /// * `proxy_name` - Name of the proxy
+    ///
+    /// # Returns
+    /// Reference to the proxy's penalty tracker, or None if not found
+    pub fn get_penalty(&self, proxy_name: &str) -> Option<&ProxyPenalty> {
+        self.penalty.get(proxy_name)
+    }
+
+    /// Get weight multiplier for a proxy from configuration
+    ///
+    /// # Arguments
+    /// * `proxy_name` - Name of the proxy
+    ///
+    /// # Returns
+    /// Weight multiplier (default: 1.0)
+    pub fn get_weight(&self, proxy_name: &str) -> f64 {
+        self.weight_config.get_weight(proxy_name)
+    }
+
+    /// Get or create site statistics for a proxy-site combination
+    ///
+    /// # Arguments
+    /// * `proxy_name` - Name of the proxy
+    /// * `site` - Site identifier (hostname or IP)
+    ///
+    /// # Returns
+    /// Mutable reference to the site statistics
+    pub fn get_site_stats_mut(&mut self, proxy_name: &str, site: &str) -> &mut SiteStats {
+        self.site_stats
+            .entry(proxy_name.to_string())
+            .or_default()
+            .entry(site.to_string())
+            .or_default()
+    }
+
+    /// Get site statistics for a proxy-site combination (read-only)
+    ///
+    /// # Arguments
+    /// * `proxy_name` - Name of the proxy
+    /// * `site` - Site identifier (hostname or IP)
+    ///
+    /// # Returns
+    /// Reference to site statistics, or None if not found
+    pub fn get_site_stats(&self, proxy_name: &str, site: &str) -> Option<&SiteStats> {
+        self.site_stats
+            .get(proxy_name)
+            .and_then(|sites| sites.get(site))
+    }
+
+    /// Record a connection result for penalty and statistics tracking
+    ///
+    /// # Arguments
+    /// * `proxy_name` - Name of the proxy used
+    /// * `site` - Site that was accessed
+    /// * `dest_ip` - Optional destination IP address
+    /// * `delay` - Connection delay in milliseconds
+    /// * `success` - Whether the connection was successful
+    pub fn record_connection_result(
+        &mut self,
+        proxy_name: &str,
+        site: &str,
+        dest_ip: Option<&str>,
+        delay: f64,
+        success: bool,
+    ) {
+        // Update penalty
+        let penalty = self.get_penalty_mut(proxy_name);
+        if success {
+            penalty.reward();
+        } else {
+            penalty.add_penalty();
+        }
+
+        // Update site statistics
+        let site_stats = self.get_site_stats_mut(proxy_name, site);
+        site_stats.add_result(delay, success, None);
+
+        // Update IP statistics if available
+        if let Some(ip) = dest_ip {
+            let ip_stats = self.get_site_stats_mut(proxy_name, ip);
+            ip_stats.add_result(delay, success, None);
+        }
+
+    }
+
+    /// Get site preference for a site
+    ///
+    /// # Arguments
+    /// * `site` - Site identifier
+    ///
+    /// # Returns
+    /// Reference to site preference, or None if not found
+    pub fn get_site_preference(&self, site: &str) -> Option<&SitePreference> {
+        self.site_preferences.get(site)
+    }
+
+    /// Update site preference based on connection result
+    ///
+    /// # Arguments
+    /// * `site` - Site identifier
+    /// * `proxy_name` - Name of the proxy used
+    /// * `success` - Whether the connection was successful
+    /// * `site_stickiness` - Site stickiness configuration (0.0-1.0)
+    pub fn update_site_preference(&mut self, site: &str, proxy_name: &str, success: bool, site_stickiness: f64) {
+        if site_stickiness <= 0.0 {
+            return;
+        }
+
+        if let Some(preference) = self.site_preferences.get_mut(site) {
+            if preference.preferred_proxy == proxy_name {
+                preference.update_success(success);
+                if !success && preference.success_rate < 0.5 {
+                    debug!("Removing site preference for {} from {} (poor performance)", site, proxy_name);
+                    self.site_preferences.remove(site);
+                }
+            } else if success && preference.success_rate < 0.8 {
+                // Switch to this better performing proxy
+                debug!("Switching site preference for {} from {} to {} (better performance)",
+                       site, preference.preferred_proxy, proxy_name);
+                *preference = SitePreference::new(proxy_name.to_string());
+            }
+        } else if success {
+            self.site_preferences.insert(
+                site.to_string(),
+                SitePreference::new(proxy_name.to_string())
+            );
+        }
+    }
+
+    /// Generate session ID from session information
+    ///
+    /// # Arguments
+    /// * `sess` - Session information
+    ///
+    /// # Returns
+    /// Unique session identifier string
+    pub fn generate_session_id(sess: &Session) -> String {
+        format!("{}:{}->{}", sess.network, sess.source, sess.destination)
+    }
+
+    /// Start tracking traffic for a session
+    ///
+    /// # Arguments
+    /// * `sess` - Session to start tracking
+    pub fn start_traffic_tracking(&mut self, sess: &Session) {
+        let session_id = Self::generate_session_id(sess);
+        self.traffic_collector.start_session(&session_id);
+    }
+
+    /// Record traffic data for a session
+    ///
+    /// # Arguments
+    /// * `sess` - Session information
+    /// * `uploaded` - Bytes uploaded
+    /// * `downloaded` - Bytes downloaded
+    pub fn record_traffic(&mut self, sess: &Session, uploaded: u64, downloaded: u64) {
+        let session_id = Self::generate_session_id(sess);
+        self.traffic_collector.record_transfer(&session_id, uploaded, downloaded);
+    }
+
+    /// Record a request event for a session
+    ///
+    /// # Arguments
+    /// * `sess` - Session information
+    pub fn record_request(&mut self, sess: &Session) {
+        let session_id = Self::generate_session_id(sess);
+        self.traffic_collector.record_request(&session_id);
+    }
+
+    /// Get traffic statistics for a session
+    ///
+    /// # Arguments
+    /// * `sess` - Session information
+    ///
+    /// # Returns
+    /// Traffic statistics if available
+    pub fn get_traffic_stats(&self, sess: &Session) -> Option<TrafficStats> {
+        let session_id = Self::generate_session_id(sess);
+        self.traffic_collector.get_stats(&session_id)
+    }
+
+    /// Clean up stale data to prevent memory leaks
+    ///
+    /// Removes outdated statistics, preferences, and other data
+    /// that is no longer relevant or useful.
+    pub fn cleanup_stale(&mut self) {
+        // Clean up stale site statistics
+        for stats in self.site_stats.values_mut() {
+            stats.retain(|_, site_stat| !site_stat.is_stale());
+        }
+
+        // Clean up old traffic data
+        self.traffic_collector.cleanup_old_sessions();
+
+        // Clean up old site preferences (older than 1 hour with poor performance)
+        let cutoff = Instant::now().checked_sub(std::time::Duration::from_secs(3600));
+        if let Some(cutoff) = cutoff {
+            self.site_preferences.retain(|_, pref| {
+                pref.last_used > cutoff || pref.success_rate > 0.7
+            });
+        }
+
+        // Decay penalties for all proxies and clean up negligible or very old ones
+        self.penalty.retain(|_, penalty| {
+            penalty.decay();
+            // Keep penalty if it's significant and not too old (less than 1 hour)
+            !penalty.is_negligible() && penalty.age().as_secs() < 3600
+        });
+    }
+
+    /// Get comprehensive statistics for monitoring and debugging
+    ///
+    /// # Returns
+    /// (tracked_proxies, active_sites, active_sessions, avg_success_rate)
+    pub fn get_statistics(&self) -> (usize, usize, usize, f64) {
+        let tracked_proxies = self.penalty.len();
+        let active_sites = self.site_preferences.len();
+        let active_sessions = self.traffic_collector.active_session_count();
+        
+        // Calculate average success rate across all site preferences
+        let avg_success_rate = if !self.site_preferences.is_empty() {
+            self.site_preferences.values()
+                .map(|pref| pref.success_rate)
+                .sum::<f64>() / self.site_preferences.len() as f64
+        } else {
+            0.0
+        };
+
+        (tracked_proxies, active_sites, active_sessions, avg_success_rate)
+    }
+}
+
+impl Default for SmartState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_smart_state_creation() {
+        let state = SmartState::new();
+        let (proxies, sites, sessions, _) = state.get_statistics();
+        assert_eq!(proxies, 0);
+        assert_eq!(sites, 0);
+        assert_eq!(sessions, 0);
+    }
+
+    #[test]
+    fn test_penalty_tracking() {
+        let mut state = SmartState::new();
+        
+        // Record a failure
+        state.record_connection_result("proxy1", "example.com", None, 1000.0, false);
+        
+        let penalty = state.get_penalty("proxy1");
+        assert!(penalty.is_some());
+        assert!(penalty.unwrap().value() > 0.0);
+    }
+
+    #[test]
+    fn test_site_preference() {
+        let mut state = SmartState::new();
+        
+        // Record successful connection
+        state.update_site_preference("example.com", "proxy1", true, 0.8);
+        
+        let preference = state.get_site_preference("example.com");
+        assert!(preference.is_some());
+        assert_eq!(preference.unwrap().preferred_proxy, "proxy1");
+    }
+
+    #[test]
+    fn test_weight_config() {
+        let state = SmartState::new_with_weight_config(Some("proxy1:0.5"));
+        assert_eq!(state.get_weight("proxy1"), 0.5);
+        assert_eq!(state.get_weight("proxy2"), 1.0); // default
+    }
+}

--- a/clash_lib/src/proxy/group/smart/stats.rs
+++ b/clash_lib/src/proxy/group/smart/stats.rs
@@ -456,13 +456,14 @@ mod tests {
     fn test_site_stats_trend() {
         let mut stats = SiteStats::new();
 
-        // Add older failures
+        // Add older failures (not added to delay history)
         stats.add_result(100.0, false);
         stats.add_result(100.0, false);
 
-        // Add recent successes
-        stats.add_result(100.0, true);
-        stats.add_result(100.0, true);
+        // Add recent successes with decreasing delays
+        stats.add_result(150.0, true); // high delay
+        stats.add_result(120.0, true); // medium delay
+        stats.add_result(100.0, true); // low delay
 
         assert_eq!(stats.get_trend(), 1); // Improving
     }

--- a/clash_lib/src/proxy/group/smart/stats.rs
+++ b/clash_lib/src/proxy/group/smart/stats.rs
@@ -406,14 +406,6 @@ impl TrafficStatsCollector {
         self.throughput_samples
             .retain(|session_id, _| self.connection_start.contains_key(session_id));
     }
-
-    // /// Get the number of active sessions
-    // ///
-    // /// # Returns
-    // /// Number of currently tracked sessions
-    // pub fn active_session_count(&self) -> usize {
-    //     self.connection_start.len()
-    // }
 }
 
 impl Default for TrafficStatsCollector {

--- a/clash_lib/src/proxy/group/smart/stats.rs
+++ b/clash_lib/src/proxy/group/smart/stats.rs
@@ -1,0 +1,407 @@
+//! Statistics and preference tracking for smart proxy group
+//!
+//! This module provides comprehensive statistics tracking and site preference
+//! management, leveraging session traffic stats from the existing infrastructure.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    time::{Duration, Instant},
+};
+
+use crate::{
+    app::remote_content_manager::TrafficStats,
+    session::Session,
+};
+
+/// Unified site statistics and preference tracking
+///
+/// Combines performance metrics and site preference functionality,
+/// utilizing traffic statistics from session data when available.
+pub struct SiteStats {
+    /// History of connection delays (milliseconds)
+    delay_history: Vec<f64>,
+    /// Track connection success/failure history
+    success_history: Vec<bool>,
+    /// Last time this site was accessed
+    last_attempt: Instant,
+    /// Maximum history size to prevent unbounded growth
+    max_history: usize,
+}
+
+impl SiteStats {
+    /// Create a new SiteStats instance
+    pub fn new() -> Self {
+        Self {
+            delay_history: Vec::with_capacity(10),
+            success_history: Vec::with_capacity(10),
+            last_attempt: Instant::now(),
+            max_history: 10,
+        }
+    }
+
+    /// Calculate success rate for this site
+    pub fn success_rate(&self) -> f64 {
+        if self.success_history.is_empty() {
+            return 0.0;
+        }
+        self.success_history.iter().filter(|&&x| x).count() as f64
+            / self.success_history.len() as f64
+    }
+
+
+    /// Add a new connection result with optional session data
+    ///
+    /// Enhanced to utilize traffic statistics from session when available
+    pub fn add_result(&mut self, delay: f64, success: bool, session: Option<&Session>) {
+        // Use enhanced delay calculation if traffic stats are available
+        let effective_delay = if let Some(sess) = session {
+            if let Some(traffic_stats) = &sess.traffic_stats {
+                // Weight delay based on traffic characteristics
+                self.calculate_traffic_weighted_delay(delay, traffic_stats)
+            } else {
+                delay
+            }
+        } else {
+            delay
+        };
+
+        // Update delay history (only for successful connections)
+        if success {
+            if self.delay_history.len() >= self.max_history {
+                self.delay_history.remove(0);
+            }
+            self.delay_history.push(effective_delay);
+        }
+
+        // Update success history
+        if self.success_history.len() >= self.max_history {
+            self.success_history.remove(0);
+        }
+        self.success_history.push(success);
+
+        self.last_attempt = Instant::now();
+    }
+
+    /// Calculate traffic-weighted delay using session statistics
+    fn calculate_traffic_weighted_delay(&self, base_delay: f64, traffic_stats: &TrafficStats) -> f64 {
+        let mut weighted_delay = base_delay;
+        
+        // Adjust for bidirectional traffic (typically more complex)
+        if traffic_stats.is_bidirectional {
+            weighted_delay *= 1.1;
+        }
+        
+        // Adjust for high request frequency (more overhead)
+        if traffic_stats.request_frequency > 10.0 {
+            weighted_delay *= 1.05;
+        }
+        
+        // Adjust for connection duration (longer connections might indicate stability)
+        if traffic_stats.connection_duration.as_secs() > 30 {
+            weighted_delay *= 0.95;
+        }
+        
+        weighted_delay
+    }
+
+    /// Check if stats are stale and should be cleaned up
+    pub fn is_stale(&self) -> bool {
+        self.last_attempt.elapsed().as_secs() > 300 // 5 minutes
+    }
+
+    /// Calculate weighted delay score considering recent history and success rate
+    pub fn get_delay_score(&self) -> f64 {
+        if self.delay_history.is_empty() {
+            return 9999.0;
+        }
+
+        let mut sum = 0.0;
+        let mut weight_sum = 0.0;
+        let now = Instant::now();
+
+        for delay in self.delay_history.iter() {
+            let age = now.duration_since(self.last_attempt).as_secs_f64();
+            // Faster decay for older samples and higher delays
+            let time_weight = (-0.1 * age).exp();
+            let delay_weight = (-0.001 * delay).exp(); // Higher delays get less weight
+            let weight = time_weight * delay_weight;
+
+            sum += delay * weight;
+            weight_sum += weight;
+        }
+
+        let avg_delay = if weight_sum > 0.0 {
+            sum / weight_sum
+        } else {
+            9999.0
+        };
+
+        // Adjust based on success rate
+        let success_rate = self.success_rate();
+        avg_delay * (2.0 - success_rate) // Higher success rate reduces effective delay
+    }
+
+    /// Get recent performance trend
+    pub fn get_trend(&self) -> i8 {
+        if self.success_history.len() < 4 {
+            return 0; // Not enough data
+        }
+
+        let recent_half = self.success_history.len() / 2;
+        let older_success = self.success_history[..recent_half].iter().filter(|&&x| x).count();
+        let recent_success = self.success_history[recent_half..].iter().filter(|&&x| x).count();
+
+        let older_rate = older_success as f64 / recent_half as f64;
+        let recent_rate = recent_success as f64 / (self.success_history.len() - recent_half) as f64;
+
+        if recent_rate > older_rate + 0.2 {
+            1 // Improving
+        } else if recent_rate < older_rate - 0.2 {
+            -1 // Degrading
+        } else {
+            0 // Stable
+        }
+    }
+
+}
+
+impl Default for SiteStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Traffic statistics collector for real-time monitoring
+///
+/// Tracks traffic patterns, throughput, and connection characteristics
+/// to support traffic-aware proxy selection decisions.
+pub struct TrafficStatsCollector {
+    /// Connection start time for duration calculation
+    connection_start: HashMap<String, Instant>,
+    /// Accumulated bytes per session (uploaded, downloaded)
+    session_bytes: HashMap<String, (u64, u64)>,
+    /// Request frequency tracking
+    request_counts: HashMap<String, VecDeque<Instant>>,
+    /// Throughput samples for bandwidth analysis
+    throughput_samples: HashMap<String, VecDeque<(Instant, f64)>>,
+}
+
+impl TrafficStatsCollector {
+    /// Create a new traffic statistics collector
+    ///
+    /// # Returns
+    /// New TrafficStatsCollector instance
+    pub fn new() -> Self {
+        Self {
+            connection_start: HashMap::new(),
+            session_bytes: HashMap::new(),
+            request_counts: HashMap::new(),
+            throughput_samples: HashMap::new(),
+        }
+    }
+
+    /// Start tracking a new session
+    ///
+    /// Initializes tracking data structures for a new connection session.
+    ///
+    /// # Arguments
+    /// * `session_id` - Unique identifier for the session
+    pub fn start_session(&mut self, session_id: &str) {
+        self.connection_start.insert(session_id.to_string(), Instant::now());
+        self.session_bytes.insert(session_id.to_string(), (0, 0));
+        self.request_counts.insert(session_id.to_string(), VecDeque::new());
+        self.throughput_samples.insert(session_id.to_string(), VecDeque::new());
+    }
+
+    /// Record data transfer for a session
+    ///
+    /// Updates byte counters and calculates current throughput.
+    ///
+    /// # Arguments
+    /// * `session_id` - Session identifier
+    /// * `uploaded` - Bytes uploaded in this transfer
+    /// * `downloaded` - Bytes downloaded in this transfer
+    pub fn record_transfer(&mut self, session_id: &str, uploaded: u64, downloaded: u64) {
+        if let Some((up, down)) = self.session_bytes.get_mut(session_id) {
+            *up += uploaded;
+            *down += downloaded;
+            
+            // Calculate and record current throughput
+            if let Some(start_time) = self.connection_start.get(session_id) {
+                let elapsed = start_time.elapsed().as_secs_f64();
+                if elapsed > 0.0 {
+                    let current_throughput = (uploaded + downloaded) as f64 / elapsed;
+                    if let Some(samples) = self.throughput_samples.get_mut(session_id) {
+                        samples.push_back((Instant::now(), current_throughput));
+                        // Keep only last 10 samples
+                        if samples.len() > 10 {
+                            samples.pop_front();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Record a request event for frequency calculation
+    ///
+    /// Tracks individual requests to calculate request frequency patterns.
+    ///
+    /// # Arguments
+    /// * `session_id` - Session identifier
+    pub fn record_request(&mut self, session_id: &str) {
+        if let Some(requests) = self.request_counts.get_mut(session_id) {
+            requests.push_back(Instant::now());
+            // Keep only requests from last 60 seconds
+            let cutoff = Instant::now() - Duration::from_secs(60);
+            while let Some(&front_time) = requests.front() {
+                if front_time < cutoff {
+                    requests.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Generate traffic statistics for a session
+    ///
+    /// Compiles comprehensive traffic statistics including throughput,
+    /// request frequency, and traffic characteristics.
+    ///
+    /// # Arguments
+    /// * `session_id` - Session identifier
+    ///
+    /// # Returns
+    /// `Some(TrafficStats)` if session exists, `None` otherwise
+    pub fn get_stats(&self, session_id: &str) -> Option<TrafficStats> {
+        let start_time = self.connection_start.get(session_id)?;
+        let (uploaded, downloaded) = self.session_bytes.get(session_id)?;
+        let connection_duration = start_time.elapsed();
+        
+        // Calculate average throughput
+        let total_bytes = uploaded + downloaded;
+        let average_throughput = if connection_duration.as_secs_f64() > 0.0 {
+            total_bytes as f64 / connection_duration.as_secs_f64()
+        } else {
+            0.0
+        };
+
+        // Calculate peak throughput
+        let peak_throughput = self.throughput_samples.get(session_id)
+            .map(|samples| samples.iter().map(|(_, throughput)| *throughput).fold(0.0, f64::max))
+            .unwrap_or(0.0);
+
+        // Calculate request frequency (requests per second)
+        let request_frequency = self.request_counts.get(session_id)
+            .map(|requests| requests.len() as f64 / 60.0) // requests per minute -> per second
+            .unwrap_or(0.0);
+
+        // Determine if traffic is bidirectional
+        let is_bidirectional = if total_bytes > 0 {
+            let upload_ratio = *uploaded as f64 / total_bytes as f64;
+            upload_ratio > 0.1 && upload_ratio < 0.9 // Neither extremely upload nor download heavy
+        } else {
+            false
+        };
+
+        Some(TrafficStats {
+            bytes_uploaded: *uploaded,
+            bytes_downloaded: *downloaded,
+            connection_duration,
+            average_throughput,
+            peak_throughput,
+            request_frequency,
+            is_bidirectional,
+        })
+    }
+
+    /// Clean up old sessions to prevent memory leaks
+    ///
+    /// Removes session data older than 5 minutes to prevent
+    /// unbounded memory growth.
+    pub fn cleanup_old_sessions(&mut self) {
+        let cutoff = Instant::now() - Duration::from_secs(300); // 5 minutes
+        
+        self.connection_start.retain(|_, start_time| *start_time > cutoff);
+        self.session_bytes.retain(|session_id, _| self.connection_start.contains_key(session_id));
+        self.request_counts.retain(|session_id, _| self.connection_start.contains_key(session_id));
+        self.throughput_samples.retain(|session_id, _| self.connection_start.contains_key(session_id));
+    }
+
+    /// Get the number of active sessions
+    ///
+    /// # Returns
+    /// Number of currently tracked sessions
+    pub fn active_session_count(&self) -> usize {
+        self.connection_start.len()
+    }
+}
+
+impl Default for TrafficStatsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_site_stats_success_rate() {
+        let mut stats = SiteStats::new();
+        
+        stats.add_result(100.0, true, None);
+        stats.add_result(150.0, true, None);
+        stats.add_result(200.0, false, None);
+        
+        assert_eq!(stats.success_rate(), 2.0/3.0);
+        assert!(stats.get_delay_score() > 0.0);
+    }
+
+    #[test]
+    fn test_site_stats_delay_score() {
+        let mut stats = SiteStats::new();
+        
+        stats.add_result(100.0, true, None);
+        stats.add_result(200.0, true, None);
+        stats.add_result(300.0, false, None); // Should not affect delay average
+        
+        // Delay score should be calculated from successful connections only
+        let score = stats.get_delay_score();
+        assert!(score > 0.0);
+        assert!(score < 9999.0); // Should not be the default high value
+    }
+
+    #[test]
+    fn test_site_stats_trend() {
+        let mut stats = SiteStats::new();
+        
+        // Add older failures
+        stats.add_result(100.0, false, None);
+        stats.add_result(100.0, false, None);
+        
+        // Add recent successes
+        stats.add_result(100.0, true, None);
+        stats.add_result(100.0, true, None);
+        
+        assert_eq!(stats.get_trend(), 1); // Improving
+    }
+
+    #[test]
+    fn test_traffic_collector() {
+        let mut collector = TrafficStatsCollector::new();
+        
+        collector.start_session("test-session");
+        collector.record_transfer("test-session", 1000, 2000);
+        collector.record_request("test-session");
+        
+        let stats = collector.get_stats("test-session");
+        assert!(stats.is_some());
+        
+        let stats = stats.unwrap();
+        assert_eq!(stats.bytes_uploaded, 1000);
+        assert_eq!(stats.bytes_downloaded, 2000);
+    }
+}

--- a/clash_lib/src/proxy/group/smart/stats.rs
+++ b/clash_lib/src/proxy/group/smart/stats.rs
@@ -1,17 +1,16 @@
 //! Statistics and preference tracking for smart proxy group
 //!
 //! This module provides comprehensive statistics tracking and site preference
-//! management, leveraging session traffic stats from the existing infrastructure.
+//! management, leveraging session traffic stats from the existing
+//! infrastructure.
 
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, VecDeque},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
-use serde::{Deserialize, Serialize};
 
-use crate::{
-    app::remote_content_manager::TrafficStats,
-};
+use crate::app::remote_content_manager::TrafficStats;
 
 /// Unified site statistics and preference tracking
 ///
@@ -38,14 +37,15 @@ impl Serialize for SiteStats {
         let mut state = serializer.serialize_struct("SiteStats", 4)?;
         state.serialize_field("delay_history", &self.delay_history)?;
         state.serialize_field("success_history", &self.success_history)?;
-        
+
         // Convert Instant to timestamp
-        let duration = SystemTime::now().duration_since(UNIX_EPOCH)
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default();
         let elapsed = self.last_attempt.elapsed();
         let timestamp = duration.saturating_sub(elapsed);
         state.serialize_field("last_attempt", &timestamp.as_secs())?;
-        
+
         state.serialize_field("max_history", &self.max_history)?;
         state.end()
     }
@@ -63,21 +63,22 @@ impl<'de> Deserialize<'de> for SiteStats {
             last_attempt: u64,
             max_history: usize,
         }
-        
+
         let data = SiteStatsData::deserialize(deserializer)?;
-        
+
         // Convert timestamp back to Instant
         let timestamp = Duration::from_secs(data.last_attempt);
-        let now_duration = SystemTime::now().duration_since(UNIX_EPOCH)
+        let now_duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default();
-        
+
         let last_attempt = if now_duration > timestamp {
             let elapsed = now_duration - timestamp;
             Instant::now() - elapsed
         } else {
             Instant::now()
         };
-        
+
         Ok(SiteStats {
             delay_history: data.delay_history,
             success_history: data.success_history,
@@ -108,7 +109,6 @@ impl SiteStats {
         (success_count as f64) / (self.success_history.len() as f64)
     }
 
-
     /// Add a new connection result with optional session data
     ///
     /// Enhanced to utilize traffic statistics from session when available
@@ -130,13 +130,13 @@ impl SiteStats {
         self.last_attempt = Instant::now();
     }
 
-
     /// Check if stats are stale and should be cleaned up
     pub fn is_stale(&self) -> bool {
         self.last_attempt.elapsed().as_secs() > 300 // 5 minutes
     }
 
-    /// Calculate weighted delay score considering recent history and success rate
+    /// Calculate weighted delay score considering recent history and success
+    /// rate
     pub fn get_delay_score(&self) -> f64 {
         if self.delay_history.is_empty() {
             return 9999.0;
@@ -175,11 +175,18 @@ impl SiteStats {
         }
 
         let recent_half = self.success_history.len() / 2;
-        let older_success = self.success_history[..recent_half].iter().filter(|&&x| x).count();
-        let recent_success = self.success_history[recent_half..].iter().filter(|&&x| x).count();
+        let older_success = self.success_history[..recent_half]
+            .iter()
+            .filter(|&&x| x)
+            .count();
+        let recent_success = self.success_history[recent_half..]
+            .iter()
+            .filter(|&&x| x)
+            .count();
 
         let older_rate = older_success as f64 / recent_half as f64;
-        let recent_rate = recent_success as f64 / (self.success_history.len() - recent_half) as f64;
+        let recent_rate = recent_success as f64
+            / (self.success_history.len() - recent_half) as f64;
 
         if recent_rate > older_rate + 0.2 {
             1 // Improving
@@ -189,7 +196,6 @@ impl SiteStats {
             0 // Stable
         }
     }
-
 }
 
 impl Default for SiteStats {
@@ -234,10 +240,13 @@ impl TrafficStatsCollector {
     /// # Arguments
     /// * `session_id` - Unique identifier for the session
     pub fn start_session(&mut self, session_id: &str) {
-        self.connection_start.insert(session_id.to_string(), Instant::now());
+        self.connection_start
+            .insert(session_id.to_string(), Instant::now());
         self.session_bytes.insert(session_id.to_string(), (0, 0));
-        self.request_counts.insert(session_id.to_string(), VecDeque::new());
-        self.throughput_samples.insert(session_id.to_string(), VecDeque::new());
+        self.request_counts
+            .insert(session_id.to_string(), VecDeque::new());
+        self.throughput_samples
+            .insert(session_id.to_string(), VecDeque::new());
     }
 
     /// Record data transfer for a session
@@ -248,17 +257,25 @@ impl TrafficStatsCollector {
     /// * `session_id` - Session identifier
     /// * `uploaded` - Bytes uploaded in this transfer
     /// * `downloaded` - Bytes downloaded in this transfer
-    pub fn record_transfer(&mut self, session_id: &str, uploaded: u64, downloaded: u64) {
+    pub fn record_transfer(
+        &mut self,
+        session_id: &str,
+        uploaded: u64,
+        downloaded: u64,
+    ) {
         if let Some((up, down)) = self.session_bytes.get_mut(session_id) {
             *up += uploaded;
             *down += downloaded;
-            
+
             // Calculate and record current throughput
             if let Some(start_time) = self.connection_start.get(session_id) {
                 let elapsed = start_time.elapsed().as_secs_f64();
                 if elapsed > 0.0 {
-                    let current_throughput = (uploaded + downloaded) as f64 / elapsed;
-                    if let Some(samples) = self.throughput_samples.get_mut(session_id) {
+                    let current_throughput =
+                        (uploaded + downloaded) as f64 / elapsed;
+                    if let Some(samples) =
+                        self.throughput_samples.get_mut(session_id)
+                    {
                         samples.push_back((Instant::now(), current_throughput));
                         // Keep only last 10 samples
                         if samples.len() > 10 {
@@ -305,7 +322,7 @@ impl TrafficStatsCollector {
         let start_time = self.connection_start.get(session_id)?;
         let (uploaded, downloaded) = self.session_bytes.get(session_id)?;
         let connection_duration = start_time.elapsed();
-        
+
         // Calculate average throughput
         let total_bytes = uploaded + downloaded;
         let average_throughput = if connection_duration.as_secs_f64() > 0.0 {
@@ -315,8 +332,15 @@ impl TrafficStatsCollector {
         };
 
         // Calculate peak throughput
-        let peak_throughput = self.throughput_samples.get(session_id)
-            .map(|samples| samples.iter().map(|(_, throughput)| *throughput).fold(0.0, f64::max))
+        let peak_throughput = self
+            .throughput_samples
+            .get(session_id)
+            .map(|samples| {
+                samples
+                    .iter()
+                    .map(|(_, throughput)| *throughput)
+                    .fold(0.0, f64::max)
+            })
             .unwrap_or(0.0);
 
         // Calculate request frequency (requests per second)
@@ -349,11 +373,15 @@ impl TrafficStatsCollector {
     /// unbounded memory growth.
     pub fn cleanup_old_sessions(&mut self) {
         let cutoff = Instant::now() - Duration::from_secs(300); // 5 minutes
-        
-        self.connection_start.retain(|_, start_time| *start_time > cutoff);
-        self.session_bytes.retain(|session_id, _| self.connection_start.contains_key(session_id));
-        self.request_counts.retain(|session_id, _| self.connection_start.contains_key(session_id));
-        self.throughput_samples.retain(|session_id, _| self.connection_start.contains_key(session_id));
+
+        self.connection_start
+            .retain(|_, start_time| *start_time > cutoff);
+        self.session_bytes
+            .retain(|session_id, _| self.connection_start.contains_key(session_id));
+        self.request_counts
+            .retain(|session_id, _| self.connection_start.contains_key(session_id));
+        self.throughput_samples
+            .retain(|session_id, _| self.connection_start.contains_key(session_id));
     }
 
     // /// Get the number of active sessions
@@ -378,23 +406,23 @@ mod tests {
     #[test]
     fn test_site_stats_success_rate() {
         let mut stats = SiteStats::new();
-        
+
         stats.add_result(100.0, true);
         stats.add_result(150.0, true);
         stats.add_result(200.0, false);
-        
-        assert_eq!(stats.success_rate(), 2.0/3.0);
+
+        assert_eq!(stats.success_rate(), 2.0 / 3.0);
         assert!(stats.get_delay_score() > 0.0);
     }
 
     #[test]
     fn test_site_stats_delay_score() {
         let mut stats = SiteStats::new();
-        
+
         stats.add_result(100.0, true);
         stats.add_result(200.0, true);
         stats.add_result(300.0, false); // Should not affect delay average
-        
+
         // Delay score should be calculated from successful connections only
         let score = stats.get_delay_score();
         assert!(score > 0.0);
@@ -404,29 +432,29 @@ mod tests {
     #[test]
     fn test_site_stats_trend() {
         let mut stats = SiteStats::new();
-        
+
         // Add older failures
         stats.add_result(100.0, false);
         stats.add_result(100.0, false);
-        
+
         // Add recent successes
         stats.add_result(100.0, true);
         stats.add_result(100.0, true);
-        
+
         assert_eq!(stats.get_trend(), 1); // Improving
     }
 
     #[test]
     fn test_traffic_collector() {
         let mut collector = TrafficStatsCollector::new();
-        
+
         collector.start_session("test-session");
         collector.record_transfer("test-session", 1000, 2000);
         collector.record_request("test-session");
-        
+
         let stats = collector.get_stats("test-session");
         assert!(stats.is_some());
-        
+
         let stats = stats.unwrap();
         assert_eq!(stats.bytes_uploaded, 1000);
         assert_eq!(stats.bytes_downloaded, 2000);

--- a/clash_lib/src/proxy/mod.rs
+++ b/clash_lib/src/proxy/mod.rs
@@ -133,6 +133,7 @@ pub enum OutboundType {
     Selector,
     Relay,
     LoadBalance,
+    Smart,
     Fallback,
 
     Direct,
@@ -157,6 +158,7 @@ impl Display for OutboundType {
             OutboundType::Selector => write!(f, "Selector"),
             OutboundType::Relay => write!(f, "Relay"),
             OutboundType::LoadBalance => write!(f, "LoadBalance"),
+            OutboundType::Smart => write!(f, "Smart"),
             OutboundType::Fallback => write!(f, "Fallback"),
 
             OutboundType::Direct => write!(f, "Direct"),

--- a/clash_lib/src/session.rs
+++ b/clash_lib/src/session.rs
@@ -469,7 +469,10 @@ impl Session {
         );
         rv.insert("host".to_string(), Box::new(self.destination.host()) as _);
         rv.insert("asn".to_string(), Box::new(self.asn.clone()) as _);
-        rv.insert("traffic_stats".to_string(), Box::new(self.traffic_stats.clone()) as _);
+        rv.insert(
+            "traffic_stats".to_string(),
+            Box::new(self.traffic_stats.clone()) as _,
+        );
         rv
     }
 }

--- a/clash_lib/src/session.rs
+++ b/clash_lib/src/session.rs
@@ -441,6 +441,8 @@ pub struct Session {
     pub iface: Option<Interface>,
     /// The ASN of the destination IP address. Only for display.
     pub asn: Option<String>,
+    /// Traffic statistics for intelligent proxy selection
+    pub traffic_stats: Option<crate::app::remote_content_manager::TrafficStats>,
 }
 
 impl Session {
@@ -467,6 +469,7 @@ impl Session {
         );
         rv.insert("host".to_string(), Box::new(self.destination.host()) as _);
         rv.insert("asn".to_string(), Box::new(self.asn.clone()) as _);
+        rv.insert("traffic_stats".to_string(), Box::new(self.traffic_stats.clone()) as _);
         rv
     }
 }
@@ -482,6 +485,7 @@ impl Default for Session {
             so_mark: None,
             iface: None,
             asn: None,
+            traffic_stats: None,
         }
     }
 }
@@ -520,6 +524,7 @@ impl Clone for Session {
             so_mark: self.so_mark,
             iface: self.iface.as_ref().cloned(),
             asn: self.asn.clone(),
+            traffic_stats: self.traffic_stats.clone(),
         }
     }
 }

--- a/docs/clash_doc/struct.ClashConfigDef.html
+++ b/docs/clash_doc/struct.ClashConfigDef.html
@@ -124,8 +124,6 @@ proxy-groups:
       - &quot;file-provider&quot;
     proxies:
       - DIRECT
-    url: &quot;http://www.gstatic.com/generate_204&quot;
-    interval: 300
   - name: select
     type: select
     use:

--- a/docs/clash_doc/struct.ClashConfigDef.html
+++ b/docs/clash_doc/struct.ClashConfigDef.html
@@ -86,6 +86,7 @@ proxy-groups:
       - &quot;auto&quot;
       - &quot;fallback-auto&quot;
       - &quot;load-balance&quot;
+      - &quot;smart&quot;
       - &quot;select&quot;
       - DIRECT
   - name: &quot;relay-one&quot;
@@ -115,6 +116,14 @@ proxy-groups:
     proxies:
       - DIRECT
     strategy: round-robin
+    url: &quot;http://www.gstatic.com/generate_204&quot;
+    interval: 300
+  - name: &quot;smart&quot;
+    type: smart
+    use:
+      - &quot;file-provider&quot;
+    proxies:
+      - DIRECT
     url: &quot;http://www.gstatic.com/generate_204&quot;
     interval: 300
   - name: select


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 💡 Background and solution

Inspired by:  
- https://github.com/MetaCubeX/mihomo/commit/3c9d4cecef6f2cef4be3c7a714f4b44adf7a89bc  
- https://kb.nssurge.com/surge-knowledge-base/guidelines/smart-group  
  - https://kb.nssurge.com/surge-knowledge-base/zh/guidelines/smart-group (Chinese version)

This PR introduces a new intelligent proxy group type: `smart`, designed for dynamic and adaptive proxy selection based on real-world traffic and proxy behavior. It includes several key mechanisms:

1.  **Penalty-based reliability tracking ([`penalty.rs`](clash_lib/src/proxy/group/smart/penalty.rs))**
    *   Each proxy has a `penalty` score that increases exponentially on failure:
        ```markdown
        penalty = (penalty + 1.0) * 2.0
        ```
    *   Penalty decays exponentially over time with a 10-second half-life.
    *   Successful connections instantly reduce the penalty by 80%.

2.  **Per-site performance statistics ([`stats.rs`](clash_lib/src/proxy/group/smart/stats.rs))**
    *   Maintains history (up to 10 samples) for connection `delay` (successful connections only) and `success` status for both hostname and IP address destinations.
    *   Statistics expire after 5 minutes of inactivity for a specific proxy-destination pair.

3.  **Trend Analysis ([`stats.rs`](clash_lib/src/proxy/group/smart/stats.rs))**
    *   Calculates a 5-level performance trend (-2: Significantly Degrading, -1: Degrading, 0: Stable, 1: Improving, 2: Significantly Improving).
    *   Uses Exponential Moving Average (EMA) with `alpha = 0.3` to smooth both success rate and delay history, reducing noise from short-term fluctuations.
    *   Compares the smoothed performance of the earliest 25% of data against the latest 25% to determine the trend direction and magnitude based on *both* delay change rate and success rate change.

4.  **Traffic-aware Selection ([`remote_content_manager/mod.rs`](clash_lib/src/app/remote_content_manager/mod.rs))**
    *   Uses `TrafficStatsCollector` ([`stats.rs`](clash_lib/src/proxy/group/smart/stats.rs)) to track per-session throughput, duration, request frequency, and bidirectionality.
    *   Automatically classifies traffic patterns (e.g., Gaming, Video Streaming, File Download, Web Browsing) using heuristics based on these stats and destination information ([`analyze_traffic_pattern`](clash_lib/src/app/remote_content_manager/mod.rs:219)).
    *   Applies different scoring weights for delay, packet loss, RTT, and alive penalty based on the detected traffic pattern ([`get_site_tuning`](clash_lib/src/app/remote_content_manager/mod.rs:816)).

5.  **Composite Scoring Model ([`mod.rs`](clash_lib/src/proxy/group/smart/mod.rs))**
    *   Calculates a base score for each proxy considering multiple factors:
        ```markdown
        base_score = adjusted_historical_delay * delay_weight
                   + packet_loss * loss_weight
                   + rtt * rtt_weight
                   + alive_penalty  // Applied if proxy is not alive
                   + penalty_score
                   + bandwidth_score // If bandwidth_weight > 0
        ```
    *   The `adjusted_historical_delay` incorporates historical success rate and the **5-level trend**:
        ```markdown
        // Combines average delay from site and IP history
        avg_hist_delay = (site_delay_score + ip_delay_score) / 2.0

        // Apply trend multiplier based on the 5-level trend (t)
        trend_multiplier = match t {
            2 => 0.7,   // Significantly improving: 30% bonus
            1 => 0.9,   // Improving: 10% bonus
            -1 => 1.1,  // Degrading: 10% penalty
            -2 => 1.3,  // Significantly degrading: 30% penalty
            _ => 1.0,   // Stable: no change
        }

        // Adjust delay based on success rate (sr) and trend
        adjusted_historical_delay = avg_hist_delay * (2.0 - sr) * trend_multiplier
        ```
    *   The final score is the base score multiplied by any custom weight defined by the user:
        ```markdown
        final_score = base_score * custom_weight
        ```
    *   Proxies with lower `final_score` are preferred.

6.  **Adaptive Retry Mechanism ([`mod.rs`](clash_lib/src/proxy/group/smart/mod.rs))**
    *   Calculates the maximum number of retries based on the destination's historical average success rate, clamped between 2 and 6 attempts.
    *   Uses exponential backoff for delays between retries, starting at 100ms and capped at 5000ms.
    *   Avoids retrying proxies that have already failed within the same connection attempt sequence.

7.  **Site Stickiness ([`preference.rs`](clash_lib/src/proxy/group/smart/preference.rs), [`state.rs`](clash_lib/src/proxy/group/smart/state.rs))**
    *   Optionally enabled via `site_stickiness` parameter.
    *   Tracks the preferred proxy for each site based on recent successful connections.
    *   If a preference exists, is recent (within 5 minutes), and meets a minimum success rate (default 70%), that proxy is used directly, bypassing the full scoring logic.

### 📝 Changelog

- Introduced a new proxy group type: `smart`

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed
