### PR TITLE
fix: reset udp outbound map when selector changed

### DIFF
--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -297,6 +297,17 @@ impl Dispatcher {
                         mgr.get_outbound(PROXY_DIRECT).unwrap()
                     });
 
+                let outbound_name =
+                    if let Some(group) = handler.try_as_group_handler() {
+                        group
+                            .get_active_proxy()
+                            .await
+                            .map(|x| x.name().to_owned())
+                            .unwrap_or(outbound_name)
+                    } else {
+                        outbound_name
+                    };
+
                 match outbound_handle_guard
                     .get_outbound_sender_mut(
                         &outbound_name,

--- a/clash-netstack/src/tcp_stream.rs
+++ b/clash-netstack/src/tcp_stream.rs
@@ -101,7 +101,9 @@ impl tokio::io::AsyncWrite for TcpStream {
             trace!("TcpStream::poll_write: send buffer is full, waiting for space");
             // Register the waker to be notified when space is available
             self.handle.send_waker.register(cx.waker());
-
+            self.stack_notifier
+                .send(IfaceEvent::TcpSocketReady)
+                .expect("Failed to notify TCP socket ready");
             return std::task::Poll::Pending;
         }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

Fixes #878

### 💡 Background and solution

This PR fixes an issue where the UDP outbound map was not being reset when a selector proxy changed its active proxy selection. This could cause UDP connections to continue using the old proxy even after the selector changed.

The fix adds logic to:
1. Get the active proxy name from group handlers when available in the dispatcher
2. Ensure TCP socket notifications are properly sent when the send buffer is full

### 📝 Changelog

- Fixed UDP connections not updating when selector proxy changes active proxy
- Improved TCP socket notification handling in netstack

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed