### PR TITLE
fix(dispatcher): canonicalize IPv4-mapped IPv6 UDP dst to prevent EINVAL on bind

### DIFF
--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -10,7 +10,9 @@ use crate::{
         def::RunMode,
         internal::proxy::{PROXY_DIRECT, PROXY_GLOBAL},
     },
-    proxy::{AnyInboundDatagram, ClientStream, datagram::UdpPacket},
+    proxy::{
+        AnyInboundDatagram, ClientStream, datagram::UdpPacket, utils::ToCanonical,
+    },
     session::{Session, SocksAddr},
 };
 use futures::{SinkExt, StreamExt};
@@ -257,13 +259,14 @@ impl Dispatcher {
             while let Some(mut packet) = local_r.next().await {
                 let mut sess = sess.clone();
 
-                // Preserve the original destination IP before reverse_lookup
-                // may convert it to a domain name (via DNS cache). This is used
-                // by family_hint_for_session so the outbound socket uses the
-                // same address family as the client requested, rather than
-                // re-resolving the domain to a potentially different family
-                // (e.g. IPv4 1.1.1.1 → domain → AAAA → IPv6 → EINVAL on bind).
-                if let crate::session::SocksAddr::Ip(addr) = &packet.dst_addr {
+                // Canonicalize IPv4-mapped IPv6 destination addresses to plain
+                // IPv4 (e.g. SS2022 inbound on a dual-stack socket may produce
+                // ::ffff:x.x.x.x for an IPv4 target), then preserve the IP for
+                // family_hint_for_session before reverse_lookup may replace it
+                // with a domain name.  Without canonicalization, new_udp_socket
+                // picks AF_INET6 while bind_addr is 0.0.0.0, causing EINVAL.
+                if let crate::session::SocksAddr::Ip(addr) = &mut packet.dst_addr {
+                    *addr = addr.to_canonical();
                     sess.resolved_ip = Some(addr.ip());
                 }
 


### PR DESCRIPTION
## Problem

The SS2022 inbound path can produce `packet.dst_addr` as `SocksAddr::Ip(SocketAddr::V6(::ffff:x.x.x.x))` even when the original wire encoding used ATYP=0x01 (IPv4). This happens because the underlying dual-stack UDP socket internally represents the address as an IPv4-mapped IPv6 address.

Trace log evidence:
```
created udp socket src=Some(0.0.0.0:0) iface=None family_hint=Some([::ffff:1.1.1.1]:53)
```

The `family_hint` is derived from `sess.resolved_ip` which was set from `addr.ip()` — still `IpAddr::V6(::ffff:1.1.1.1)`. This causes `new_udp_socket` to create an `AF_INET6` socket, but `bind_addr` is `0.0.0.0` (derived from the IPv4 session source). Binding an IPv6 socket to `0.0.0.0:0` returns **EINVAL (os error 22)**, silently dropping all outbound UDP datagrams.

## Fix

Before stashing `resolved_ip` and before `reverse_lookup`, call `addr.to_canonical()` (via the existing `ToCanonical` trait) to convert `::ffff:x.x.x.x → x.x.x.x`. This ensures both `packet.dst_addr` and `sess.resolved_ip` carry a plain IPv4 address, so `new_udp_socket` creates an `AF_INET` socket compatible with the `0.0.0.0` bind address.

For pure IPv4 and pure IPv6 addresses, `to_canonical()` is a no-op — no regression risk.