### PR TITLE
fix(tun): wait for tun visibility before adding routes

### DIFF
--- a/clash-lib/src/proxy/tun/inbound.rs
+++ b/clash-lib/src/proxy/tun/inbound.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use futures::{SinkExt, StreamExt};
-use std::sync::Arc;
+use std::{sync::Arc, thread::sleep, time::Duration};
 use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
@@ -142,6 +142,24 @@ pub fn get_runner(
             let dev = tun_builder.build_async()?;
 
             if !tun_exist {
+                let mut tun_visible = false;
+                for _ in 0..40 {
+                    tun_visible = network_interface::NetworkInterface::show()
+                        .map(|ifs| ifs.into_iter().any(|x| x.name == tun_name))
+                        .unwrap_or(false);
+                    if tun_visible {
+                        break;
+                    }
+                    sleep(Duration::from_millis(50));
+                }
+
+                if !tun_visible {
+                    return Err(Error::Operation(format!(
+                        "tun device {} not visible after waiting 2000ms",
+                        tun_name
+                    )));
+                }
+
                 info!("setting up routes for tun {}", &tun_name);
                 maybe_add_routes(&cfg, &tun_name)?;
             } else {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

fix #1032 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. Provider a sample config if you can.
3. How to fix the problem, and list the final implementation and usage sample if that is a new feature.
-->

On Linux/systemd, TUN startup can fail intermittently with:

- `tun interface not found`

This happens when route setup runs right after `build_async()`, but the new TUN interface is not yet visible from `NetworkInterface::show()`.

This PR adds a short wait before route setup for newly created TUN interfaces:
- retry up to 40 times, 50ms each (max 2s)
- return a clear error if still not visible

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Fix intermittent TUN startup race on Linux.
- Wait for TUN interface visibility before `maybe_add_routes()`.


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed
