### PR TITLE
feat: adding dual stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8653,7 +8653,7 @@ dependencies = [
 [[package]]
 name = "unix-udp-sock"
 version = "0.7.0"
-source = "git+https://github.com/Watfaq/unix-udp-sock.git?rev=cd3e4eca43e6f3be82a2703c3d711b7e18fbfd18#cd3e4eca43e6f3be82a2703c3d711b7e18fbfd18"
+source = "git+https://github.com/Watfaq/unix-udp-sock.git?rev=847c80b519f0fd8cff5c887ae708429897d08671#847c80b519f0fd8cff5c887ae708429897d08671"
 dependencies = [
  "bytes",
  "futures-core",

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -197,7 +197,7 @@ httpmock = "0.7.0"
 prost-build = "0.14"
 
 [target.'cfg(target_os="linux")'.dependencies]
-unix-udp-sock = { git = "https://github.com/Watfaq/unix-udp-sock.git", rev = "cd3e4eca43e6f3be82a2703c3d711b7e18fbfd18" }
+unix-udp-sock = { git = "https://github.com/Watfaq/unix-udp-sock.git", rev = "847c80b519f0fd8cff5c887ae708429897d08671" }
 
 [target.'cfg(macos)'.dependencies]
 security-framework = "3.2.0"

--- a/clash-lib/src/config/internal/config.rs
+++ b/clash-lib/src/config/internal/config.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use std::{
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
 
@@ -106,6 +106,10 @@ impl BindAddress {
         Self(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     }
 
+    pub fn dual_stack() -> Self {
+        Self(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
+    }
+
     pub fn local() -> Self {
         Self(IpAddr::V4(Ipv4Addr::LOCALHOST))
     }
@@ -132,6 +136,7 @@ impl<'de> Deserialize<'de> for BindAddress {
         match str.as_str() {
             "*" => Ok(Self(IpAddr::V4(Ipv4Addr::UNSPECIFIED))),
             "localhost" => Ok(Self(IpAddr::from([127, 0, 0, 1]))),
+            "[::]" | "::" => Ok(Self(IpAddr::V6(Ipv6Addr::UNSPECIFIED))),
             _ => {
                 if let Ok(ip) = str.parse::<IpAddr>() {
                     Ok(Self(ip))
@@ -152,6 +157,7 @@ impl FromStr for BindAddress {
         match str {
             "*" => Ok(Self(IpAddr::V4(Ipv4Addr::UNSPECIFIED))),
             "localhost" => Ok(Self(IpAddr::from([127, 0, 0, 1]))),
+            "[::]" | "::" => Ok(Self(IpAddr::V6(Ipv6Addr::UNSPECIFIED))),
             _ => {
                 if let Ok(ip) = str.parse::<IpAddr>() {
                     Ok(Self(ip))

--- a/clash-lib/src/proxy/http/inbound/mod.rs
+++ b/clash-lib/src/proxy/http/inbound/mod.rs
@@ -5,7 +5,10 @@ mod proxy;
 use crate::{
     Dispatcher,
     common::auth::ThreadSafeAuthenticator,
-    proxy::{inbound::InboundHandlerTrait, utils::apply_tcp_options},
+    proxy::{
+        inbound::InboundHandlerTrait,
+        utils::{ToCanonical, apply_tcp_options, try_create_dualstack_tcplistener},
+    },
 };
 
 pub use proxy::handle as handle_http;
@@ -60,13 +63,15 @@ impl InboundHandlerTrait for HttpInbound {
     }
 
     async fn listen_tcp(&self) -> std::io::Result<()> {
-        let listener = TcpListener::bind(self.addr).await?;
+        let listener = try_create_dualstack_tcplistener(self.addr)?;
 
         loop {
             let (socket, _) = listener.accept().await?;
-            let src_addr = socket.peer_addr()?;
+            let src_addr = socket.peer_addr()?.to_canonical();
 
-            if !self.allow_lan && src_addr.ip() != socket.local_addr()?.ip() {
+            if !self.allow_lan
+                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
+            {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }

--- a/clash-lib/src/proxy/http/inbound/mod.rs
+++ b/clash-lib/src/proxy/http/inbound/mod.rs
@@ -16,7 +16,6 @@ pub use proxy::handle as handle_http;
 use crate::common::errors::new_io_error;
 use async_trait::async_trait;
 use std::{net::SocketAddr, sync::Arc};
-use tokio::net::TcpListener;
 use tracing::warn;
 
 #[derive(Clone)]

--- a/clash-lib/src/proxy/mixed/mod.rs
+++ b/clash-lib/src/proxy/mixed/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     Dispatcher,
     common::auth::ThreadSafeAuthenticator,
+    proxy::utils::{ToCanonical, try_create_dualstack_tcplistener},
     session::{Network, Session},
 };
 
@@ -54,7 +55,7 @@ impl InboundHandlerTrait for MixedInbound {
     }
 
     async fn listen_tcp(&self) -> std::io::Result<()> {
-        let listener = TcpListener::bind(self.addr).await?;
+        let listener = try_create_dualstack_tcplistener(self.addr)?;
 
         loop {
             let (socket, _) = match listener.accept().await {
@@ -65,13 +66,15 @@ impl InboundHandlerTrait for MixedInbound {
                 }
             };
             let src_addr = match socket.peer_addr() {
-                Ok(a) => a,
+                Ok(a) => a.to_canonical(),
                 Err(e) => {
                     warn!("failed to get peer address: {:?}", e);
                     continue;
                 }
             };
-            if !self.allow_lan && src_addr.ip() != socket.local_addr()?.ip() {
+            if !self.allow_lan
+                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
+            {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }
@@ -101,7 +104,7 @@ impl InboundHandlerTrait for MixedInbound {
                 socks::SOCKS5_VERSION => {
                     let mut sess = Session {
                         network: Network::Tcp,
-                        source: socket.peer_addr()?,
+                        source: socket.peer_addr()?.to_canonical(),
                         so_mark: fw_mark,
                         ..Default::default()
                     };
@@ -118,7 +121,7 @@ impl InboundHandlerTrait for MixedInbound {
                 }
 
                 _ => {
-                    let src = socket.peer_addr()?;
+                    let src = socket.peer_addr()?.to_canonical();
                     let dispatcher = dispatcher.clone();
                     let authenticator = authenticator.clone();
                     tokio::spawn(async move {

--- a/clash-lib/src/proxy/mixed/mod.rs
+++ b/clash-lib/src/proxy/mixed/mod.rs
@@ -9,7 +9,6 @@ use super::{http, inbound::InboundHandlerTrait, socks, utils::apply_tcp_options}
 use crate::common::errors::new_io_error;
 use async_trait::async_trait;
 use std::{net::SocketAddr, sync::Arc};
-use tokio::net::TcpListener;
 use tracing::warn;
 
 pub struct MixedInbound {

--- a/clash-lib/src/proxy/socks/inbound/mod.rs
+++ b/clash-lib/src/proxy/socks/inbound/mod.rs
@@ -2,13 +2,18 @@ mod datagram;
 mod stream;
 
 use crate::{
-    common::auth::ThreadSafeAuthenticator, proxy::{inbound::InboundHandlerTrait, utils::{apply_tcp_options, try_create_dualstack_tcplistener, ToCanonical}}, session::{Network, Session, Type}, Dispatcher
+    Dispatcher,
+    common::auth::ThreadSafeAuthenticator,
+    proxy::{
+        inbound::InboundHandlerTrait,
+        utils::{ToCanonical, apply_tcp_options, try_create_dualstack_tcplistener},
+    },
+    session::{Network, Session, Type},
 };
 
 use async_trait::async_trait;
 use std::{net::SocketAddr, sync::Arc};
 pub use stream::handle_tcp;
-use tokio::net::TcpListener;
 use tracing::warn;
 
 use crate::common::errors::new_io_error;
@@ -62,7 +67,9 @@ impl InboundHandlerTrait for SocksInbound {
         loop {
             let (socket, _) = listener.accept().await?;
             let src_addr = socket.peer_addr()?.to_canonical();
-            if !self.allow_lan && src_addr.ip() != socket.local_addr()?.ip().to_canonical() {
+            if !self.allow_lan
+                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
+            {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }

--- a/clash-lib/src/proxy/socks/socks5.rs
+++ b/clash-lib/src/proxy/socks/socks5.rs
@@ -99,7 +99,11 @@ pub(crate) async fn client_handshake(
     buf.put_u8(command);
     buf.put_u8(0x00);
     if command == socks_command::UDP_ASSOCIATE {
-        let addr = SocksAddr::any_ipv4();
+        let addr = if addr.clone().must_into_socket_addr().is_ipv4() {
+            SocksAddr::any_ipv4()
+        } else {
+            SocksAddr::any_ipv6()
+        };
         addr.write_buf(&mut buf);
     } else {
         addr.write_buf(&mut buf);

--- a/clash-lib/src/proxy/tproxy/ip6tables.sh
+++ b/clash-lib/src/proxy/tproxy/ip6tables.sh
@@ -1,0 +1,70 @@
+### IPv6 RULES
+
+
+TPROXY_IP=::
+TPROXY_PORT=8900
+
+readonly IPV6_RESERVED_IPADDRS="\
+::/128 \
+::1/128 \
+::ffff:0:0/96 \
+::ffff:0:0:0/96 \
+64:ff9b::/96 \
+100::/64 \
+2001::/32 \
+2001:20::/28 \
+2001:db8::/32 \
+2002::/16 \
+fc00::/7 \
+fe80::/10 \
+ff00::/8 \
+"
+
+## TCP+UDP
+# Strategy Route
+ip -6 rule del fwmark 0x1 table 803
+ip -6 rule add fwmark 0x1 table 803
+ip -6 route del local ::/0 dev lo table 803
+ip -6 route add local ::/0 dev lo table 803
+
+# TPROXY for LAN
+ip6tables -t mangle -N CLASH-TRPOXY
+# Skip LoopBack, Reserved
+for addr in ${IPV6_RESERVED_IPADDRS}; do
+   ip6tables -t mangle -A CLASH-TRPOXY -d "${addr}" -j RETURN
+done
+
+# Bypass LAN data
+ip6tables -t mangle -A CLASH-TRPOXY -m addrtype --dst-type LOCAL -j RETURN
+# Bypass sslocal's outbound data
+ip6tables -t mangle -A CLASH-TRPOXY -m mark --mark 0xff/0xff -j RETURN
+# UDP: TPROXY UDP
+ip6tables -t mangle -A CLASH-TRPOXY -p udp -j TPROXY --on-ip ${TPROXY_IP} --on-port ${TPROXY_PORT} --tproxy-mark 0x01/0x01
+
+# TCP: TPROXY UDP
+ip6tables -t mangle -A CLASH-TRPOXY -p tcp -j TPROXY --on-ip ${TPROXY_IP} --on-port ${TPROXY_PORT} --tproxy-mark 0x01/0x01
+
+# TPROXY for Local
+ip6tables -t mangle -N CLASH-TRPOXY-mark
+# Skip LoopBack, Reserved
+for addr in ${IPV6_RESERVED_IPADDRS}; do
+   ip6tables -t mangle -A CLASH-TRPOXY-mark -d "${addr}" -j RETURN
+done
+
+# TCP: conntrack
+ip6tables -t mangle -A CLASH-TRPOXY-mark -p tcp -m conntrack --ctdir REPLY -j RETURN
+# Bypass sslocal's outbound data
+ip6tables -t mangle -A CLASH-TRPOXY-mark -m mark --mark 0xff/0xff -j RETURN
+ip6tables -t mangle -A CLASH-TRPOXY-mark -m owner --uid-owner root -j RETURN
+# Set MARK and reroute
+ip6tables -t mangle -A CLASH-TRPOXY-mark -p udp -j MARK --set-xmark 0x01/0xffffffff
+ip6tables -t mangle -A CLASH-TRPOXY-mark -p tcp -j MARK --set-xmark 0x01/0xffffffff
+
+# Apply TPROXY to LAN
+ip6tables -t mangle -A PREROUTING -p udp -j CLASH-TRPOXY
+ip6tables -t mangle -A PREROUTING -p tcp -j CLASH-TRPOXY
+#ip6tables -t mangle -A PREROUTING -p udp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j CLASH-TRPOXY
+# Apply TPROXY for Local
+ip6tables -t mangle -A OUTPUT -p udp -j CLASH-TRPOXY-mark
+ip6tables -t mangle -A OUTPUT -p tcp -j CLASH-TRPOXY-mark
+#ip6tables -t mangle -A OUTPUT -p udp -m addrtype --src-type LOCAL ! --dst-type LOCAL -j CLASH-TRPOXY-mark

--- a/clash-lib/src/proxy/tproxy/iptables.sh
+++ b/clash-lib/src/proxy/tproxy/iptables.sh
@@ -4,6 +4,7 @@
 readonly LOCAL_BY_PASS="\
 127/8 \
 10/8 \
+192/8
 "
 
 # declare ip as local for tproxy

--- a/clash-lib/src/proxy/tproxy/mod.rs
+++ b/clash-lib/src/proxy/tproxy/mod.rs
@@ -118,7 +118,7 @@ impl InboundHandlerTrait for TproxyInbound {
             socket.set_ip_transparent_v4(true)?;
         }
         if self.addr.is_ipv6() {
-            // This might not be neccessary
+            // This might not be necessary
             set_ip_transparent_v6(&socket)?;
         }
 
@@ -169,7 +169,7 @@ fn bind_nonlocal_socket(src_addr: SocketAddr) -> io::Result<UdpSocket> {
 }
 
 async fn handle_inbound_datagram(
-    allow_lan: bool,
+    _allow_lan: bool,
     socket: Arc<unix_udp_sock::UdpSocket>,
     dispatcher: Arc<Dispatcher>,
 ) -> std::io::Result<()> {
@@ -218,13 +218,13 @@ async fn handle_inbound_datagram(
                         orig_dst,
                         socket.local_addr()
                     );
-                    if !allow_lan
-                        && let Ok(local_addr) = socket.local_addr()
-                        && meta.addr.ip() != local_addr.ip()
-                    {
-                        warn!("Connection from {} is not allowed", meta.addr);
-                        continue;
-                    }
+                    // if !allow_lan
+                    //     && let Ok(local_addr) = socket.local_addr()
+                    //     && meta.addr.ip() != local_addr.ip()
+                    // {
+                    //     warn!("Connection from {} is not allowed", meta.addr);
+                    //     continue;
+                    // }
                     let pkt = UdpPacket {
                         data: buf[..meta.len].to_vec(),
                         src_addr: meta.addr.to_canonical().into(),

--- a/clash-lib/src/proxy/tproxy/mod.rs
+++ b/clash-lib/src/proxy/tproxy/mod.rs
@@ -121,7 +121,7 @@ impl InboundHandlerTrait for TproxyInbound {
             // This might not be necessary
             set_ip_transparent_v6(&socket)?;
         }
-
+        socket.set_reuse_port(true)?;
         socket.set_nonblocking(true)?;
         socket.set_broadcast(true)?;
         set_ip_recv_orig_dstaddr(

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -5,11 +5,10 @@ use crate::{
 };
 
 use futures::io;
-use tokio::net::TcpListener;
 use socket2::TcpKeepalive;
 use std::{net::SocketAddr, time::Duration};
 use tokio::{
-    net::{TcpSocket, TcpStream, UdpSocket},
+    net::{TcpListener, TcpSocket, TcpStream, UdpSocket},
     time::timeout,
 };
 use tracing::{debug, error};
@@ -240,14 +239,16 @@ pub fn try_create_dualstack_socket(
     Ok((socket, dualstack))
 }
 
-pub fn try_create_dualstack_tcplistener(addr: SocketAddr) -> io::Result<TcpListener>{
-            let (socket, _dualstack) =
-            try_create_dualstack_socket(addr, socket2::Type::STREAM)?;
+pub fn try_create_dualstack_tcplistener(
+    addr: SocketAddr,
+) -> io::Result<TcpListener> {
+    let (socket, _dualstack) =
+        try_create_dualstack_socket(addr, socket2::Type::STREAM)?;
 
-        socket.set_nonblocking(true)?;
-        socket.bind(&addr.into())?;
-        socket.listen(1024)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&addr.into())?;
+    socket.listen(1024)?;
 
-        let listener = TcpListener::from_std(socket.into())?;
-        Ok(listener)
+    let listener = TcpListener::from_std(socket.into())?;
+    Ok(listener)
 }

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -246,6 +246,8 @@ pub fn try_create_dualstack_tcplistener(
         try_create_dualstack_socket(addr, socket2::Type::STREAM)?;
 
     socket.set_nonblocking(true)?;
+    // For fast restart avoid Address In Use Error
+    socket.set_reuse_address(true)?;
     socket.bind(&addr.into())?;
     socket.listen(1024)?;
 

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -4,6 +4,8 @@ use crate::{
     session::Session,
 };
 
+use futures::io;
+use tokio::net::TcpListener;
 use socket2::TcpKeepalive;
 use std::{net::SocketAddr, time::Duration};
 use tokio::{
@@ -236,4 +238,16 @@ pub fn try_create_dualstack_socket(
         }
     };
     Ok((socket, dualstack))
+}
+
+pub fn try_create_dualstack_tcplistener(addr: SocketAddr) -> io::Result<TcpListener>{
+            let (socket, _dualstack) =
+            try_create_dualstack_socket(addr, socket2::Type::STREAM)?;
+
+        socket.set_nonblocking(true)?;
+        socket.bind(&addr.into())?;
+        socket.listen(1024)?;
+
+        let listener = TcpListener::from_std(socket.into())?;
+        Ok(listener)
 }

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -109,11 +109,7 @@ pub async fn new_udp_socket(
         (None, Some(src), _) if src.is_ipv6() => {
             debug!("resolved v6 socket for v6 src {src:?}");
             (
-                socket2::Socket::new(
-                    socket2::Domain::IPV6,
-                    socket2::Type::DGRAM,
-                    None,
-                )?,
+                try_create_dualstack_socket(src, socket2::Type::DGRAM)?.0,
                 socket2::Domain::IPV6,
             )
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
As have been discussed, this PR is a draft to support dual stack. 
Finally I take the first approach. Namely using `[::]:port` as a dual stack socket.
To achieve this "Ipv6" Addess is added to `BindAdress`. Unfortunately. Binding to ipv6 address forces us to also implement dualstack for socks/http/mixed. 
<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
1. Adding ipv6 bind address
2. Adding TProxy dualstack
3. The socks outbound associate destination is 0.0.0.0:0, changed to [::]:0 if it's ipv6
4. TProxy UDP sending pack to local is using TProxy as src addr. Create a new udp to send udp packets back.
5. Adding dualstack for http/mixed/ss inbound\
6. Allowlan for TProxy is commented. No trivial way to get local address
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge
- [x] TProxy
- [ ] Redir
- [x] Socks
- [x] http
- [x] mixed 
- [x] shadowsocks (Not tested)
⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
