### PR TITLE
fix(tproxy): using raw socket to sending packet to local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ dependencies = [
  "educe 0.6.0",
  "env_logger",
  "erased-serde",
+ "etherparse 0.12.0",
  "filetime",
  "futures",
  "h2",
@@ -2368,6 +2369,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "etherparse"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb08c4aab4e2985045305551e67126b43f1b6b136bc4e1cd87fb0327877a611"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -33,7 +33,9 @@ ssh = ["dep:russh", "dep:dirs", "dep:totp-rs"]
 onion = ["dep:arti-client", "dep:tor-rtcompat", "arti-client/onion-service-client"]
 shadowquic = ["dep:shadowquic"]
 wireguard = ["dep:boringtun", "dep:smoltcp"]
-tproxy = ["tun"]
+tproxy = [
+    "dep:etherparse",
+]
 tun = [
     "dep:tun-rs",
     "dep:watfaq-netstack",
@@ -194,6 +196,8 @@ downcast-rs = "2.0"
 # workaround for https://github.com/cross-rs/cross/issues/16
 aws-lc-rs = { version = "1", default-features = false, optional = true, features = ["bindgen"] }
 
+# tproxy
+etherparse = {version = "0.12", optional = true }
 [dev-dependencies]
 tempfile = "3.23"
 mockall = "0.14.0"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
#974 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
As stated in #974 , Using `bind nonlocal socket` may collide with other process. This PR fixes this by using raw socket 
to sending udp packet back to local clients. 

This requires to construct a UDP packet  manually. So etherparse package is used to build IP header and UDP header.

<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
