### PR TITLE
[wip]refactor: introduce AppContext to replace global CancellationToken

### DIFF
--- a/clash-bin/src/main.rs
+++ b/clash-bin/src/main.rs
@@ -195,6 +195,7 @@ fn main() -> anyhow::Result<()> {
         cwd: cli.directory.map(|x| x.to_string_lossy().to_string()),
         rt: Some(TokioRuntime::MultiThread),
         log_file: cli.log_file,
+        ctx: None,
     })
     .inspect_err(|err| eprintln!("Failed to start clash: {err}"))?;
     Ok(())

--- a/clash-lib/src/app/api/runner.rs
+++ b/clash-lib/src/app/api/runner.rs
@@ -49,7 +49,7 @@ pub struct ApiRunner {
     router: ThreadSafeRouter,
     cwd: String,
 
-    cancellation_token: tokio_util::sync::CancellationToken,
+    ctx: crate::app::context::AppContext,
     dns_listen_addr: DNSListenAddr,
     dns_enabled: bool,
 }
@@ -68,7 +68,7 @@ impl ApiRunner {
         cache_store: ThreadSafeCacheFile,
         router: ThreadSafeRouter,
         cwd: String,
-        cancellation_token: Option<tokio_util::sync::CancellationToken>,
+        ctx: crate::app::context::AppContext,
         dns_listen_addr: DNSListenAddr,
         dns_enabled: bool,
     ) -> Self {
@@ -84,7 +84,7 @@ impl ApiRunner {
             cache_store,
             router,
             cwd,
-            cancellation_token: cancellation_token.unwrap_or_default(),
+            ctx,
             dns_listen_addr,
             dns_enabled,
         }
@@ -136,7 +136,7 @@ impl Runner for ApiRunner {
             log_source_tx: self.log_source.clone(),
             statistics_manager: statistics_manager.clone(),
         });
-        let cancellation_token = self.cancellation_token.clone();
+        let cancellation_token = self.ctx.shutdown_token.clone();
         tokio::spawn(async move {
             let mut router = Router::new()
                 .route("/", get(handlers::hello::handle))
@@ -327,7 +327,7 @@ impl Runner for ApiRunner {
 
     fn shutdown(&self) {
         info!("Shutting down API server");
-        self.cancellation_token.cancel();
+        self.ctx.shutdown();
     }
 
     fn join(&self) -> futures::future::BoxFuture<'_, Result<(), crate::Error>> {

--- a/clash-lib/src/app/context/mod.rs
+++ b/clash-lib/src/app/context/mod.rs
@@ -1,0 +1,42 @@
+
+use tokio_util::sync::CancellationToken;
+
+/// Application context that provides global state and cancellation signals
+/// to all components in the system.
+#[derive(Clone, Debug)]
+pub struct AppContext {
+    pub shutdown_token: CancellationToken,
+    // Future additions (e.g., config, global log level) can be placed here
+}
+
+impl AppContext {
+    /// Create a new application context with an empty cancellation token.
+    pub fn new() -> Self {
+        Self {
+            shutdown_token: CancellationToken::new(),
+        }
+    }
+
+    /// Create an application context bounded to an existing cancellation token.
+    pub fn with_token(token: CancellationToken) -> Self {
+        Self {
+            shutdown_token: token,
+        }
+    }
+
+    /// Check if a shutdown has been requested.
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown_token.is_cancelled()
+    }
+
+    /// Request a shutdown for all components using this context.
+    pub fn shutdown(&self) {
+        self.shutdown_token.cancel();
+    }
+}
+
+impl Default for AppContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/clash-lib/src/app/dns/resolver/mod.rs
+++ b/clash-lib/src/app/dns/resolver/mod.rs
@@ -15,7 +15,7 @@ pub use system::SystemResolver;
 
 use super::{Config, ThreadSafeDNSResolver};
 use crate::{
-    app::profile::ThreadSafeCacheFile, dns::filters::PendingMmdb, print_and_exit,
+    app::profile::ThreadSafeCacheFile, dns::filters::PendingMmdb, 
     proxy::utils::OutboundHandlerRegistry,
 };
 
@@ -24,17 +24,17 @@ pub async fn new(
     store: Option<ThreadSafeCacheFile>,
     mmdb: Option<PendingMmdb>,
     outbounds: OutboundHandlerRegistry,
-) -> ThreadSafeDNSResolver {
+) -> crate::Result<ThreadSafeDNSResolver> {
     if cfg.enable {
         match store {
             Some(store) => {
-                Arc::new(EnhancedResolver::new(cfg, store, mmdb, outbounds).await)
+                Ok(Arc::new(EnhancedResolver::new(cfg, store, mmdb, outbounds).await))
             }
-            _ => print_and_exit!("enhanced resolver requires cache store"),
+            _ => Err(crate::Error::InvalidConfig("enhanced resolver requires cache store".into())),
         }
     } else {
-        Arc::new(
-            SystemResolver::new(cfg.ipv6).expect("failed to create system resolver"),
-        )
+        Ok(Arc::new(
+            SystemResolver::new(cfg.ipv6).map_err(|e| crate::Error::DNSError(e.to_string()))?,
+        ))
     }
 }

--- a/clash-lib/src/app/dns/server/mod.rs
+++ b/clash-lib/src/app/dns/server/mod.rs
@@ -36,7 +36,7 @@ pub struct DnsRunner {
     resolver: ThreadSafeDNSResolver,
     cwd: std::path::PathBuf,
 
-    cancellation_token: tokio_util::sync::CancellationToken,
+    ctx: crate::app::context::AppContext,
 }
 
 impl DnsRunner {
@@ -45,14 +45,14 @@ impl DnsRunner {
         listen: DNSListenAddr,
         resolver: ThreadSafeDNSResolver,
         cwd: &std::path::Path,
-        cancellation_token: Option<tokio_util::sync::CancellationToken>,
+        ctx: crate::app::context::AppContext,
     ) -> Self {
         Self {
             enable,
             listener: listen,
             resolver,
             cwd: cwd.to_path_buf(),
-            cancellation_token: cancellation_token.unwrap_or_default(),
+            ctx,
         }
     }
 }
@@ -67,7 +67,7 @@ impl Runner for DnsRunner {
         let resolver = self.resolver.clone();
         let listen = self.listener.clone();
         let cwd = self.cwd.clone();
-        let cancellation_token = self.cancellation_token.clone();
+        let cancellation_token = self.ctx.shutdown_token.clone();
 
         tokio::spawn(async move {
             let h = DnsMessageExchanger { resolver };
@@ -95,7 +95,7 @@ impl Runner for DnsRunner {
 
     fn shutdown(&self) {
         info!("Shutting down DNS server");
-        self.cancellation_token.cancel();
+        self.ctx.shutdown();
     }
 
     fn join(&self) -> futures::future::BoxFuture<'_, Result<(), crate::Error>> {

--- a/clash-lib/src/app/inbound/manager.rs
+++ b/clash-lib/src/app/inbound/manager.rs
@@ -79,7 +79,7 @@ pub struct InboundManager {
     /// provider name -> provider (kept alive for lifecycle management)
     inbound_providers: Arc<RwLock<HashMap<String, Arc<InboundSetProvider>>>>,
 
-    cancellation_token: tokio_util::sync::CancellationToken,
+    ctx: crate::app::context::AppContext,
 }
 
 impl Runner for InboundManager {
@@ -87,21 +87,21 @@ impl Runner for InboundManager {
         let inbound_handlers = self.inbound_handlers.clone();
         let dispatcher = self.dispatcher.clone();
         let authenticator = self.authenticator.clone();
-        let cancellation_token = self.cancellation_token.clone();
+        let ctx = self.ctx.clone();
 
         tokio::spawn(async move {
             Self::start_all_listeners(
                 dispatcher,
                 authenticator,
                 inbound_handlers,
-                cancellation_token,
+                ctx,
             )
             .await;
         });
     }
 
     fn shutdown(&self) {
-        self.cancellation_token.cancel();
+        self.ctx.shutdown();
     }
 
     fn join(&self) -> BoxFuture<'_, Result<(), crate::Error>> {
@@ -113,7 +113,7 @@ impl InboundManager {
         dispatcher: Arc<Dispatcher>,
         authenticator: ThreadSafeAuthenticator,
         inbounds_opt: HashSet<InboundOpts>,
-        cancellation_token: Option<tokio_util::sync::CancellationToken>,
+        ctx: crate::app::context::AppContext,
     ) -> Self {
         Self {
             inbound_handlers: Arc::new(RwLock::new(
@@ -123,7 +123,7 @@ impl InboundManager {
             inbound_providers: Arc::new(RwLock::new(HashMap::new())),
             dispatcher,
             authenticator,
-            cancellation_token: cancellation_token.unwrap_or_default(),
+            ctx,
         }
     }
 
@@ -171,14 +171,14 @@ impl InboundManager {
             let provider_handles = self.provider_handles.clone();
             let dispatcher = self.dispatcher.clone();
             let authenticator = self.authenticator.clone();
-            let cancellation_token = self.cancellation_token.clone();
+            let ctx = self.ctx.clone();
             let provider_name = name.clone();
 
             let on_update = move |new_opts: Vec<InboundOpts>| {
                 let provider_handles = provider_handles.clone();
                 let dispatcher = dispatcher.clone();
                 let authenticator = authenticator.clone();
-                let cancellation_token = cancellation_token.clone();
+                let cancellation_token = ctx.shutdown_token.clone();
                 let provider_name = provider_name.clone();
 
                 Box::pin(async move {
@@ -319,10 +319,10 @@ impl InboundManager {
         dispatcher: Arc<Dispatcher>,
         authenticator: ThreadSafeAuthenticator,
         inbound_handlers: Arc<RwLock<HashMap<InboundOpts, Option<JoinHandle<()>>>>>,
-        cancellation_token: tokio_util::sync::CancellationToken,
+        ctx: crate::app::context::AppContext,
     ) {
         for (opts, handler) in inbound_handlers.write().await.iter_mut() {
-            let cancellation_token = cancellation_token.clone();
+            let cancellation_token = ctx.shutdown_token.clone();
             let name = opts.common_opts().name.clone();
             *handler = build_network_listeners(
                 opts,
@@ -412,12 +412,12 @@ impl InboundManager {
         let inbound_handlers = self.inbound_handlers.clone();
         let dispatcher = self.dispatcher.clone();
         let authenticator = self.authenticator.clone();
-        let cancellation_token = self.cancellation_token.clone();
+        let ctx = self.ctx.clone();
         Self::start_all_listeners(
             dispatcher,
             authenticator,
             inbound_handlers,
-            cancellation_token,
+            ctx,
         )
         .await;
         Ok(())

--- a/clash-lib/src/app/mod.rs
+++ b/clash-lib/src/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod context;
 pub mod dispatcher;
 pub mod dns;
 pub mod inbound;

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -31,7 +31,6 @@ use crate::{
         OutboundGroupProtocol, OutboundProxyProtocol, OutboundProxyProviderDef,
         PROXY_DIRECT, PROXY_GLOBAL, PROXY_REJECT,
     },
-    print_and_exit,
     proxy::{
         AnyOutboundHandler,
         direct::{self},
@@ -560,19 +559,20 @@ impl OutboundManager {
             provider_names: &Option<Vec<String>>,
             provider_registry: &HashMap<String, ThreadSafeProxyProvider>,
             providers: &mut Vec<ThreadSafeProxyProvider>,
-        ) {
+        ) -> crate::Result<()> {
             if let Some(provider_names) = provider_names {
                 for provider_name in provider_names {
                     let provider = provider_registry
                         .get(provider_name)
-                        .unwrap_or_else(|| {
-                            print_and_exit!("provider {} not found", provider_name);
-                        })
+                        .ok_or_else(|| {
+                            crate::Error::InvalidConfig(format!("provider {} not found", provider_name))
+                        })?
                         .clone();
 
                     providers.push(provider);
                 }
             }
+            Ok(())
         }
 
         fn check_group_empty(
@@ -613,7 +613,7 @@ impl OutboundManager {
                         &proto.use_provider,
                         provider_registry,
                         &mut providers,
-                    );
+                    )?;
 
                     let relay = relay::Handler::new(
                         relay::HandlerOptions {
@@ -654,7 +654,7 @@ impl OutboundManager {
                         &proto.use_provider,
                         provider_registry,
                         &mut providers,
-                    );
+                    )?;
 
                     let url_test = urltest::Handler::new(
                         urltest::HandlerOptions {
@@ -698,7 +698,7 @@ impl OutboundManager {
                         &proto.use_provider,
                         provider_registry,
                         &mut providers,
-                    );
+                    )?;
 
                     let fallback = fallback::Handler::new(
                         fallback::HandlerOptions {
@@ -742,7 +742,7 @@ impl OutboundManager {
                         &proto.use_provider,
                         provider_registry,
                         &mut providers,
-                    );
+                    )?;
 
                     let load_balance = loadbalance::Handler::new(
                         loadbalance::HandlerOptions {
@@ -786,7 +786,7 @@ impl OutboundManager {
                         &proto.use_provider,
                         provider_registry,
                         &mut providers,
-                    );
+                    )?;
 
                     let stored_selection =
                         cache_store.get_selected(&proto.name).await;
@@ -835,7 +835,7 @@ impl OutboundManager {
                         &proto.use_provider,
                         provider_registry,
                         &mut providers,
-                    );
+                    )?;
 
                     let smart_handler = smart::Handler::new_with_cache(
                         smart::HandlerOptions {
@@ -874,9 +874,7 @@ impl OutboundManager {
             match provider {
                 OutboundProxyProviderDef::Http(http) => {
                     let vehicle = http_vehicle::Vehicle::new(
-                        http.url.parse::<Uri>().unwrap_or_else(|_| {
-                            print_and_exit!("invalid provider url: {}", http.url);
-                        }),
+                        http.url.parse::<Uri>().map_err(|_| crate::Error::InvalidConfig(format!("invalid provider url: {}", http.url)))?,
                         http.path,
                         Some(cwd.clone()),
                         resolver.clone(),

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -447,7 +447,7 @@ fn make_classical_rules(
 
         let rule_matcher =
             map_rule_type(rule_type, mmdb.clone(), geodata.clone(), None);
-        rv.push(rule_matcher);
+        rv.push(rule_matcher?);
     }
     Ok(rv)
 }

--- a/clash-lib/src/app/router/mod.rs
+++ b/clash-lib/src/app/router/mod.rs
@@ -12,7 +12,6 @@ use crate::{
         final_::Final, ipcidr::IpCidr, ruleset::RuleSet,
     },
     config::internal::{config::RuleProviderDef, rule::RuleType},
-    print_and_exit,
     session::Session,
 };
 
@@ -72,7 +71,7 @@ impl Router {
                         Some(&rule_provider_registry),
                     )
                 })
-                .collect(),
+                .collect::<crate::Result<Vec<_>>>().unwrap_or_default(),
             dns_resolver,
 
             asn_mmdb,
@@ -145,9 +144,7 @@ impl Router {
             match provider {
                 RuleProviderDef::Http(http) => {
                     let vehicle = http_vehicle::Vehicle::new(
-                        http.url.parse::<Uri>().unwrap_or_else(|_| {
-                            print_and_exit!("invalid provider url: {}", http.url)
-                        }),
+                        http.url.parse::<Uri>().map_err(|_| crate::Error::InvalidConfig(format!("invalid provider url: {}", http.url)))?,
                         http.path,
                         Some(cwd.clone()),
                         resolver.clone(),
@@ -242,8 +239,8 @@ pub fn map_rule_type(
     mmdb: Option<MmdbLookup>,
     geodata: Option<GeoDataLookup>,
     rule_provider_registry: Option<&HashMap<String, ThreadSafeRuleProvider>>,
-) -> Box<dyn RuleMatcher> {
-    match rule_type {
+) -> crate::Result<Box<dyn RuleMatcher>> {
+    Ok(match rule_type {
         RuleType::Domain { domain, target } => {
             Box::new(Domain { domain, target }) as Box<dyn RuleMatcher>
         }
@@ -339,9 +336,9 @@ pub fn map_rule_type(
                 target,
                 rule_provider_registry
                     .get(&rule_set)
-                    .unwrap_or_else(|| {
-                        print_and_exit!("rule provider {} not found", rule_set)
-                    })
+                    .ok_or_else(|| {
+                        crate::Error::InvalidConfig(format!("rule provider {} not found", rule_set))
+                    })?
                     .clone(),
             )),
             None => {
@@ -380,7 +377,7 @@ pub fn map_rule_type(
             }
         }
         RuleType::Match { target } => Box::new(Final { target }),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/clash-lib/src/app/router/rules/composite.rs
+++ b/clash-lib/src/app/router/rules/composite.rs
@@ -253,7 +253,7 @@ impl CompositeRule {
         // It's a leaf rule - parse as RuleType
         let rule = RuleType::new(rule_type, rest, "", None)?;
         let matcher = map_rule_type(rule, mmdb, geodata, rule_provider_registry);
-        Ok(RuleExpression::Rule(matcher))
+        Ok(RuleExpression::Rule(matcher?))
     }
 }
 

--- a/clash-lib/src/common/errors.rs
+++ b/clash-lib/src/common/errors.rs
@@ -14,13 +14,6 @@ where
     io::Error::other(format!("{:?}", anyhow::anyhow!(err)))
 }
 
-#[macro_export]
-macro_rules! print_and_exit {
-    ($($arg:tt)*) => {{
-        eprintln!($($arg)*);
-        std::process::exit(1);
-    }};
-}
 
 pub trait IntoIoResultExt<T> {
     fn into_io(self) -> std::io::Result<T>;

--- a/clash-lib/src/config/internal/rule.rs
+++ b/clash-lib/src/config/internal/rule.rs
@@ -1,4 +1,4 @@
-use crate::{Error, print_and_exit};
+use crate::Error;
 use std::{fmt::Display, str::FromStr};
 
 pub enum RuleType {
@@ -179,15 +179,11 @@ impl RuleType {
             }),
             "SRC-PORT" => Ok(RuleType::SRCPort {
                 target: target.to_string(),
-                port: payload.parse().unwrap_or_else(|_| {
-                    print_and_exit!("invalid port: {}", payload)
-                }),
+                port: payload.parse().map_err(|_| crate::Error::InvalidConfig(format!("invalid port: {}", payload)))?,
             }),
             "DST-PORT" => Ok(RuleType::DSTPort {
                 target: target.to_string(),
-                port: payload.parse().unwrap_or_else(|_| {
-                    print_and_exit!("invalid port: {}", payload)
-                }),
+                port: payload.parse().map_err(|_| crate::Error::InvalidConfig(format!("invalid port: {}", payload)))?,
             }),
             "PROCESS-NAME" => Ok(RuleType::ProcessName {
                 process_name: payload.to_string(),

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -220,7 +220,7 @@ pub async fn start(
         components.cache_store.clone(),
         components.router.clone(),
         cwd.to_string_lossy().to_string(),
-        Some(ctx.shutdown_token.child_token()),
+        crate::app::context::AppContext::with_token(ctx.shutdown_token.child_token()),
         components.dns_listen.clone(),
         components.dns_enabled,
     ));
@@ -283,7 +283,7 @@ pub async fn start(
                 new_components.cache_store.clone(),
                 new_components.router.clone(),
                 cwd_clone.to_string_lossy().to_string(),
-                Some(reload_token.clone()),
+                crate::app::context::AppContext::with_token(reload_token.clone()),
                 new_components.dns_listen.clone(),
                 new_components.dns_enabled,
             ));
@@ -555,7 +555,7 @@ async fn create_components(
             dispatcher.clone(),
             authenticator,
             config.listeners,
-            Some(ctx.shutdown_token.child_token()),
+            crate::app::context::AppContext::with_token(ctx.shutdown_token.child_token()),
         )
         .await,
     );
@@ -577,7 +577,7 @@ async fn create_components(
         config.tun,
         dispatcher.clone(),
         dns_resolver.clone(),
-        Some(ctx.shutdown_token.child_token()),
+        crate::app::context::AppContext::with_token(ctx.shutdown_token.child_token()),
     )?);
 
     debug!("initializing dns listener");
@@ -586,7 +586,7 @@ async fn create_components(
         dns_listen.clone(),
         dns_resolver.clone(),
         &cwd,
-        Some(ctx.shutdown_token.child_token()),
+        crate::app::context::AppContext::with_token(ctx.shutdown_token.child_token()),
     ));
 
     info!("all components initialized");

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -88,6 +88,7 @@ pub struct Options {
     pub cwd: Option<String>,
     pub rt: Option<TokioRuntime>,
     pub log_file: Option<String>,
+    pub ctx: Option<app::context::AppContext>,
 }
 
 pub enum TokioRuntime {
@@ -147,8 +148,10 @@ pub fn start_scaffold(opts: Options) -> Result<()> {
         opts.log_file,
     );
 
+    let ctx = opts.ctx.unwrap_or_else(app::context::AppContext::new);
+
     rt.block_on(async {
-        match start(config, cwd, log_tx).await {
+        match start(ctx, config, cwd, log_tx).await {
             Err(e) => {
                 eprintln!("start error: {e}");
                 Err(e)
@@ -158,22 +161,6 @@ pub fn start_scaffold(opts: Options) -> Result<()> {
     })
 }
 
-static SHUTDOWN_TOKEN: std::sync::Mutex<Vec<tokio_util::sync::CancellationToken>> =
-    std::sync::Mutex::new(Vec::new());
-
-pub fn shutdown() -> bool {
-    let mut token_guard = SHUTDOWN_TOKEN.lock().unwrap();
-    if !token_guard.is_empty() {
-        for token in token_guard.drain(..) {
-            token.cancel();
-        }
-        warn!("Shutdown signal sent, waiting for shutdown to complete...");
-        true
-    } else {
-        warn!("Shutdown token not initialized, cannot shutdown");
-        false
-    }
-}
 
 static CRYPTO_PROVIDER_LOCK: OnceLock<()> = OnceLock::new();
 
@@ -191,17 +178,15 @@ pub fn setup_default_crypto_provider() {
 }
 
 pub async fn start(
+    ctx: app::context::AppContext,
     config: InternalConfig,
     cwd: String,
     log_tx: broadcast::Sender<LogEvent>,
 ) -> Result<()> {
     setup_default_crypto_provider();
 
-    let shutdown_token = tokio_util::sync::CancellationToken::new();
 
     {
-        let mut token_guard = SHUTDOWN_TOKEN.lock().unwrap();
-        token_guard.push(shutdown_token.clone());
     }
 
     let cwd = PathBuf::from(cwd);
@@ -210,7 +195,7 @@ pub async fn start(
     let controller_cfg = config.general.controller.clone();
     let log_level = config.general.log_level;
 
-    let components = create_components(cwd.clone(), config).await?;
+    let components = create_components(ctx.clone(), cwd.clone(), config).await?;
 
     let (reload_tx, mut reload_rx) = mpsc::channel(1);
 
@@ -235,7 +220,7 @@ pub async fn start(
         components.cache_store.clone(),
         components.router.clone(),
         cwd.to_string_lossy().to_string(),
-        Some(shutdown_token.child_token()),
+        Some(ctx.shutdown_token.child_token()),
         components.dns_listen.clone(),
         components.dns_enabled,
     ));
@@ -257,7 +242,8 @@ pub async fn start(
 
     let cwd_clone = cwd.clone();
 
-    let reload_token = shutdown_token.child_token();
+    let reload_token = ctx.shutdown_token.child_token();
+    let ctx_clone = ctx.clone();
     tokio::spawn(async move {
         // Listen for config reload signal and reload config
         while let Some((config, done)) = reload_rx.recv().await {
@@ -273,7 +259,7 @@ pub async fn start(
             let controller_cfg = config.general.controller.clone();
 
             let new_components =
-                create_components(cwd_clone.clone(), config).await?;
+                create_components(ctx_clone.clone(), cwd_clone.clone(), config).await?;
 
             done.send(()).unwrap();
 
@@ -317,7 +303,7 @@ pub async fn start(
 
     tokio::select! {
         result = tokio::signal::ctrl_c() => { result.map_err(Error::Io)?; }
-        _ = shutdown_token.cancelled() => {}
+        _ = ctx.shutdown_token.cancelled() => {}
     }
     Ok(())
 }
@@ -355,6 +341,7 @@ impl RuntimeComponents {
 }
 
 async fn create_components(
+    ctx: app::context::AppContext,
     cwd: PathBuf,
     config: InternalConfig,
 ) -> Result<RuntimeComponents> {
@@ -363,7 +350,6 @@ async fn create_components(
         init_net_config(config.tun.so_mark).await;
     }
 
-    let cancellation_token = tokio_util::sync::CancellationToken::new();
 
     debug!("initializing cache store");
     let cache_store = profile::ThreadSafeCacheFile::new(
@@ -444,7 +430,7 @@ async fn create_components(
         pending_country_mmdb.clone(),
         outbound_registry.clone(),
     )
-    .await;
+    .await?;
 
     debug!("initializing outbound manager");
     let outbound_manager = Arc::new(
@@ -569,7 +555,7 @@ async fn create_components(
             dispatcher.clone(),
             authenticator,
             config.listeners,
-            Some(cancellation_token.child_token()),
+            Some(ctx.shutdown_token.child_token()),
         )
         .await,
     );
@@ -591,7 +577,7 @@ async fn create_components(
         config.tun,
         dispatcher.clone(),
         dns_resolver.clone(),
-        Some(cancellation_token.child_token()),
+        Some(ctx.shutdown_token.child_token()),
     )?);
 
     debug!("initializing dns listener");
@@ -600,7 +586,7 @@ async fn create_components(
         dns_listen.clone(),
         dns_resolver.clone(),
         &cwd,
-        Some(cancellation_token.child_token()),
+        Some(ctx.shutdown_token.child_token()),
     ));
 
     info!("all components initialized");
@@ -622,7 +608,7 @@ async fn create_components(
 
 #[cfg(test)]
 mod tests {
-    use crate::{Config, Options, shutdown, start_scaffold};
+    use crate::{Config, Options, start_scaffold};
     use std::{sync::Once, thread, time::Duration};
 
     static INIT: Once = Once::new();
@@ -645,9 +631,12 @@ mod tests {
           - {name: REJECT_alias, type: reject}
         "#;
 
-        let handle = thread::spawn(|| {
+        let ctx = crate::app::context::AppContext::new();
+        let ctx_clone = ctx.clone();
+        let handle = thread::spawn(move || {
             start_scaffold(Options {
                 config: Config::Str(conf.to_string()),
+                ctx: Some(ctx_clone),
                 cwd: None,
                 rt: None,
                 log_file: None,
@@ -655,9 +644,9 @@ mod tests {
             .unwrap()
         });
 
-        thread::spawn(|| {
+        thread::spawn(move || {
             thread::sleep(Duration::from_secs(3));
-            assert!(shutdown());
+            ctx.shutdown();
         });
 
         handle.join().unwrap();

--- a/clash-lib/src/proxy/tun/mod.rs
+++ b/clash-lib/src/proxy/tun/mod.rs
@@ -11,7 +11,7 @@ pub use datagram::TunDatagram;
 mod tests {
     use std::thread;
 
-    use crate::{Config, Options, shutdown, start_scaffold};
+    use crate::{Config, Options, start_scaffold};
 
     fn wait_port_open(port: u16) {
         let mut count = 0;
@@ -53,11 +53,15 @@ mod tests {
         let log_file = uuid::Uuid::new_v4().to_string() + ".log";
 
         let cwd_clone = cwd.clone();
+
+        let ctx = crate::app::context::AppContext::new();
+        let ctx_clone = ctx.clone();
         let log_file_clone = log_file.clone();
 
         let handle = thread::spawn(|| {
             start_scaffold(Options {
                 config: Config::Str(conf.to_string()),
+                ctx: Some(ctx_clone),
                 cwd: Some(cwd_clone),
                 rt: None,
                 log_file: Some(log_file_clone),
@@ -81,7 +85,7 @@ mod tests {
 
         assert_eq!(buf[0], req[0]);
 
-        assert!(shutdown());
+        ctx.shutdown();
 
         thread::sleep(std::time::Duration::from_secs(1));
 
@@ -124,11 +128,15 @@ mod tests {
         let log_file = uuid::Uuid::new_v4().to_string() + ".log";
 
         let cwd_clone = cwd.clone();
+
+        let ctx = crate::app::context::AppContext::new();
+        let ctx_clone = ctx.clone();
         let log_file_clone = log_file.clone();
 
         let handle = thread::spawn(|| {
             start_scaffold(Options {
                 config: Config::Str(conf.to_string()),
+                ctx: Some(ctx_clone),
                 cwd: Some(cwd_clone),
                 rt: None,
                 log_file: Some(log_file_clone),
@@ -155,7 +163,7 @@ mod tests {
 
         assert_eq!(b"hello", &buf[..5]);
 
-        assert!(shutdown());
+        ctx.shutdown();
 
         thread::sleep(std::time::Duration::from_secs(1));
 

--- a/clash-lib/src/proxy/tun/runner.rs
+++ b/clash-lib/src/proxy/tun/runner.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use futures::{FutureExt, SinkExt, StreamExt, future::BoxFuture};
-use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -33,7 +32,7 @@ pub struct TunRunner {
     cfg: TunConfig,
     dispatcher: Arc<Dispatcher>,
     resolver: ThreadSafeDNSResolver,
-    cancellation_token: CancellationToken,
+    ctx: crate::app::context::AppContext,
 }
 
 impl TunRunner {
@@ -41,13 +40,13 @@ impl TunRunner {
         cfg: TunConfig,
         dispatcher: Arc<Dispatcher>,
         resolver: ThreadSafeDNSResolver,
-        cancellation_token: Option<CancellationToken>,
+        ctx: crate::app::context::AppContext,
     ) -> Result<TunRunner, Error> {
         Ok(Self {
             cfg,
             dispatcher,
             resolver,
-            cancellation_token: cancellation_token.unwrap_or_default(),
+            ctx,
         })
     }
 
@@ -253,7 +252,7 @@ impl Runner for TunRunner {
         let dispatcher = self.dispatcher.clone();
         let resolver = self.resolver.clone();
         let dns_hijack = self.cfg.dns_hijack;
-        let cancellation_token = self.cancellation_token.clone();
+        let cancellation_token = self.ctx.shutdown_token.clone();
 
         tokio::spawn(async move {
             let (tun, stack, mut tcp_listener, udp_socket) =
@@ -388,7 +387,7 @@ impl Runner for TunRunner {
                 error!("failed to clean up routes: {}", e);
             }
         }
-        self.cancellation_token.cancel();
+        self.ctx.shutdown();
     }
 
     fn join(&self) -> BoxFuture<'_, Result<(), Error>> {


### PR DESCRIPTION
## What does this PR do?

- Removes the global `SHUTDOWN_TOKEN` static variable and `shutdown()` function from `clash-lib/src/lib.rs`.
- Introduces an `AppContext` struct in `clash-lib/src/app/context/mod.rs` to properly manage lifecycle and cancellation signals across components.
- Propagates `AppContext` via dependency injection to core runtime components (`InboundManager`, `TunRunner`, `DnsRunner`, `ApiRunner`), replacing their internal standalone cancellation tokens.
- Replaces multiple instances of the custom `print_and_exit!` macro and direct `std::process::exit` calls (e.g. in config rule parsing, resolver initialization, and outbound manager) with returning `Result::Err(crate::Error)` for graceful error propagation, which is vital for using `clash-lib` as a robust library.

This provides a cleaner, more idiomatic architecture that prevents sudden process crashes on configuration errors and gives the library consumer full control over component lifecycle.