### PR TITLE
fix(proxy): udp not bound for shadowquic #918

### DIFF
--- a/clash-lib/src/proxy/shadowquic/mod.rs
+++ b/clash-lib/src/proxy/shadowquic/mod.rs
@@ -88,12 +88,17 @@ impl Handler {
                     }
                     SocksAddr::Ip(socket_addr) => socket_addr,
                 };
+                let bind_addr = if addr.is_ipv4() {
+                    "0.0.0.0:0".parse().unwrap()
+                } else {
+                    "[::]:0".parse().unwrap()
+                };
                 let socket = new_udp_socket(
-                    None,
+                    Some(bind_addr),
                     sess.iface.as_ref(),
                     #[cfg(target_os = "linux")]
                     sess.so_mark,
-                    Some(addr),
+                    None,
                 )
                 .await?;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
#918

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->
Due to change of `new_udp_socket` function. UDP socket is not bound for shadowquic outbound. It works on
linux but failed on windows. 

This PR should fix

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
