### PR TITLE
fix(dispatcher): canonicalize IPv4-mapped IPv6 UDP dst to prevent EINVAL on bind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,7 +2137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caef6056a5788d05d173cdc3c562ac28ae093828f851f69378b74e4e3d578e41"
 dependencies = [
  "heck",
- "indexmap 2.13.1",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2293,7 +2293,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2674,7 +2674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3759,7 +3759,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4103,7 +4103,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4144,9 +4144,9 @@ checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5009,7 +5009,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6185,7 +6185,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6202,7 +6202,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6280,9 +6280,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6955,7 +6955,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7038,7 +7038,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7400,7 +7400,7 @@ checksum = "191a4f997fef5e095212c5790898516e9567d2d8502c4159317603ff0321e394"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "figment",
  "garde",
@@ -7731,9 +7731,8 @@ dependencies = [
 
 [[package]]
 name = "shadowsocks"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482831bf9d55acf3c98e211b6c852c3dfdf1d1b0d23fdf1d887c5a4b2acad4e4"
+version = "1.25.0"
+source = "git+https://github.com/Watfaq/shadowsocks-rust?rev=dee2d932dc580e0e1b7a5a591ff5f8c51f70495e#dee2d932dc580e0e1b7a5a591ff5f8c51f70495e"
 dependencies = [
  "aes 0.8.4",
  "arc-swap",
@@ -7751,7 +7750,7 @@ dependencies = [
  "notify",
  "percent-encoding",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.10.0",
  "sealed",
  "sendfd",
  "serde",
@@ -8320,7 +8319,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8330,7 +8329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10651,7 +10650,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ warnings = "deny"
 [workspace.lints.clippy]
 redundant_clone = "deny"
 needless_collect = "deny"
+
+[patch.crates-io]
+shadowsocks = { git = "https://github.com/Watfaq/shadowsocks-rust", rev = "dee2d932dc580e0e1b7a5a591ff5f8c51f70495e" }

--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -10,7 +10,7 @@ use crate::{
         def::RunMode,
         internal::proxy::{PROXY_DIRECT, PROXY_GLOBAL},
     },
-    proxy::{AnyInboundDatagram, ClientStream, datagram::UdpPacket},
+    proxy::{AnyInboundDatagram, ClientStream, datagram::UdpPacket, utils::ToCanonical},
     session::{Session, SocksAddr},
 };
 use futures::{SinkExt, StreamExt};
@@ -256,6 +256,16 @@ impl Dispatcher {
         let t1 = tokio::spawn(async move {
             while let Some(mut packet) = local_r.next().await {
                 let mut sess = sess.clone();
+
+                // Canonicalize IPv4-mapped IPv6 destination addresses to plain
+                // IPv4.  Some SS2022 inbound paths produce ::ffff:x.x.x.x when
+                // the original target was IPv4 (e.g. because the proxy socket is
+                // internally dual-stack).  Without this, new_udp_socket picks
+                // AF_INET6, while bind_addr is still 0.0.0.0 (IPv4), causing
+                // EINVAL on bind.
+                if let crate::session::SocksAddr::Ip(addr) = &mut packet.dst_addr {
+                    *addr = addr.to_canonical();
+                }
 
                 // Preserve the original destination IP before reverse_lookup
                 // may convert it to a domain name (via DNS cache). This is used

--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -257,6 +257,16 @@ impl Dispatcher {
             while let Some(mut packet) = local_r.next().await {
                 let mut sess = sess.clone();
 
+                // Preserve the original destination IP before reverse_lookup
+                // may convert it to a domain name (via DNS cache). This is used
+                // by family_hint_for_session so the outbound socket uses the
+                // same address family as the client requested, rather than
+                // re-resolving the domain to a potentially different family
+                // (e.g. IPv4 1.1.1.1 → domain → AAAA → IPv6 → EINVAL on bind).
+                if let crate::session::SocksAddr::Ip(addr) = &packet.dst_addr {
+                    sess.resolved_ip = Some(addr.ip());
+                }
+
                 let dest = match reverse_lookup(&resolver, &packet.dst_addr).await {
                     Some(dest) => dest,
                     None => {

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -60,28 +60,39 @@ impl futures::Stream for InboundShadowsocksDatagram {
             ..
         } = self.get_mut();
 
-        buf.resize(buf.capacity(), 0);
-        let mut buf = ReadBuf::new(buf);
+        loop {
+            buf.resize(buf.capacity(), 0);
+            let mut read_buf = ReadBuf::new(buf);
 
-        let rv = ready!(socket.poll_recv_from_with_ctrl(cx, &mut buf));
-        debug!("recv udp packet from inbound: {:?}", rv);
+            let rv = ready!(socket.poll_recv_from_with_ctrl(cx, &mut read_buf));
+            debug!("recv udp packet from inbound: {:?}", rv);
 
-        match rv {
-            Ok((n, src, target, _, ctrl)) => Poll::Ready(Some(UdpPacket {
-                data: buf.filled()[..n].to_vec(),
-                src_addr: src.into(),
-                dst_addr: match target {
-                    shadowsocks::relay::Address::SocketAddress(a) => a.into(),
-                    shadowsocks::relay::Address::DomainNameAddress(domain, port) => {
-                        SocksAddr::Domain(domain, port)
-                    }
-                },
-                inbound_user: ctrl.and_then(|c| c.user).map(|u| u.name().to_owned()),
-            })),
-            Err(e) => {
-                error!("failed to receive udp packet: {}", e);
-                // Don't close the stream.
-                Poll::Pending
+            match rv {
+                Ok((n, src, target, _, ctrl)) => {
+                    return Poll::Ready(Some(UdpPacket {
+                        data: read_buf.filled()[..n].to_vec(),
+                        src_addr: src.into(),
+                        dst_addr: match target {
+                            shadowsocks::relay::Address::SocketAddress(a) => a.into(),
+                            shadowsocks::relay::Address::DomainNameAddress(domain, port) => {
+                                SocksAddr::Domain(domain, port)
+                            }
+                        },
+                        inbound_user: ctrl
+                            .and_then(|c| c.user)
+                            .map(|u| u.name().to_owned()),
+                    }))
+                }
+                Err(e) => {
+                    // Log the error but keep the stream alive. Without looping
+                    // here, returning Poll::Pending would leave the task without
+                    // a registered waker (the waker was consumed when data
+                    // arrived), permanently suspending the UDP dispatch loop.
+                    error!("failed to receive udp packet: {}", e);
+                    // Fall through to the next loop iteration: if the socket
+                    // is empty, poll_recv_from_with_ctrl will re-register the
+                    // waker and return Poll::Pending via ready!().
+                }
             }
         }
     }

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -73,15 +73,18 @@ impl futures::Stream for InboundShadowsocksDatagram {
                         data: read_buf.filled()[..n].to_vec(),
                         src_addr: src.into(),
                         dst_addr: match target {
-                            shadowsocks::relay::Address::SocketAddress(a) => a.into(),
-                            shadowsocks::relay::Address::DomainNameAddress(domain, port) => {
-                                SocksAddr::Domain(domain, port)
+                            shadowsocks::relay::Address::SocketAddress(a) => {
+                                a.into()
                             }
+                            shadowsocks::relay::Address::DomainNameAddress(
+                                domain,
+                                port,
+                            ) => SocksAddr::Domain(domain, port),
                         },
                         inbound_user: ctrl
                             .and_then(|c| c.user)
                             .map(|u| u.name().to_owned()),
-                    }))
+                    }));
                 }
                 Err(e) => {
                     // Log the error but keep the stream alive. Without looping

--- a/clash-lib/src/proxy/shadowsocks/inbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/mod.rs
@@ -14,11 +14,6 @@ use crate::{
     },
     session::{Network, Session, SocksAddr, Type},
 };
-
-use aes::{
-    Aes256,
-    cipher::{BlockDecrypt, KeyInit},
-};
 use async_trait::async_trait;
 use shadowsocks::{
     ProxySocket,
@@ -26,8 +21,6 @@ use shadowsocks::{
     context::Context,
     relay::{Address, tcprelay::proxy_stream::server::ProxyServerStream},
 };
-use std::{net::SocketAddr, sync::Arc};
-use tracing::{debug, info, warn};
 
 #[derive(Clone)]
 pub struct ShadowsocksInbound {
@@ -119,40 +112,6 @@ fn build_user_manager(
     Some(Arc::new(mgr))
 }
 
-/// Peek at the first 48 bytes (salt + EIH) of an SS2022 stream and resolve
-/// the authenticated user name without consuming any bytes.
-///
-/// Returns `None` if the stream has fewer than 48 bytes, the cipher is not
-/// AES-256-based (only 2022-blake3-aes-256-gcm is currently supported), or
-/// the EIH doesn't match any registered user.
-async fn peek_user_identity(
-    stream: &tokio::net::TcpStream,
-    server_key_bytes: &[u8],
-    user_manager: &ServerUserManager,
-) -> Option<String> {
-    let mut buf = [0u8; 48];
-    if stream.peek(&mut buf).await.ok()? < 48 {
-        return None;
-    }
-
-    let salt = &buf[0..32];
-    let eih = &buf[32..48];
-
-    // BLAKE3 KDF — exact context string and key material from shadowsocks crate
-    let key_material = [server_key_bytes, salt].concat();
-    let subkey =
-        blake3::derive_key("shadowsocks 2022 identity subkey", &key_material);
-
-    // AES-256-ECB single-block decrypt
-    let cipher = Aes256::new_from_slice(&subkey[0..32]).ok()?;
-    let mut user_hash = aes::Block::default();
-    cipher.decrypt_block_b2b(aes::Block::from_slice(eih), &mut user_hash);
-
-    user_manager
-        .get_user_by_hash(user_hash.as_slice())
-        .map(|u| u.name().to_string())
-}
-
 #[async_trait]
 impl InboundHandlerTrait for ShadowsocksInbound {
     fn handle_tcp(&self) -> bool {
@@ -167,8 +126,6 @@ impl InboundHandlerTrait for ShadowsocksInbound {
         let context = Context::new_shared(shadowsocks::config::ServerType::Server);
         let config = self.build_server_config()?;
         let method = map_cipher(&self.cipher)?;
-
-        // Arc so each spawned task gets a cheap clone instead of a full copy.
         let server_key_bytes: Arc<Vec<u8>> = Arc::new(config.key().to_vec());
 
         let raw_listener = try_create_dualstack_tcplistener(self.addr)?;
@@ -205,7 +162,7 @@ impl InboundHandlerTrait for ShadowsocksInbound {
                     }
 
                     // Spawn immediately so the accept loop is never blocked by
-                    // per-connection I/O (peek, handshake). A stalling client
+                    // per-connection I/O (handshake). A stalling client
                     // only affects its own task.
                     let dispatcher = self.dispatcher.clone();
                     let context = context.clone();
@@ -214,25 +171,27 @@ impl InboundHandlerTrait for ShadowsocksInbound {
                     let fw_mark = self.fw_mark;
 
                     tokio::spawn(async move {
-                        let inbound_user = if let Some(ref m) = mgr {
-                            peek_user_identity(&stream, &key_bytes, m).await
-                        } else {
-                            None
-                        };
-
                         let mut socket =
                             ProxyServerStream::from_stream_with_user_manager(
                                 context,
                                 stream,
                                 method,
                                 &key_bytes,
-                                mgr,
+                                mgr.clone(),
                             );
 
                         let Ok(target) = socket.handshake().await else {
                             warn!("Failed to perform Shadowsocks handshake");
                             return;
                         };
+
+                        // Resolve the authenticated user name from the key
+                        // exposed by the handshake — no manual peek needed.
+                        let inbound_user = socket.user_key().and_then(|key| {
+                            mgr.as_ref()?.users_iter()
+                                .find(|u| u.key() == key)
+                                .map(|u| u.name().to_owned())
+                        });
 
                         debug!("Shadowsocks TCP connection target: {:?}", target);
 

--- a/clash-lib/src/proxy/shadowsocks/inbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/mod.rs
@@ -21,6 +21,8 @@ use shadowsocks::{
     context::Context,
     relay::{Address, tcprelay::proxy_stream::server::ProxyServerStream},
 };
+use std::{net::SocketAddr, sync::Arc};
+use tracing::{debug, info, warn};
 
 #[derive(Clone)]
 pub struct ShadowsocksInbound {


### PR DESCRIPTION
## Problem

The SS2022 inbound path can produce `packet.dst_addr` as `SocksAddr::Ip(SocketAddr::V6(::ffff:x.x.x.x))` even when the original wire encoding used ATYP=0x01 (IPv4). This happens because the underlying dual-stack UDP socket internally represents the address as an IPv4-mapped IPv6 address.

Trace log evidence:
```
created udp socket src=Some(0.0.0.0:0) iface=None family_hint=Some([::ffff:1.1.1.1]:53)
```

The `family_hint` is derived from `sess.resolved_ip` which was set from `addr.ip()` — still `IpAddr::V6(::ffff:1.1.1.1)`. This causes `new_udp_socket` to create an `AF_INET6` socket, but `bind_addr` is `0.0.0.0` (derived from the IPv4 session source). Binding an IPv6 socket to `0.0.0.0:0` returns **EINVAL (os error 22)**, silently dropping all outbound UDP datagrams.

## Fix

Before stashing `resolved_ip` and before `reverse_lookup`, call `addr.to_canonical()` (via the existing `ToCanonical` trait) to convert `::ffff:x.x.x.x → x.x.x.x`. This ensures both `packet.dst_addr` and `sess.resolved_ip` carry a plain IPv4 address, so `new_udp_socket` creates an `AF_INET` socket compatible with the `0.0.0.0` bind address.

For pure IPv4 and pure IPv6 addresses, `to_canonical()` is a no-op — no regression risk.