### PR TITLE
refactor(log): don't display IP if it isn't not present

### DIFF
--- a/clash-lib/src/session.rs
+++ b/clash-lib/src/session.rs
@@ -469,14 +469,18 @@ impl Default for Session {
 
 impl Display for Session {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "[{}] {} -> {}[{}]",
-            self.network,
-            self.source,
-            self.destination,
-            self.resolved_ip.unwrap_or(IpAddr::V4(Ipv4Addr::from(0)))
-        )
+        match self.resolved_ip {
+            Some(ip) => write!(
+                f,
+                "[{}] {} -> {}[{}]",
+                self.network, self.source, self.destination, ip
+            ),
+            None => write!(
+                f,
+                "[{}] {} -> {}",
+                self.network, self.source, self.destination,
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Simplified the `Display` implementation for `Session` by directly using the bound variable `ip` in the `Some(ip)` match arm, instead of unnecessarily calling `unwrap_or` on `self.resolved_ip`.

### 📝 Changelog

Minor code simplification, no functional changes or breaking changes.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed