### PR TITLE
feature: support vless reality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "h2",
  "h3 0.0.8",
  "h3-quinn 0.0.10",
+ "hex",
  "hickory-client",
  "hickory-proto",
  "hickory-resolver",
@@ -8139,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "tokio-watfaq-rustls"
 version = "0.26.0"
-source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=638db32084d7ecf9c2660847b55d48d1186b4055#638db32084d7ecf9c2660847b55d48d1186b4055"
+source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=cf8961ac1a36e580d0e38bedc8a41ca4a9b301e8#cf8961ac1a36e580d0e38bedc8a41ca4a9b301e8"
 dependencies = [
  "rustls-pki-types",
  "tokio",
@@ -10028,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "watfaq-rustls"
 version = "0.23.21"
-source = "git+https://github.com/Watfaq/rustls.git?rev=4cae3aa2e84ea29d8a74b495793773bdb0a72206#4cae3aa2e84ea29d8a74b495793773bdb0a72206"
+source = "git+https://github.com/Watfaq/rustls.git?rev=c3ab043d673029d245fd618b9bc86fd6a6109bae#c3ab043d673029d245fd618b9bc86fd6a6109bae"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -10037,6 +10038,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
+ "x25519-dalek",
  "zeroize",
 ]
 

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -68,8 +68,8 @@ rustls = { version = "0.23", default-features = false }
 webpki-roots = "1.0"
 
 # shadow-tls
-tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "638db32084d7ecf9c2660847b55d48d1186b4055", default-features = false, features = ["logging", "tls12"] }
-watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "4cae3aa2e84ea29d8a74b495793773bdb0a72206", default-features = false }
+tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "cf8961ac1a36e580d0e38bedc8a41ca4a9b301e8", default-features = false, features = ["logging", "tls12"] }
+watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "c3ab043d673029d245fd618b9bc86fd6a6109bae", default-features = false }
 
 # Error handing & logging
 thiserror = "2"
@@ -98,6 +98,7 @@ lru_time_cache = "0.11"
 uuid = { version = "1", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 network-interface = { version = "2" }
 base64 = "0.22"
+hex = "0.4"
 zstd = "0.13"
 portable-atomic = { version = "1", features = ["serde"] }
 

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -231,6 +231,13 @@ pub struct GrpcOpt {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
+pub struct RealityOpt {
+    pub public_key: String,
+    pub short_id: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
+#[serde(rename_all = "kebab-case")]
 pub struct OutboundTrojan {
     #[serde(flatten)]
     pub common_opts: CommonConfigOptions,
@@ -279,6 +286,9 @@ pub struct OutboundVless {
     pub ws_opts: Option<WsOpt>,
     pub h2_opts: Option<H2Opt>,
     pub grpc_opts: Option<GrpcOpt>,
+    pub reality_opts: Option<RealityOpt>,
+    pub flow: Option<String>,
+    pub client_fingerprint: Option<String>,
 }
 
 #[cfg(feature = "wireguard")]

--- a/clash-lib/src/proxy/converters/utils.rs
+++ b/clash-lib/src/proxy/converters/utils.rs
@@ -1,6 +1,8 @@
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use http::uri::InvalidUri;
 
 use crate::{
+    Error,
     config::proxy::{CommonConfigOptions, GrpcOpt, H2Opt, WsOpt},
     proxy::transport::{self, GrpcClient, H2Client, WsClient},
 };
@@ -70,4 +72,21 @@ impl TryFrom<(&H2Opt, &CommonConfigOptions)> for H2Client {
             path.try_into()?,
         ))
     }
+}
+
+pub fn decode_base64_public_key(base64_public_key: &str) -> Result<[u8; 32], Error> {
+    URL_SAFE_NO_PAD
+        .decode(base64_public_key)
+        .map_err(|e| {
+            Error::InvalidConfig(format!("reality public-key base64: {e}"))
+        })?
+        .try_into()
+        .map_err(|_| {
+            Error::InvalidConfig("reality public-key must decode to 32 bytes".into())
+        })
+}
+
+pub fn decode_short_id(hex_short_id: &str) -> Result<Vec<u8>, Error> {
+    hex::decode(hex_short_id)
+        .map_err(|e| Error::InvalidConfig(format!("reality short-id hex: {e}")))
 }

--- a/clash-lib/src/proxy/converters/vless.rs
+++ b/clash-lib/src/proxy/converters/vless.rs
@@ -3,7 +3,9 @@ use crate::{
     config::internal::proxy::OutboundVless,
     proxy::{
         HandlerCommonOptions,
-        transport::{GrpcClient, H2Client, TlsClient, WsClient},
+        transport::{
+            GrpcClient, H2Client, RealityClient, TlsClient, Transport, WsClient,
+        },
         vless::{Handler, HandlerOptions},
     },
 };
@@ -28,6 +30,69 @@ impl TryFrom<&OutboundVless> for Handler {
                 s.common_opts.server
             );
         }
+
+        if s.client_fingerprint.is_some() {
+            warn!(
+                "client-fingerprint (uTLS) is not yet implemented, ignored for {}",
+                s.common_opts.name
+            );
+        }
+
+        let tls: Option<Box<dyn Transport>> = if let Some(ref reality_opts) =
+            s.reality_opts
+        {
+            // vless with reality
+
+            // reality public-key bytes
+            let pk_bytes =
+                super::utils::decode_base64_public_key(&reality_opts.public_key)?;
+
+            // reality short id bytes
+            let short_id = super::utils::decode_short_id(&reality_opts.short_id)?;
+
+            // SNI
+            let sni = s
+                .server_name
+                .clone()
+                .unwrap_or_else(|| s.common_opts.server.clone());
+
+            Some(Box::new(RealityClient::new(sni, pk_bytes, short_id)))
+        } else {
+            // vless without reality
+            match s.tls.unwrap_or_default() {
+                true => {
+                    let client = TlsClient::new(
+                        s.skip_cert_verify.unwrap_or_default(),
+                        s.server_name.as_ref().map(|x| x.to_owned()).unwrap_or(
+                            s.ws_opts
+                                .as_ref()
+                                .and_then(|x| {
+                                    x.headers.clone().and_then(|x| {
+                                        let h = x.get("Host");
+                                        h.cloned()
+                                    })
+                                })
+                                .unwrap_or(s.common_opts.server.to_owned()),
+                        ),
+                        s.network
+                            .as_ref()
+                            .map(|x| match x.as_str() {
+                                "tcp" => Ok(vec![]),
+                                "ws" => Ok(vec!["http/1.1".to_owned()]),
+                                "http" => Ok(vec![]),
+                                "h2" | "grpc" => Ok(vec!["h2".to_owned()]),
+                                _ => Err(Error::InvalidConfig(format!(
+                                    "unsupported network: {x}"
+                                ))),
+                            })
+                            .transpose()?,
+                        None,
+                    );
+                    Some(Box::new(client))
+                }
+                false => None,
+            }
+        };
 
         Ok(Handler::new(HandlerOptions {
             name: s.common_opts.name.to_owned(),
@@ -87,39 +152,8 @@ impl TryFrom<&OutboundVless> for Handler {
                 })
                 .transpose()?
                 .flatten(),
-            tls: match s.tls.unwrap_or_default() {
-                true => {
-                    let client = TlsClient::new(
-                        s.skip_cert_verify.unwrap_or_default(),
-                        s.server_name.as_ref().map(|x| x.to_owned()).unwrap_or(
-                            s.ws_opts
-                                .as_ref()
-                                .and_then(|x| {
-                                    x.headers.clone().and_then(|x| {
-                                        let h = x.get("Host");
-                                        h.cloned()
-                                    })
-                                })
-                                .unwrap_or(s.common_opts.server.to_owned()),
-                        ),
-                        s.network
-                            .as_ref()
-                            .map(|x| match x.as_str() {
-                                "tcp" => Ok(vec![]),
-                                "ws" => Ok(vec!["http/1.1".to_owned()]),
-                                "http" => Ok(vec![]),
-                                "h2" | "grpc" => Ok(vec!["h2".to_owned()]),
-                                _ => Err(Error::InvalidConfig(format!(
-                                    "unsupported network: {x}"
-                                ))),
-                            })
-                            .transpose()?,
-                        None,
-                    );
-                    Some(Box::new(client))
-                }
-                false => None,
-            },
+            tls,
+            flow: s.flow.clone(),
         }))
     }
 }
@@ -148,6 +182,7 @@ mod tests {
             ws_opts: None,
             h2_opts: None,
             grpc_opts: None,
+            ..Default::default()
         };
 
         let handler = Handler::try_from(&config);
@@ -176,6 +211,7 @@ mod tests {
             ws_opts: None,
             h2_opts: None,
             grpc_opts: None,
+            ..Default::default()
         };
 
         let handler = Handler::try_from(&config);
@@ -204,6 +240,7 @@ mod tests {
             ws_opts: None,
             h2_opts: None,
             grpc_opts: None,
+            ..Default::default()
         };
 
         let handler = Handler::try_from(&config);

--- a/clash-lib/src/proxy/transport/mod.rs
+++ b/clash-lib/src/proxy/transport/mod.rs
@@ -1,17 +1,21 @@
 mod grpc;
 mod h2;
+mod reality;
 mod shadow_tls;
 mod simple_obfs;
 mod sip003;
+pub mod splice_tls;
 mod tls;
 mod v2ray;
 mod ws;
 
 pub use grpc::Client as GrpcClient;
 pub use h2::Client as H2Client;
+pub use reality::Client as RealityClient;
 pub use shadow_tls::Client as Shadowtls;
 pub use simple_obfs::*;
 pub use sip003::Plugin as Sip003Plugin;
+pub use splice_tls::VisionOptions;
 pub use tls::Client as TlsClient;
 pub use v2ray::{V2RayOBFSOption, V2rayWsClient};
 pub use ws::Client as WsClient;
@@ -22,4 +26,15 @@ pub trait Transport: Send + Sync {
         &self,
         stream: super::AnyStream,
     ) -> std::io::Result<super::AnyStream>;
+
+    /// Like `proxy_stream`, but additionally returns a `VisionOptions` for
+    /// transports that support XTLS-splice (Reality).  The default
+    /// implementation delegates to `proxy_stream` and returns `None`,
+    /// meaning no splice is available.
+    async fn proxy_stream_spliced(
+        &self,
+        stream: super::AnyStream,
+    ) -> std::io::Result<(super::AnyStream, Option<VisionOptions>)> {
+        Ok((self.proxy_stream(stream).await?, None))
+    }
 }

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -1,0 +1,191 @@
+use async_trait::async_trait;
+use tokio_watfaq_rustls::{TlsConnector, client::TlsStream};
+use watfaq_rustls::{
+    ClientConfig, RootCertStore, client::RealityConfig, pki_types::ServerName,
+};
+
+use std::{
+    io,
+    ops::Deref,
+    sync::{Arc, OnceLock, atomic::AtomicBool},
+};
+
+use crate::proxy::{
+    AnyStream,
+    transport::{Transport, VisionOptions, splice_tls::SplicableTlsStream},
+};
+
+fn init_roots() -> Arc<RootCertStore> {
+    Arc::new(webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect())
+}
+
+#[derive(Clone)]
+pub struct Client(Arc<ClientInner>);
+
+impl Client {
+    pub fn new(sni: String, public_key: [u8; 32], short_id: Vec<u8>) -> Self {
+        Self(Arc::new(ClientInner {
+            sni,
+            public_key,
+            short_id,
+            roots: OnceLock::new(),
+        }))
+    }
+}
+
+impl Deref for Client {
+    type Target = ClientInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Client {
+    /// Connect with Reality TLS and return the concrete `TlsStream` (not
+    /// boxed).  Used by XTLS-Vision splice mode so VisionStream can later
+    /// bypass the TLS layer for raw-copy.
+    pub async fn connect_tls(
+        &self,
+        stream: AnyStream,
+    ) -> io::Result<TlsStream<AnyStream>> {
+        let reality = RealityConfig::new(self.public_key, self.short_id.clone())
+            .map_err(|e| {
+                io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
+            })?;
+
+        let tls_config = ClientConfig::builder()
+            .with_root_certificates(self.roots.get_or_init(init_roots).clone())
+            .with_reality(reality)
+            .with_no_client_auth();
+
+        let sni: ServerName<'_> =
+            ServerName::try_from(self.sni.clone()).map_err(|e| {
+                io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
+            })?;
+
+        TlsConnector::from(std::sync::Arc::new(tls_config))
+            .connect(sni, stream)
+            .await
+            .map_err(io::Error::other)
+    }
+}
+
+#[async_trait]
+impl Transport for Client {
+    async fn proxy_stream(&self, stream: AnyStream) -> io::Result<AnyStream> {
+        self.connect_tls(stream)
+            .await
+            .map(|x| Box::new(x) as AnyStream)
+    }
+
+    /// Establish a Reality TLS connection and return the stream together with
+    /// `VisionOptions` (a pair of `Arc<AtomicBool>` splice flags) that allow
+    /// the upper `VisionStream` to signal this layer when XTLS-splice mode is
+    /// triggered.
+    ///
+    /// ## Layer stack
+    ///
+    /// ```text
+    ///  VisionStream          (owns VisionOptions – writes the flags)
+    ///    └─ VlessStream      (VLESS framing)
+    ///        └─ SplicableTlsStream  (reads the flags; bypasses TLS when set)
+    ///            └─ Reality TLS
+    ///                └─ TCP
+    /// ```
+    ///
+    /// ## Handshake / splice sequence
+    ///
+    /// ```text
+    ///  Client                                  Xray server
+    ///    |                                          |
+    ///    |---------- Reality TLS handshake -------->|
+    ///    |<--------- Reality TLS handshake ---------|
+    ///    |   (all traffic above is Reality-TLS encrypted)
+    ///    |                                          |
+    ///    |========== Vision framing mode ===========|
+    ///    |--[UUID][CMD=0x00][inner TLS ClientHello]->|  Vision-framed inner TLS
+    ///    |<-[UUID][CMD=0x00][inner TLS ServerHello]--|
+    ///    |<-[CMD=0x02][inner TLS AppData]------------|  server triggers splice
+    ///    |--[CMD=0x02][inner TLS AppData]----------->|  client triggers splice
+    ///    |                                          |
+    ///    |  (both sides received CMD_DIRECT)        |
+    ///    |                                          |
+    ///    |========== Splice mode (raw TCP) ==========|
+    ///    |--[raw inner-TLS AppData]----------------->|  no outer TLS encryption
+    ///    |<-[raw inner-TLS AppData]------------------|
+    /// ```
+    ///
+    /// On `CMD_PADDING_DIRECT` (0x02):
+    /// - `VisionStream` sets `read_flag` / `write_flag` to `true`.
+    /// - `SplicableTlsStream` detects the flags and bypasses Reality TLS,
+    ///   reading/writing raw bytes directly on the TCP socket.
+    async fn proxy_stream_spliced(
+        &self,
+        stream: AnyStream,
+    ) -> io::Result<(AnyStream, Option<VisionOptions>)> {
+        let read_flag = Arc::new(AtomicBool::new(false));
+        let write_flag = Arc::new(AtomicBool::new(false));
+        let tls_stream = self.connect_tls(stream).await?;
+        let splittable = SplicableTlsStream::new(
+            tls_stream,
+            Arc::clone(&read_flag),
+            Arc::clone(&write_flag),
+        );
+        let opts = VisionOptions {
+            read_flag,
+            write_flag,
+        };
+        Ok((Box::new(splittable), Some(opts)))
+    }
+}
+
+pub struct ClientInner {
+    sni: String,
+    public_key: [u8; 32],
+    short_id: Vec<u8>,
+    // cached for performance
+    roots: OnceLock<Arc<RootCertStore>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_stream() -> AnyStream {
+        let (client, _server) = tokio::io::duplex(1024);
+        Box::new(client)
+    }
+
+    #[test]
+    fn test_new() {
+        let c = Client::new("example.com".to_string(), [1u8; 32], vec![0xab, 0xcd]);
+        assert_eq!(c.sni, "example.com");
+        assert_eq!(c.public_key, [1u8; 32]);
+        assert_eq!(c.short_id, vec![0xab, 0xcd]);
+    }
+
+    // short_id > 8 bytes → RealityConfig::new() fails → InvalidInput
+    #[tokio::test]
+    async fn test_short_id_too_long() {
+        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 9]);
+        let err = c.proxy_stream(make_stream()).await.err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    // Invalid SNI → ServerName::try_from fails → InvalidInput
+    #[tokio::test]
+    async fn test_invalid_sni() {
+        let c = Client::new("".to_string(), [0u8; 32], vec![0u8; 4]);
+        let err = c.proxy_stream(make_stream()).await.err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    // Valid params, server side dropped → TLS handshake error (not InvalidInput)
+    #[tokio::test]
+    async fn test_handshake_error_on_closed_peer() {
+        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 4]);
+        let err = c.proxy_stream(make_stream()).await.err().unwrap();
+        assert_ne!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/clash-lib/src/proxy/transport/splice_tls.rs
+++ b/clash-lib/src/proxy/transport/splice_tls.rs
@@ -1,0 +1,167 @@
+/// XTLS-splice capable TLS stream.
+///
+/// Wraps a `TlsStream<AnyStream>` and can switch to raw (bypass-TLS) mode when
+/// signalled via shared `Arc<AtomicBool>` flags.  This is required for
+/// XTLS-Vision: after both sides exchange `CMD_PADDING_DIRECT`, they bypass the
+/// outer Reality-TLS layer and communicate over the raw TCP socket.
+use std::{
+    io::{self, Read},
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, BufMut, BytesMut};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tracing::debug;
+
+use crate::proxy::AnyStream;
+
+pub type RealityTlsStream = tokio_watfaq_rustls::client::TlsStream<AnyStream>;
+
+/// Options passed to `VisionStream` when XTLS-splice mode is active.
+///
+/// Shared `Arc<AtomicBool>` flags are written by `VisionStream` when it
+/// detects `CMD_PADDING_DIRECT`, and read by `SplicableTlsStream` to know
+/// when to bypass the Reality TLS layer.
+pub struct VisionOptions {
+    pub read_flag: Arc<AtomicBool>,
+    pub write_flag: Arc<AtomicBool>,
+}
+
+pub struct SplicableTlsStream {
+    tls: RealityTlsStream,
+
+    // Bytes drained from TLS plaintext buffer on the first raw-read.
+    leftover: BytesMut,
+
+    // Shared with VisionStream: set when CMD_DIRECT is received from server.
+    read_flag: Arc<AtomicBool>,
+    read_spliced: bool,
+
+    // Shared with VisionStream: set when CMD_DIRECT is sent to server.
+    write_flag: Arc<AtomicBool>,
+    write_spliced: bool,
+}
+
+impl SplicableTlsStream {
+    pub fn new(
+        tls: RealityTlsStream,
+        read_flag: Arc<AtomicBool>,
+        write_flag: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            tls,
+            leftover: BytesMut::new(),
+            read_flag,
+            read_spliced: false,
+            write_flag,
+            write_spliced: false,
+        }
+    }
+
+    /// Drain the TLS plaintext buffer into `self.leftover` and flip
+    /// `read_spliced`.  After this, reads go directly to the raw IO.
+    fn activate_read_splice(&mut self) {
+        debug!("SplicableTlsStream: activating read splice (bypassing Reality TLS)");
+        let (_, conn) = self.tls.get_mut();
+        let mut tmp = [0u8; 4096];
+        loop {
+            match conn.reader().read(&mut tmp) {
+                Ok(0) => break,
+                Ok(n) => self.leftover.put_slice(&tmp[..n]),
+                Err(_) => break,
+            }
+        }
+        self.read_spliced = true;
+    }
+
+    fn activate_write_splice(&mut self) {
+        debug!(
+            "SplicableTlsStream: activating write splice (bypassing Reality TLS)"
+        );
+        self.write_spliced = true;
+    }
+}
+
+impl AsyncRead for SplicableTlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        // Check if we need to switch to raw read.
+        if !this.read_spliced && this.read_flag.load(Ordering::Acquire) {
+            this.activate_read_splice();
+        }
+
+        // Return leftover plaintext drained from TLS first.
+        if !this.leftover.is_empty() {
+            let amt = this.leftover.len().min(buf.remaining());
+            buf.put_slice(&this.leftover[..amt]);
+            this.leftover.advance(amt);
+            return Poll::Ready(Ok(()));
+        }
+
+        if this.read_spliced {
+            // Bypass Reality TLS — read raw bytes from the underlying IO.
+            let (io, _) = this.tls.get_mut();
+            Pin::new(io).poll_read(cx, buf)
+        } else {
+            Pin::new(&mut this.tls).poll_read(cx, buf)
+        }
+    }
+}
+
+impl AsyncWrite for SplicableTlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+
+        if !this.write_spliced && this.write_flag.load(Ordering::Acquire) {
+            this.activate_write_splice();
+        }
+
+        if this.write_spliced {
+            // Bypass Reality TLS — write raw bytes to the underlying IO.
+            let (io, _) = this.tls.get_mut();
+            Pin::new(io).poll_write(cx, buf)
+        } else {
+            Pin::new(&mut this.tls).poll_write(cx, buf)
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if this.write_spliced {
+            let (io, _) = this.tls.get_mut();
+            Pin::new(io).poll_flush(cx)
+        } else {
+            Pin::new(&mut this.tls).poll_flush(cx)
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if this.write_spliced {
+            let (io, _) = this.tls.get_mut();
+            Pin::new(io).poll_shutdown(cx)
+        } else {
+            Pin::new(&mut this.tls).poll_shutdown(cx)
+        }
+    }
+}

--- a/clash-lib/src/proxy/vless/mod.rs
+++ b/clash-lib/src/proxy/vless/mod.rs
@@ -1,4 +1,4 @@
-use self::stream::VlessStream;
+use self::{stream::VlessStream, vision::VisionStream};
 use super::{
     AnyStream, ConnectorType, DialWithConnector, HandlerCommonOptions,
     OutboundHandler, OutboundType,
@@ -23,6 +23,7 @@ use tracing::debug;
 
 mod datagram;
 mod stream;
+mod vision;
 
 pub struct HandlerOptions {
     pub name: String,
@@ -33,6 +34,7 @@ pub struct HandlerOptions {
     pub udp: bool,
     pub transport: Option<Box<dyn Transport>>,
     pub tls: Option<Box<dyn Transport>>,
+    pub flow: Option<String>,
 }
 
 pub struct Handler {
@@ -64,10 +66,10 @@ impl Handler {
         sess: &Session,
         is_udp: bool,
     ) -> io::Result<AnyStream> {
-        let s = if let Some(tls) = self.opts.tls.as_ref() {
-            tls.proxy_stream(s).await?
+        let (s, vision_opts) = if let Some(tls) = self.opts.tls.as_ref() {
+            tls.proxy_stream_spliced(s).await?
         } else {
-            s
+            (s, None)
         };
 
         let s = if let Some(transport) = self.opts.transport.as_ref() {
@@ -76,10 +78,23 @@ impl Handler {
             s
         };
 
-        let vless_stream =
-            VlessStream::new(s, &self.opts.uuid, &sess.destination, is_udp)?;
+        let vless_stream = VlessStream::new(
+            s,
+            &self.opts.uuid,
+            &sess.destination,
+            is_udp,
+            self.opts.flow.clone(),
+        )?;
 
-        Ok(Box::new(vless_stream))
+        if self.opts.flow.as_deref() == Some("xtls-rprx-vision") {
+            Ok(Box::new(VisionStream::new(
+                Box::new(vless_stream),
+                self.opts.uuid.clone(),
+                vision_opts,
+            )?))
+        } else {
+            Ok(Box::new(vless_stream))
+        }
     }
 }
 
@@ -269,6 +284,7 @@ mod tests {
             udp: true,
             tls: tls_client(None),
             transport: Some(Box::new(ws_client)),
+            flow: None,
         };
         let handler = Arc::new(Handler::new(opts));
 

--- a/clash-lib/src/proxy/vless/stream.rs
+++ b/clash-lib/src/proxy/vless/stream.rs
@@ -22,6 +22,7 @@ pub struct VlessStream {
     uuid: uuid::Uuid,
     destination: SocksAddr,
     is_udp: bool,
+    flow: Option<String>,
 }
 
 impl VlessStream {
@@ -30,6 +31,7 @@ impl VlessStream {
         uuid: &str,
         destination: &SocksAddr,
         is_udp: bool,
+        flow: Option<String>,
     ) -> io::Result<Self> {
         let uuid = uuid::Uuid::parse_str(uuid).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidInput, "invalid UUID format")
@@ -45,6 +47,7 @@ impl VlessStream {
             uuid,
             destination: destination.clone(),
             is_udp,
+            flow,
         })
     }
 
@@ -52,12 +55,19 @@ impl VlessStream {
         let mut buf = BytesMut::new();
 
         // VLESS request header:
-        // Version (1 byte) + UUID (16 bytes) + Additional info length (1 byte)
-        // + Command (1 byte) + Port (2 bytes) + Address type + Address + Additional
-        //   info
+        // Version (1 byte) + UUID (16 bytes) + Addon length (1 byte)
+        // + Addon bytes (variable) + Command (1 byte) + Port (2 bytes)
+        // + Address type + Address
         buf.put_u8(VLESS_VERSION);
         buf.put_slice(self.uuid.as_bytes());
-        buf.put_u8(0); // Additional info length (0 for simplicity)
+
+        if let Some(ref flow) = self.flow {
+            let addon = build_addon_bytes(flow);
+            buf.put_u8(addon.len() as u8);
+            buf.extend_from_slice(&addon);
+        } else {
+            buf.put_u8(0); // No addon
+        }
 
         if self.is_udp {
             buf.put_u8(VLESS_COMMAND_UDP);
@@ -135,8 +145,9 @@ impl VlessStream {
                 e
             })?;
             debug!(
-                "VLESS additional info received: {} bytes",
-                additional_info_len
+                "VLESS additional info received: {} bytes: {:02x?}",
+                additional_info_len,
+                &additional_info[..additional_info_len.min(32) as usize],
             );
         }
 
@@ -201,5 +212,95 @@ impl AsyncWrite for VlessStream {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// Encode the flow field as a Protobuf field-1 length-delimited value.
+/// Format: [0x0A][varint len][bytes]
+pub(crate) fn build_addon_bytes(flow: &str) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(2 + flow.len());
+    buf.push(0x0A); // field 1, wire type 2 (length-delimited)
+    buf.push(flow.len() as u8); // single-byte varint (flow strings are short)
+    buf.extend_from_slice(flow.as_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::SocksAddr;
+
+    fn dummy_stream() -> AnyStream {
+        let (client, _server) = tokio::io::duplex(1024);
+        Box::new(client)
+    }
+
+    fn tcp_dest() -> SocksAddr {
+        "1.2.3.4:80".parse().unwrap()
+    }
+
+    // --- build_addon_bytes ---
+
+    #[test]
+    fn test_build_addon_bytes_empty_flow() {
+        let addon = build_addon_bytes("");
+        // tag(1) + len(0) = 2 bytes, no payload
+        assert_eq!(addon, vec![0x0A, 0x00]);
+    }
+
+    #[test]
+    fn test_build_addon_bytes_vision_flow() {
+        let flow = "xtls-rprx-vision";
+        let addon = build_addon_bytes(flow);
+        assert_eq!(addon.len(), 2 + flow.len()); // 18 bytes
+        assert_eq!(addon[0], 0x0A); // field-1, wire-type-2 tag
+        assert_eq!(addon[1], flow.len() as u8); // 0x10 = 16
+        assert_eq!(&addon[2..], flow.as_bytes());
+    }
+
+    // --- build_handshake_header ---
+
+    #[test]
+    fn test_handshake_header_no_flow() {
+        let s = VlessStream::new(
+            dummy_stream(),
+            "5415d8e0-df92-3655-afa4-b79de66413f5",
+            &tcp_dest(),
+            false,
+            None,
+        )
+        .unwrap();
+        let hdr = s.build_handshake_header();
+        // byte 17 (0-indexed) is the addon-length byte
+        assert_eq!(hdr[17], 0); // no addon
+    }
+
+    #[test]
+    fn test_handshake_header_with_flow() {
+        let flow = "xtls-rprx-vision";
+        let s = VlessStream::new(
+            dummy_stream(),
+            "5415d8e0-df92-3655-afa4-b79de66413f5",
+            &tcp_dest(),
+            false,
+            Some(flow.to_string()),
+        )
+        .unwrap();
+        let hdr = s.build_handshake_header();
+        let addon_len = hdr[17] as usize;
+        assert_eq!(addon_len, 2 + flow.len()); // 18
+        let addon = &hdr[18..18 + addon_len];
+        assert_eq!(addon[0], 0x0A);
+        assert_eq!(addon[1], flow.len() as u8);
+        assert_eq!(&addon[2..], flow.as_bytes());
+    }
+
+    // --- new() ---
+
+    #[test]
+    fn test_new_invalid_uuid() {
+        let result =
+            VlessStream::new(dummy_stream(), "not-a-uuid", &tcp_dest(), false, None);
+        assert!(result.is_err());
     }
 }

--- a/clash-lib/src/proxy/vless/vision.rs
+++ b/clash-lib/src/proxy/vless/vision.rs
@@ -1,0 +1,600 @@
+use std::{
+    io,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, BufMut, BytesMut};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::proxy::{AnyStream, transport::VisionOptions};
+
+/// Vision command bytes (first byte of each frame header).
+///
+/// Source: Xray-core `proxy/proxy.go` (`CommandPadding*` constants).
+const CMD_PADDING_CONTINUE: u8 = 0x00; // more Vision frames coming
+const CMD_PADDING_END: u8 = 0x01; // last Vision frame, do not splice yet
+const CMD_PADDING_DIRECT: u8 = 0x02; // last Vision frame, enter splice mode
+
+/// TLS ApplicationData record type; triggers the direct-mode transition.
+const TLS_APPLICATION_DATA: u8 = 0x17;
+
+/// Wraps a VLESS stream with Vision framing (xtls-rprx-vision flow).
+///
+/// ## Wire format (Xray-core `XtlsPadding`)
+///
+/// ```text
+/// First frame only:   [UUID: 16 bytes]
+/// Every frame:        [command: u8]
+///                     [content_len: u16 big-endian]
+///                     [padding_len: u16 big-endian]
+///                     [content: content_len bytes]   ← actual TLS record
+///                     [padding: padding_len bytes]   ← random, discarded by receiver
+/// ```
+///
+/// ## Commands
+/// - `0x00` `PaddingContinue`: more Vision frames follow.
+/// - `0x01` `PaddingEnd`:      last Vision frame; stay in framed mode.
+/// - `0x02` `PaddingDirect`:   last Vision frame; enter XTLS-splice (raw) mode.
+///
+/// ## XTLS-splice mode
+/// When CMD_PADDING_DIRECT (0x02) is sent or received, both peers must bypass
+/// the outer Reality TLS layer and communicate over raw TCP.  VisionStream
+/// signals this via optional `Arc<AtomicBool>` flags shared with the
+/// `SplicableTlsStream` that sits below VlessStream in the stack.
+pub struct VisionStream {
+    inner: AnyStream,
+
+    // --- write state ---
+    /// User UUID to prepend to the very first Vision frame, then `None`.
+    user_uuid: Option<[u8; 16]>,
+    /// True once we have sent the first TLS ApplicationData record as a
+    /// Vision `0x02` frame; subsequent writes are raw.
+    write_direct: bool,
+    /// Buffered Vision-framed bytes for the in-progress write.
+    write_buf: BytesMut,
+    /// True when the pending `write_buf` was built from an ApplicationData
+    /// payload, so we flip `write_direct` once the buffer is drained.
+    write_buf_app_data: bool,
+
+    // --- read state ---
+    /// Whether the server's 16-byte UUID prefix has been consumed.
+    server_uuid_consumed: bool,
+    /// Fully decoded payload bytes ready to be returned to the caller.
+    decoded: BytesMut,
+    /// Raw bytes from `inner` that have not yet been Vision-decoded.
+    raw: BytesMut,
+    /// True once the server has switched to XTLS-splice (raw) mode.
+    read_direct: bool,
+
+    // --- XTLS-splice signals (optional, only used with Reality transport) ---
+    /// Set when CMD_DIRECT received from server → underlying TLS must switch
+    /// to raw reads.
+    read_splice_flag: Option<Arc<AtomicBool>>,
+    /// Set when CMD_DIRECT sent to server → underlying TLS must switch to raw
+    /// writes.
+    write_splice_flag: Option<Arc<AtomicBool>>,
+}
+
+impl VisionStream {
+    /// Create a `VisionStream`.
+    ///
+    /// Pass `Some(VisionOptions)` when the underlying transport is Reality, to
+    /// enable XTLS-splice: once `CMD_PADDING_DIRECT` is exchanged, the flags
+    /// inside `opts` signal `SplicableTlsStream` to bypass Reality TLS and
+    /// communicate over raw TCP.  Pass `None` for plain TLS (no splice).
+    pub fn new(
+        inner: AnyStream,
+        uuid: String,
+        opts: Option<VisionOptions>,
+    ) -> io::Result<Self> {
+        let uuid_bytes = uuid::Uuid::parse_str(&uuid)
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "invalid UUID")
+            })?
+            .into_bytes();
+        let (read_splice_flag, write_splice_flag) = opts
+            .map(|o| (Some(o.read_flag), Some(o.write_flag)))
+            .unwrap_or((None, None));
+        Ok(Self {
+            inner,
+            user_uuid: Some(uuid_bytes),
+            write_direct: false,
+            write_buf: BytesMut::new(),
+            write_buf_app_data: false,
+            server_uuid_consumed: false,
+            decoded: BytesMut::new(),
+            raw: BytesMut::new(),
+            read_direct: false,
+            read_splice_flag,
+            write_splice_flag,
+        })
+    }
+
+    /// Build a Vision frame for `data` into `self.write_buf`.
+    fn build_vision_frame(&mut self, data: &[u8]) {
+        let is_first_frame = self.user_uuid.is_some();
+
+        // Prepend UUID on the first frame (cleared immediately after).
+        if let Some(uuid) = self.user_uuid.take() {
+            self.write_buf.put_slice(&uuid);
+        }
+
+        let is_app_data = data.first() == Some(&TLS_APPLICATION_DATA);
+        let command = if is_app_data {
+            CMD_PADDING_DIRECT
+        } else {
+            CMD_PADDING_CONTINUE
+        };
+
+        let content_len = data.len() as u16;
+        // Add random padding only on the first frame for traffic-analysis
+        // resistance; subsequent frames use no padding.
+        let padding_len: u16 = if is_first_frame {
+            rand::random::<u8>() as u16
+        } else {
+            0
+        };
+
+        self.write_buf.put_u8(command);
+        self.write_buf.put_u16(content_len);
+        self.write_buf.put_u16(padding_len);
+        self.write_buf.put_slice(data);
+        for _ in 0..padding_len {
+            self.write_buf.put_u8(rand::random::<u8>());
+        }
+
+        self.write_buf_app_data = is_app_data;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AsyncRead
+// ---------------------------------------------------------------------------
+
+impl AsyncRead for VisionStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut(); // safe: VisionStream is Unpin
+
+        loop {
+            // 1. Return already-decoded data.
+            if !this.decoded.is_empty() {
+                let amt = this.decoded.len().min(buf.remaining());
+                buf.put_slice(&this.decoded[..amt]);
+                this.decoded.advance(amt);
+                return Poll::Ready(Ok(()));
+            }
+
+            // 2. Direct/splice mode: raw passthrough.
+            if this.read_direct {
+                return Pin::new(&mut this.inner).poll_read(cx, buf);
+            }
+
+            // 3. Decode Vision frames from the raw buffer.
+            let changed = decode_vision_frames(
+                &mut this.raw,
+                &mut this.decoded,
+                &mut this.read_direct,
+                &mut this.server_uuid_consumed,
+            );
+
+            // Signal the underlying SplicableTlsStream to bypass TLS.
+            if this.read_direct
+                && let Some(flag) = &this.read_splice_flag
+            {
+                flag.store(true, Ordering::Release);
+            }
+
+            if changed || this.read_direct {
+                continue;
+            }
+
+            // 4. Need more raw bytes — read from inner into a local buffer (avoids
+            //    borrowing `this.raw` and `this.inner` simultaneously).
+            let mut tmp = [0u8; 8192];
+            let mut tmp_buf = ReadBuf::new(&mut tmp);
+            match Pin::new(&mut this.inner).poll_read(cx, &mut tmp_buf) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(())) => {
+                    let filled = tmp_buf.filled();
+                    if filled.is_empty() {
+                        if !this.raw.is_empty() {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "connection closed with incomplete Vision frame",
+                            )));
+                        }
+                        return Poll::Ready(Ok(()));
+                    }
+
+                    this.raw.extend_from_slice(filled);
+                }
+            }
+        }
+    }
+}
+
+/// Drain Vision frames from `raw` into `decoded`.
+///
+/// Returns `true` if any content bytes were produced or `read_direct` was set.
+fn decode_vision_frames(
+    raw: &mut BytesMut,
+    decoded: &mut BytesMut,
+    read_direct: &mut bool,
+    server_uuid_consumed: &mut bool,
+) -> bool {
+    let before = decoded.len();
+
+    loop {
+        // First server frame is preceded by the 16-byte server UUID.
+        if !*server_uuid_consumed {
+            if raw.len() < 16 + 5 {
+                break; // need UUID (16) + frame header (5)
+            }
+            raw.advance(16);
+            *server_uuid_consumed = true;
+        }
+
+        // Frame header: [command:1][content_len:2 BE][padding_len:2 BE]
+        if raw.len() < 5 {
+            break;
+        }
+        let command = raw[0];
+        let content_len = u16::from_be_bytes([raw[1], raw[2]]) as usize;
+        let padding_len = u16::from_be_bytes([raw[3], raw[4]]) as usize;
+
+        if raw.len() < 5 + content_len + padding_len {
+            break; // incomplete frame — wait for more data
+        }
+
+        raw.advance(5);
+        decoded.extend_from_slice(&raw[..content_len]);
+        raw.advance(content_len);
+        raw.advance(padding_len);
+
+        // CMD_PADDING_END (0x01) or CMD_PADDING_DIRECT (0x02): server has
+        // finished sending Vision frames.  Remaining raw bytes are direct.
+        if command == CMD_PADDING_DIRECT || command == CMD_PADDING_END {
+            *read_direct = true;
+            decoded.extend_from_slice(raw);
+            raw.clear();
+            break;
+        }
+    }
+
+    *read_direct || decoded.len() > before
+}
+
+// ---------------------------------------------------------------------------
+// AsyncWrite
+// ---------------------------------------------------------------------------
+
+impl AsyncWrite for VisionStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut(); // safe: VisionStream is Unpin
+
+        // After the splice transition, send raw bytes.
+        if this.write_direct {
+            return Pin::new(&mut this.inner).poll_write(cx, buf);
+        }
+
+        let orig_len = buf.len();
+
+        // Build the Vision frame for `buf` if we don't already have one
+        // pending from a previous Pending-returning call.
+        if this.write_buf.is_empty() {
+            this.build_vision_frame(buf);
+        }
+
+        // Write all pending framed bytes to the inner stream.
+        loop {
+            if this.write_buf.is_empty() {
+                break;
+            }
+            let n = {
+                let pending: &[u8] = &this.write_buf;
+                // `pending` borrows `this.write_buf` (field A)
+                // `&mut this.inner` borrows `this.inner` (field B) — disjoint
+                match Pin::new(&mut this.inner).poll_write(cx, pending) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Ready(Ok(0)) => {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "broken pipe",
+                        )));
+                    }
+                    Poll::Ready(Ok(n)) => n,
+                }
+            }; // `pending` borrow ends here
+            this.write_buf.advance(n);
+        }
+
+        // All framed bytes written.
+        if this.write_buf_app_data {
+            this.write_direct = true;
+            this.write_buf_app_data = false;
+            // Signal the underlying SplicableTlsStream to bypass TLS.
+            if let Some(flag) = &this.write_splice_flag {
+                flag.store(true, Ordering::Release);
+            }
+        }
+        Poll::Ready(Ok(orig_len))
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    const TEST_UUID_STR: &str = "5415d8e0-df92-3655-afa4-b79de66413f5";
+    const TEST_UUID: [u8; 16] = [
+        0x54, 0x15, 0xd8, 0xe0, 0xdf, 0x92, 0x36, 0x55, 0xaf, 0xa4, 0xb7, 0x9d,
+        0xe6, 0x64, 0x13, 0xf5,
+    ];
+
+    fn make_vision_pair() -> (VisionStream, tokio::io::DuplexStream) {
+        let (client, server) = tokio::io::duplex(65536);
+        (
+            VisionStream::new(Box::new(client), TEST_UUID_STR.to_owned(), None)
+                .unwrap(),
+            server,
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Write-side tests
+    // -----------------------------------------------------------------------
+
+    /// Parse a Vision frame starting at `buf[offset]`.
+    /// Returns `(command, content, padding_len, next_offset)`.
+    fn parse_frame(buf: &[u8], offset: usize) -> (u8, Vec<u8>, u16, usize) {
+        let cmd = buf[offset];
+        let clan = u16::from_be_bytes([buf[offset + 1], buf[offset + 2]]) as usize;
+        let plen = u16::from_be_bytes([buf[offset + 3], buf[offset + 4]]) as u16;
+        let content = buf[offset + 5..offset + 5 + clan].to_vec();
+        let next = offset + 5 + clan + plen as usize;
+        (cmd, content, plen, next)
+    }
+
+    #[tokio::test]
+    async fn test_write_first_frame_has_uuid_and_padding() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        let payload = b"hello";
+        vs.write_all(payload).await.unwrap();
+        vs.flush().await.unwrap();
+
+        let mut received = vec![0u8; 65536];
+        let n = server.read(&mut received).await.unwrap();
+        let received = &received[..n];
+
+        // First 16 bytes: UUID
+        assert_eq!(&received[..16], &TEST_UUID);
+
+        // Frame header at offset 16
+        let (cmd, content, plen, _) = parse_frame(received, 16);
+        assert_eq!(cmd, CMD_PADDING_CONTINUE);
+        assert_eq!(content, payload);
+        assert!(plen > 0, "first frame should carry padding");
+    }
+
+    #[tokio::test]
+    async fn test_write_second_frame_no_uuid_no_padding() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        vs.write_all(b"first").await.unwrap();
+        vs.flush().await.unwrap();
+
+        let mut buf = vec![0u8; 65536];
+        server.read(&mut buf).await.unwrap(); // drain first frame
+
+        let payload = b"second";
+        vs.write_all(payload).await.unwrap();
+        vs.flush().await.unwrap();
+
+        let n = server.read(&mut buf).await.unwrap();
+        let received = &buf[..n];
+
+        // No UUID prefix on second frame.
+        let (cmd, content, plen, _) = parse_frame(received, 0);
+        assert_eq!(cmd, CMD_PADDING_CONTINUE);
+        assert_eq!(content, payload);
+        assert_eq!(plen, 0);
+    }
+
+    #[tokio::test]
+    async fn test_write_app_data_uses_direct_command_and_switches_to_raw() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        // Send a fake TLS ApplicationData record.
+        let app_data = [TLS_APPLICATION_DATA, 0x03, 0x03, 0x00, 0x04, 1, 2, 3, 4];
+        vs.write_all(&app_data).await.unwrap();
+        vs.flush().await.unwrap();
+
+        let mut buf = vec![0u8; 65536];
+        let n = server.read(&mut buf).await.unwrap();
+        let received = &buf[..n];
+
+        // UUID prefix on first frame, then CMD_PADDING_DIRECT.
+        assert_eq!(&received[..16], &TEST_UUID);
+        let (cmd, content, ..) = parse_frame(received, 16);
+        assert_eq!(cmd, CMD_PADDING_DIRECT);
+        assert_eq!(content, app_data);
+
+        // Next write must be raw (no Vision framing).
+        let raw_payload = b"raw bytes after splice";
+        vs.write_all(raw_payload).await.unwrap();
+        vs.flush().await.unwrap();
+
+        let n = server.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], raw_payload.as_slice());
+    }
+
+    // -----------------------------------------------------------------------
+    // Read-side tests
+    // -----------------------------------------------------------------------
+
+    /// Build a server-side first Vision frame (with UUID prefix).
+    fn server_first_frame(
+        uuid: &[u8; 16],
+        command: u8,
+        content: &[u8],
+        padding_len: u16,
+    ) -> Vec<u8> {
+        let mut v = uuid.to_vec();
+        v.push(command);
+        v.push((content.len() >> 8) as u8);
+        v.push(content.len() as u8);
+        v.push((padding_len >> 8) as u8);
+        v.push(padding_len as u8);
+        v.extend_from_slice(content);
+        v.resize(v.len() + padding_len as usize, 0x00); // zero padding
+        v
+    }
+
+    /// Build a subsequent Vision frame (no UUID prefix).
+    fn server_frame(command: u8, content: &[u8]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(5 + content.len());
+        v.push(command);
+        v.push((content.len() >> 8) as u8);
+        v.push(content.len() as u8);
+        v.push(0); // padding_len hi
+        v.push(0); // padding_len lo
+        v.extend_from_slice(content);
+        v
+    }
+
+    #[tokio::test]
+    async fn test_read_decodes_first_server_frame() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        let tls_hello = b"server hello";
+        server
+            .write_all(&server_first_frame(
+                &TEST_UUID,
+                CMD_PADDING_CONTINUE,
+                tls_hello,
+                10,
+            ))
+            .await
+            .unwrap();
+
+        let mut out = vec![0u8; 64];
+        let n = vs.read(&mut out).await.unwrap();
+        assert_eq!(&out[..n], tls_hello);
+    }
+
+    #[tokio::test]
+    async fn test_read_skips_padding_in_frames() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        let payload = b"cert data";
+        server
+            .write_all(&server_first_frame(
+                &TEST_UUID,
+                CMD_PADDING_CONTINUE,
+                payload,
+                32,
+            ))
+            .await
+            .unwrap();
+
+        let mut out = vec![0u8; 64];
+        let n = vs.read(&mut out).await.unwrap();
+        assert_eq!(&out[..n], payload);
+    }
+
+    #[tokio::test]
+    async fn test_read_switches_to_direct_on_cmd_direct() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        let tls_finished = b"finished";
+        let raw_after = b"\x17\x03\x03\x00\x05hello";
+
+        // First frame: continue; second frame: direct (triggers splice).
+        let mut msg =
+            server_first_frame(&TEST_UUID, CMD_PADDING_CONTINUE, tls_finished, 0);
+        msg.extend(server_frame(CMD_PADDING_DIRECT, b"last-vision"));
+        msg.extend_from_slice(raw_after);
+        server.write_all(&msg).await.unwrap();
+        drop(server);
+
+        let mut out = Vec::new();
+        vs.read_to_end(&mut out).await.unwrap();
+
+        // Content from both Vision frames, then raw splice bytes.
+        let mut expected = tls_finished.to_vec();
+        expected.extend_from_slice(b"last-vision");
+        expected.extend_from_slice(raw_after);
+        assert_eq!(out, expected);
+    }
+
+    #[tokio::test]
+    async fn test_read_switches_to_direct_on_cmd_end() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        let content = b"end-frame-content";
+        let raw_after = b"direct-data";
+
+        let mut msg = server_first_frame(&TEST_UUID, CMD_PADDING_END, content, 0);
+        msg.extend_from_slice(raw_after);
+        server.write_all(&msg).await.unwrap();
+        drop(server);
+
+        let mut out = Vec::new();
+        vs.read_to_end(&mut out).await.unwrap();
+
+        let mut expected = content.to_vec();
+        expected.extend_from_slice(raw_after);
+        assert_eq!(out, expected);
+    }
+
+    #[tokio::test]
+    async fn test_read_multiple_continue_frames() {
+        let (mut vs, mut server) = make_vision_pair();
+
+        let part1 = b"chunk1";
+        let part2 = b"chunk2";
+
+        let mut msg = server_first_frame(&TEST_UUID, CMD_PADDING_CONTINUE, part1, 0);
+        msg.extend(server_frame(CMD_PADDING_DIRECT, part2));
+        server.write_all(&msg).await.unwrap();
+        drop(server);
+
+        let mut out = Vec::new();
+        vs.read_to_end(&mut out).await.unwrap();
+
+        let mut expected = part1.to_vec();
+        expected.extend_from_slice(part2);
+        assert_eq!(out, expected);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `xtls-rprx-vision` flow for VLESS proxies running over the Reality transport. Prior to this change, configuring `flow: xtls-rprx-vision` had no effect — the flow field was parsed but never used, causing handshake failures when connecting to Xray servers that require Vision framing.

## Background

VLESS+Reality+Vision involves two distinct mechanisms:

**Vision framing** wraps inner TLS handshake records inside a custom frame format:

```
[UUID: 16 bytes — first frame only]
[command: u8]          0x00 continue | 0x01 end | 0x02 direct (splice)
[content_len: u16 BE]
[padding_len: u16 BE]
[content: content_len bytes]
[padding: padding_len bytes — random, discarded by receiver]
```

**XTLS-splice** is triggered when either side sends `CMD_PADDING_DIRECT` (`0x02`). Both peers then bypass the outer Reality TLS layer and communicate over raw TCP, with only the inner TLS providing encryption. On the Xray server side this is done via `UnwrapRawConn()` which strips the Reality connection down to the underlying `net.Conn`.

The root bug: after `CMD_DIRECT` was exchanged, the Xray server wrote raw inner-TLS bytes directly to TCP, but our `rustls` client was still attempting to decrypt them as Reality TLS records:

```
rustls::DecryptError: cannot decrypt peer's message
```

## Layer stack

```
VisionStream                   owns VisionOptions (writes flags)
  └─ VlessStream               VLESS framing + addon encoding
      └─ SplicableTlsStream    reads flags; bypasses Reality TLS when set
          └─ Reality TLS
              └─ TCP
```

## Handshake sequence

```
Client                                      Xray server
  |                                               |
  |---------- Reality TLS handshake ------------>|
  |<--------- Reality TLS handshake -------------|
  |                                               |
  |========= Vision framing mode ================|
  |--[UUID][CMD=0x00][inner TLS ClientHello]----->|
  |<-[UUID][CMD=0x00][inner TLS ServerHello]------|
  |<-[CMD=0x02][inner TLS AppData]----------------|  server triggers splice
  |--[CMD=0x02][inner TLS AppData]--------------->|  client triggers splice
  |                                               |
  |========= Splice mode (raw TCP) ==============|
  |--[raw inner-TLS AppData]--------------------->|  no outer TLS encryption
  |<-[raw inner-TLS AppData]----------------------|
```

## Changes

### `transport/splice_tls.rs` (new)

**`VisionOptions`** — a pair of `Arc<AtomicBool>` splice flags shared between the transport layer and the Vision framing layer:

```rust
pub struct VisionOptions {
    pub read_flag:  Arc<AtomicBool>,
    pub write_flag: Arc<AtomicBool>,
}
```

**`SplicableTlsStream`** — wraps a `TlsStream<AnyStream>` (Reality TLS) and monitors the splice flags. When a flag is set, it bypasses `rustls` and reads/writes directly on the underlying TCP socket via `tls.get_mut().0`. On the read side, any plaintext already buffered inside the TLS session is drained via `conn.reader()` before switching to raw mode.

### `transport/reality.rs`

`RealityClient` now overrides `proxy_stream_spliced` on the `Transport` trait. Instead of boxing the TLS stream opaquely, it:

1. Creates a `read_flag` / `write_flag` pair
2. Establishes the Reality TLS connection as a concrete `TlsStream<AnyStream>`
3. Wraps it in a `SplicableTlsStream` bound to those flags
4. Returns `(AnyStream, Some(VisionOptions))`

### `transport/mod.rs`

`Transport` gains a `proxy_stream_spliced` method with a default implementation that delegates to `proxy_stream` and returns `None` for `VisionOptions`. Only `RealityClient` overrides it; all other transports are unaffected.

```rust
async fn proxy_stream_spliced(
    &self,
    stream: AnyStream,
) -> io::Result<(AnyStream, Option<VisionOptions>)> {
    Ok((self.proxy_stream(stream).await?, None))
}
```

### `vless/vision.rs` (new)

`VisionStream` implements `AsyncRead + AsyncWrite` and handles Vision framing end-to-end.

- **Write path**: wraps each outbound buffer in a Vision frame. The first frame prepends the 16-byte client UUID and includes random padding for traffic-analysis resistance. When the payload is a TLS `ApplicationData` record (`0x17`), `CMD_PADDING_DIRECT` is used and `write_flag` is signalled — subsequent writes go raw.
- **Read path**: buffers raw bytes from the inner stream, decodes Vision frames (skipping padding and the server UUID prefix), and delivers content to the caller. On `CMD_PADDING_DIRECT` or `CMD_PADDING_END`, `read_flag` is signalled and remaining bytes pass through raw.

```rust
// Pass Some(VisionOptions) for Reality (splice enabled), None for plain TLS.
pub fn new(inner: AnyStream, uuid: String, opts: Option<VisionOptions>) -> io::Result<Self>
```

### `vless/stream.rs`

`VlessStream` now encodes the `flow` field into the VLESS request header's addon bytes using protobuf field encoding (`0x0A` + varint length + UTF-8 flow string), as required by the Xray VLESS spec. Previously the addon length was always written as `0`.

### `vless/mod.rs` and `converters/vless.rs`

`inner_proxy_stream` is simplified to a single linear flow with no Reality-specific branching:

```rust
let (s, vision_opts) = if let Some(tls) = self.opts.tls.as_ref() {
    tls.proxy_stream_spliced(s).await?
} else {
    (s, None)
};
// ...
if flow == "xtls-rprx-vision" {
    VisionStream::new(Box::new(vless_stream), uuid, vision_opts)
}
```

`HandlerOptions` no longer carries a redundant `reality_client: Option<Arc<RealityClient>>` field.

## Testing

Unit tests cover Vision framing (`vless/vision.rs`) and VLESS addon encoding (`vless/stream.rs`). End-to-end verification against a live Xray server:

```yaml
- name: vless-reality-vision
  type: vless
  flow: xtls-rprx-vision
  tls: true
  reality-opts:
    public-key: <ed25519-public-key>
    short-id: <hex-short-id>
```

```
curl --proxy http://127.0.0.1:7890 https://www.google.com   # 200
curl --proxy http://127.0.0.1:7890 https://github.com       # 200
curl --proxy http://127.0.0.1:7890 https://ifconfig.me      # <proxy exit IP, not local>
```
