### PR TITLE
fix(geoip-code): filter logically reversed

### DIFF
--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -372,7 +372,7 @@ impl From<crate::config::def::FallbackFilter> for FallbackFilter {
         let ipcidr = Config::parse_fallback_ip_cidr(&c.ip_cidr);
         Self {
             geo_ip: c.geo_ip,
-            geo_ip_code: c.geo_ip_code,
+            geo_ip_code: c.geo_ip_code.to_lowercase(),
             ip_cidr: ipcidr.ok(),
             domain: c.domain,
         }

--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -372,7 +372,7 @@ impl From<crate::config::def::FallbackFilter> for FallbackFilter {
         let ipcidr = Config::parse_fallback_ip_cidr(&c.ip_cidr);
         Self {
             geo_ip: c.geo_ip,
-            geo_ip_code: c.geo_ip_code.to_lowercase(),
+            geo_ip_code: c.geo_ip_code.to_uppercase(),
             ip_cidr: ipcidr.ok(),
             domain: c.domain,
         }

--- a/clash-lib/src/app/dns/filters.rs
+++ b/clash-lib/src/app/dns/filters.rs
@@ -16,7 +16,7 @@ impl GeoIPFilter {
 
 impl FallbackIPFilter for GeoIPFilter {
     fn apply(&self, ip: &net::IpAddr) -> bool {
-        self.1.as_ref().is_some_and(|mmdb| {
+        !self.1.as_ref().is_some_and(|mmdb| {
             mmdb.lookup_country(*ip)
                 .map(|x| x.country_code)
                 .is_ok_and(|x| x == self.0)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Apologies for the previous lax PR, the logic of this filter should be reversed. Referring to [this](https://wiki.metacubex.one/config/dns/#geoip-code), only non CN regions will use fallback.


