### PR TITLE
fix: dns not using fw_mark

### DIFF
--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -61,6 +61,7 @@ pub struct Config {
     pub hosts: Option<trie::StringTrie<IpAddr>>,
     pub nameserver_policy: HashMap<String, NameServer>,
     pub edns_client_subnet: Option<EdnsClientSubnet>,
+    pub fw_mark: Option<u32>,
 }
 
 impl Config {
@@ -281,6 +282,7 @@ impl TryFrom<&crate::config::def::Config> for Config {
         Ok(Self {
             enable: dc.enable,
             ipv6: c.ipv6 && dc.ipv6,
+            fw_mark: c.routing_mark,
             nameserver: nameservers,
             fallback,
             fallback_filter: dc.fallback_filter.clone().into(),

--- a/clash-lib/src/app/dns/dhcp.rs
+++ b/clash-lib/src/app/dns/dhcp.rs
@@ -38,6 +38,7 @@ struct Inner {
 
 pub struct DhcpClient {
     iface: OutboundInterface,
+    fw_mark: Option<u32>,
 
     inner: Mutex<Inner>,
 }
@@ -72,7 +73,7 @@ impl Client for DhcpClient {
 }
 
 impl DhcpClient {
-    pub async fn new(iface: &str) -> Self {
+    pub async fn new(iface: &str, fw_mark: Option<u32>) -> Self {
         let iface = get_interface_by_name(iface)
             .unwrap_or_else(|| panic!("can not find interface: {iface}"));
         Self {
@@ -83,6 +84,7 @@ impl DhcpClient {
                 dns_expires_at: Instant::now(),
                 iface_addr: ipnet::IpNet::default(),
             }),
+            fw_mark,
         }
     }
 
@@ -104,6 +106,7 @@ impl DhcpClient {
                 None,
                 HashMap::new(),
                 None,
+                self.fw_mark,
             )
             .await;
         }

--- a/clash-lib/src/app/dns/helper.rs
+++ b/clash-lib/src/app/dns/helper.rs
@@ -19,6 +19,7 @@ pub async fn make_clients(
     resolver: Option<Arc<dyn ClashResolver>>,
     outbounds: HashMap<String, Arc<dyn crate::proxy::OutboundHandler>>,
     edns_client_subnet: Option<EdnsClientSubnet>,
+    fw_mark: Option<u32>,
 ) -> Vec<ThreadSafeDNSClient> {
     let mut rv = Vec::new();
 
@@ -58,6 +59,7 @@ pub async fn make_clients(
                 .cloned(),
             proxy,
             ecs: edns_client_subnet.clone(),
+            fw_mark,
         })
         .await
         {

--- a/clash-lib/src/app/dns/resolver/enhanced.rs
+++ b/clash-lib/src/app/dns/resolver/enhanced.rs
@@ -69,6 +69,7 @@ impl EnhancedResolver {
                 None,
                 HashMap::new(),
                 None,
+                None,
             )
             .await,
             fallback: None,
@@ -98,6 +99,7 @@ impl EnhancedResolver {
                 None,
                 outbounds.clone(),
                 edns_client_subnet.clone(),
+                cfg.fw_mark,
             )
             .await,
             fallback: None,
@@ -118,6 +120,7 @@ impl EnhancedResolver {
                 Some(default_resolver.clone()),
                 outbounds.clone(),
                 edns_client_subnet.clone(),
+                cfg.fw_mark,
             )
             .await,
             hosts: cfg.hosts,
@@ -128,6 +131,7 @@ impl EnhancedResolver {
                         Some(default_resolver.clone()),
                         outbounds.clone(),
                         edns_client_subnet.clone(),
+                        cfg.fw_mark,
                     )
                     .await,
                 )
@@ -188,6 +192,7 @@ impl EnhancedResolver {
                                 Some(default_resolver.clone()),
                                 outbounds.clone(),
                                 edns_client_subnet.clone(),
+                                cfg.fw_mark,
                             )
                             .await,
                         ),
@@ -725,6 +730,7 @@ mod tests {
             iface: None,
             proxy: get_default_outbound(),
             ecs: None,
+            fw_mark: None,
         })
         .await
         .expect("build client");
@@ -743,6 +749,7 @@ mod tests {
             iface: None,
             proxy: get_default_outbound(),
             ecs: None,
+            fw_mark: None,
         })
         .await
         .expect("build client");
@@ -761,6 +768,7 @@ mod tests {
             iface: None,
             proxy: get_default_outbound(),
             ecs: None,
+            fw_mark: None,
         })
         .await
         .expect("build client");
@@ -781,6 +789,7 @@ mod tests {
             iface: None,
             proxy: get_default_outbound(),
             ecs: None,
+            fw_mark: None,
         })
         .await
         .expect("build client");
@@ -799,6 +808,7 @@ mod tests {
             iface: None,
             proxy: get_default_outbound(),
             ecs: None,
+            fw_mark: None,
         })
         .await
         .expect("build client");

--- a/clash-lib/src/proxy/tproxy/mod.rs
+++ b/clash-lib/src/proxy/tproxy/mod.rs
@@ -142,6 +142,7 @@ impl InboundHandlerTrait for TproxyInbound {
 
         handle_inbound_datagram(
             self.allow_lan,
+            self.fw_mark,
             Arc::new(listener),
             self.dispatcher.clone(),
         )
@@ -171,6 +172,7 @@ fn bind_nonlocal_socket(src_addr: SocketAddr) -> io::Result<UdpSocket> {
 
 async fn handle_inbound_datagram(
     _allow_lan: bool,
+    fw_mark: Option<u32>,
     socket: Arc<unix_udp_sock::UdpSocket>,
     dispatcher: Arc<Dispatcher>,
 ) -> std::io::Result<()> {
@@ -188,6 +190,7 @@ async fn handle_inbound_datagram(
     let sess = Session {
         network: Network::Udp,
         typ: Type::Tproxy,
+        so_mark: fw_mark,
         ..Default::default()
     };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
DNS is not using fw_mark. This PR should fix.

Note that system resolver resolve dns through system call. So we can't control the traffic fw_mark or outbound interface
<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Changelog is provided or not needed
