### PR TITLE
refactor: use OS-specific network interface priority lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cfb-mode",
+ "cfg-if",
  "chacha20poly1305",
  "chrono",
  "console-subscriber",
@@ -9376,7 +9377,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -197,6 +197,9 @@ aws-lc-rs = { version = "1", default-features = false, optional = true, features
 
 # tproxy
 etherparse = {version = "0.12", optional = true }
+
+# Patterns
+cfg-if = "1"
 [dev-dependencies]
 tempfile = "3.24"
 mockall = "0.14.0"

--- a/clash-lib/src/app/net/mod.rs
+++ b/clash-lib/src/app/net/mod.rs
@@ -143,17 +143,40 @@ pub fn get_outbound_interface() -> Option<OutboundInterface> {
         })
         .collect::<Vec<_>>();
 
-    let priority = [
-        "eth",
-        "en",
-        "pdp_ip",
-        "WLAN",
-        "wlp",
-        "Ethernet",
-        "vEthernet",
-        "Wi-Fi",
-        "Tailscale",
-    ];
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "android")] {
+            let priority = [
+                "wlan", // Android Wi-Fi interface
+                "rmnet", // Android mobile data interface
+            ];
+        } else if #[cfg(target_os = "windows")] {
+            let priority = [
+                "Ethernet",
+                "Wi-Fi",
+                "Tailscale",
+            ];
+        }
+        else if #[cfg(target_os = "linux")] {
+            let priority = [
+                "eth",
+                "wlp",
+                "en",
+                "Tailscale",
+            ];
+        } else if #[cfg(target_os = "macos")] {
+            let priority = [
+                "en",
+                "pdp_ip",
+                "Tailscale",
+            ];
+        } else {
+            let priority = [
+                "eth",
+                "en",
+                "wlp",
+            ];
+        }
+    }
 
     all_outbounds.sort_by(|left, right| {
         match (left.addr_v6, right.addr_v6) {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Refactoring
- [x] Enhancement feature

### 🔗 Related issue link

N/A

### 💡 Background and solution

**Background:**

The previous implementation used a single hardcoded priority list for network interface selection that included interface names from all platforms (Windows, Linux, macOS, Android, etc.). This approach was not optimal as:

1. It mixed interface naming conventions from different operating systems
2. It could lead to incorrect interface selection on specific platforms
3. It was harder to maintain and understand

**Solution:**

Refactored the interface priority configuration to use OS-specific priority lists via the `cfg-if` macro:

- **Android**: Prioritizes `wlan` (Wi-Fi) and `rmnet` (mobile data) interfaces
- **Windows**: Prioritizes `Ethernet` and `Wi-Fi` interfaces
- **Linux**: Prioritizes common Linux naming patterns (`eth`, `wlp`, `en`)
- **macOS**: Prioritizes Apple's interface naming (`en`, `pdp_ip`)
- **Fallback**: Generic list for other/unknown platforms

This ensures that the most appropriate network interface is selected based on each platform's specific naming conventions and typical usage patterns.

### 📝 Changelog

**Changed:**
- Network interface priority is now platform-specific, improving interface selection accuracy on all supported operating systems
- Added `cfg-if` crate as a dependency for cleaner conditional compilation

**Impact:**
- Users on different platforms should experience more reliable outbound interface selection
- No breaking changes to the API or configuration format
- Behavior remains the same from user perspective, but with improved accuracy

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed