### PR TITLE
fix(shadowquic): fix quinn not work when bound to interface

### DIFF
--- a/clash-lib/src/proxy/shadowquic/mod.rs
+++ b/clash-lib/src/proxy/shadowquic/mod.rs
@@ -98,7 +98,7 @@ impl Handler {
                     sess.iface.as_ref(),
                     #[cfg(target_os = "linux")]
                     sess.so_mark,
-                    None,
+                    Some(bind_addr),
                 )
                 .await?;
 

--- a/clash-lib/src/proxy/utils/platform/win.rs
+++ b/clash-lib/src/proxy/utils/platform/win.rs
@@ -1,10 +1,15 @@
 use std::{io, os::windows::io::AsRawSocket};
-use tracing::{error, warn};
-use windows::Win32::{
-    Foundation::GetLastError,
-    Networking::WinSock::{
-        IP_UNICAST_IF, IPPROTO_IP, IPPROTO_IPV6, IPV6_UNICAST_IF, SOCKET, setsockopt,
+use tracing::error;
+use windows::{
+    Win32::{
+        Foundation::GetLastError,
+        Networking::WinSock::{
+            IP_MULTICAST_IF, IP_UNICAST_IF, IPPROTO_IP, IPPROTO_IPV6,
+            IPV6_MULTICAST_IF, IPV6_UNICAST_IF, SO_TYPE, SOCK_DGRAM, SOCKET,
+            SOL_SOCKET, WINSOCK_SOCKET_TYPE, getsockopt, setsockopt,
+        },
     },
+    core::PSTR,
 };
 
 use crate::{app::net::OutboundInterface, common::errors::new_io_error};
@@ -15,22 +20,22 @@ pub(crate) fn must_bind_socket_on_interface(
     family: socket2::Domain,
 ) -> io::Result<()> {
     let handle = SOCKET(socket.as_raw_socket().try_into().unwrap());
-
+    let is_udp = is_udp_socket(handle)?;
     let idx = iface.index;
 
-    match match family {
+    let errno = match family {
         socket2::Domain::IPV4 => unsafe {
-            Ok(setsockopt(
+            setsockopt(
                 handle,
                 IPPROTO_IP.0,
                 IP_UNICAST_IF,
                 // https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
                 // a 4-byte IPv4 address in network byte order
                 Some(idx.to_be_bytes().as_ref()),
-            ))
+            )
         },
         socket2::Domain::IPV6 => unsafe {
-            Ok(setsockopt(
+            setsockopt(
                 handle,
                 IPPROTO_IPV6.0,
                 IPV6_UNICAST_IF,
@@ -39,23 +44,75 @@ pub(crate) fn must_bind_socket_on_interface(
                 // byte order
                 // OMG Windows!
                 Some(idx.to_ne_bytes().as_ref()),
-            ))
+            )
         },
-        _ => Err(io::Error::other("unsupported socket family")),
-    } {
-        Ok(errno) => {
-            if errno != 0 {
-                let err = unsafe { GetLastError().to_hresult().message() };
-                error!("bind socket to interface failed: {}, errno: {}", err, errno);
-                return Err(new_io_error(err));
-            }
-            Ok(())
-        }
-        Err(e) => {
-            warn!("failed to bind socket to interface: {}", e);
-            Err(io::Error::other(format!(
-                "failed to bind socket to interface: {e}"
-            )))
+        _ => return Err(io::Error::other("unsupported socket family")),
+    };
+
+    if errno != 0 {
+        let err = unsafe { GetLastError().to_hresult().message() };
+        error!("bind socket to interface failed: {}, errno: {}", err, errno);
+        return Err(new_io_error(err));
+    }
+
+    // UDP supports multicast
+    // MULTICAST must also be bound to an interface
+    if is_udp {
+        let errno = match family {
+            socket2::Domain::IPV4 => unsafe {
+                setsockopt(
+                    handle,
+                    IPPROTO_IP.0,
+                    IP_MULTICAST_IF,
+                    // https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+                    // a 4-byte IPv4 address in network byte order
+                    Some(idx.to_be_bytes().as_ref()),
+                )
+            },
+            socket2::Domain::IPV6 => unsafe {
+                setsockopt(
+                    handle,
+                    IPPROTO_IPV6.0,
+                    IPV6_MULTICAST_IF,
+                    // https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
+                    // 4-byte interface index of the desired outgoing interface in
+                    // host byte order
+                    // OMG Windows!
+                    Some(idx.to_ne_bytes().as_ref()),
+                )
+            },
+            _ => return Err(io::Error::other("unsupported socket family")),
+        };
+
+        if errno != 0 {
+            let err = unsafe { GetLastError().to_hresult().message() };
+            error!("bind socket to interface failed: {}, errno: {}", err, errno);
+            return Err(new_io_error(err));
         }
     }
+    Ok(())
+}
+
+/// Return true if it's a udp socket
+fn is_udp_socket(socket: SOCKET) -> io::Result<bool> {
+    let mut optval = [0u8; 4];
+    let mut optlen: i32 = 4;
+    let ret = unsafe {
+        getsockopt(
+            socket,
+            SOL_SOCKET,
+            SO_TYPE,
+            PSTR::from_raw(optval.as_mut_ptr()),
+            &mut optlen,
+        )
+    };
+    if ret != 0 {
+        let last_err = io::Error::last_os_error();
+        tracing::warn!(
+            "getsockopt failed when determining socket type: {:?}",
+            last_err
+        );
+        return Err(last_err);
+    }
+    Ok(WINSOCK_SOCKET_TYPE(i32::from_ne_bytes(optval)) == SOCK_DGRAM)
 }

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -132,6 +132,14 @@ pub async fn new_udp_socket(
                         error!("failed to bind socket to interface: {}", x);
                     },
                 )?;
+                // binding is not necessary for linux but is required on windows
+                // Without binding local_addr can't be obtained by system call
+                // which is required on quinn.
+                #[cfg(target_os = "windows")]
+                if let Some(addr) = src {
+                    socket.bind(&socket2::SockAddr::from(addr))?;
+                }
+
                 trace!(iface = ?iface, "udp socket bound: {socket:?}");
             }
             (Some(src), None) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->
1. invoke bind operation even bind to interface is enabled on windows
2. Adding bind to interface for UDP multicast on windows
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
#933 
<!--
1. Put the related issue or discussion links here.
3. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
4. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
