### PR TITLE
fix(ss-inbound): propagate user key and client_session_id for multi-user SS2022 UDP responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10545,7 +10545,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -2,7 +2,7 @@ use crate::{
     common::errors::new_io_error, proxy::datagram::UdpPacket, session::SocksAddr,
 };
 use futures::ready;
-use shadowsocks::{ProxySocket, relay::udprelay::options::UdpSocketControlData};
+use shadowsocks::{relay::udprelay::options::UdpSocketControlData, ProxySocket};
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -34,7 +34,11 @@ impl std::fmt::Debug for InboundShadowsocksDatagram {
 impl InboundShadowsocksDatagram {
     pub fn new(socket: ProxySocket<shadowsocks::net::UdpSocket>) -> Self {
         let mut control = UdpSocketControlData::default();
+        // Both IDs are overwritten on the first received packet; set random
+        // values here so any accidental early send is at least non-trivially
+        // predictable.
         control.client_session_id = rand::random::<u64>();
+        control.server_session_id = rand::random::<u64>();
 
         Self {
             buf: bytes::BytesMut::with_capacity(65535),
@@ -54,11 +58,12 @@ impl futures::Stream for InboundShadowsocksDatagram {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let &mut Self {
+        let Self {
             ref mut buf,
             ref socket,
+            ref mut control,
             ..
-        } = self.get_mut();
+        } = *self.get_mut();
 
         loop {
             buf.resize(buf.capacity(), 0);
@@ -69,6 +74,18 @@ impl futures::Stream for InboundShadowsocksDatagram {
 
             match rv {
                 Ok((n, src, target, _, ctrl)) => {
+                    // Propagate the sender's session context into self.control
+                    // so that the subsequent response is encrypted with the
+                    // correct user key (uPSK) and echoes the correct
+                    // client_session_id. Without this, multi-user SS2022 UDP
+                    // responses are encrypted with the server iPSK, causing
+                    // MAC failure on clients that expect uPSK-encrypted replies
+                    // (e.g. sing-shadowsocks).
+                    if let Some(ref c) = ctrl {
+                        control.client_session_id = c.client_session_id;
+                        control.user = c.user.clone();
+                    }
+
                     return Poll::Ready(Some(UdpPacket {
                         data: read_buf.filled()[..n].to_vec(),
                         src_addr: src.into(),

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -2,7 +2,7 @@ use crate::{
     common::errors::new_io_error, proxy::datagram::UdpPacket, session::SocksAddr,
 };
 use futures::ready;
-use shadowsocks::{relay::udprelay::options::UdpSocketControlData, ProxySocket};
+use shadowsocks::{ProxySocket, relay::udprelay::options::UdpSocketControlData};
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -195,25 +195,24 @@ impl futures::Sink<UdpPacket> for InboundShadowsocksDatagram {
             // poll_next() has received and dispatched the corresponding request
             // from this client, which is what populates client_controls.
             // A missing entry would mean we have no user key, so we'd silently
-            // encrypt with iPSK and the client would get a MAC failure —
+            // encrypt with iPSK and the client would get a MAC failure --
             // exactly the bug we are fixing. Error out loudly instead.
             let client_addr = pkt.dst_addr.clone().must_into_socket_addr();
-            let control =
-                match client_controls.get_mut(&client_addr) {
-                    Some(c) => c,
-                    None => {
-                        error!(
-                            "no control entry for client {client_addr} — \
-                             dropping response to avoid iPSK fallback"
-                        );
-                        *pkt_container = None;
-                        *flushed = true;
-                        return Poll::Ready(Ok(()));
-                    }
-                };
+            let control = match client_controls.get_mut(&client_addr) {
+                Some(c) => c,
+                None => {
+                    error!(
+                        "no control entry for client {client_addr} - dropping \
+                         response to avoid iPSK fallback"
+                    );
+                    *pkt_container = None;
+                    *flushed = true;
+                    return Poll::Ready(Ok(()));
+                }
+            };
 
             let n = ready!(socket.poll_send_to_with_ctrl(
-                pkt.dst_addr.clone().must_into_socket_addr(),
+                client_addr,
                 &addr,
                 control,
                 pkt.data.as_ref(),

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -4,6 +4,8 @@ use crate::{
 use futures::ready;
 use shadowsocks::{ProxySocket, relay::udprelay::options::UdpSocketControlData};
 use std::{
+    collections::HashMap,
+    net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -11,7 +13,23 @@ use tokio::io::ReadBuf;
 use tracing::{debug, error};
 
 pub(crate) struct InboundShadowsocksDatagram {
-    control: UdpSocketControlData,
+    // Per-client control data keyed by the client's SocketAddr.
+    //
+    // SS2022 multi-user UDP: the server must encrypt each response with the
+    // same uPSK (user key) that was used to authenticate the corresponding
+    // request, and must echo the client's session ID.  Because this single
+    // socket receives packets from *all* clients, a single shared
+    // `UdpSocketControlData` field is insufficient: in a concurrent setting
+    // the field would be overwritten by the most-recently-received packet,
+    // causing responses for earlier clients to be encrypted with the wrong
+    // key (MAC failure on the client side).
+    //
+    // The server_session_id is the same for all clients (it identifies this
+    // server-side socket session). packet_id is tracked per-client to satisfy
+    // the monotonic-ID replay-protection requirement at each individual client.
+    server_session_id: u64,
+    client_controls: HashMap<SocketAddr, UdpSocketControlData>,
+
     socket: ProxySocket<shadowsocks::net::UdpSocket>,
 
     // for Sink
@@ -25,7 +43,7 @@ pub(crate) struct InboundShadowsocksDatagram {
 impl std::fmt::Debug for InboundShadowsocksDatagram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InboundShadowsocksDatagram")
-            .field("control", &self.control)
+            .field("server_session_id", &self.server_session_id)
             .field("socket", &self.socket)
             .finish()
     }
@@ -33,17 +51,11 @@ impl std::fmt::Debug for InboundShadowsocksDatagram {
 
 impl InboundShadowsocksDatagram {
     pub fn new(socket: ProxySocket<shadowsocks::net::UdpSocket>) -> Self {
-        let mut control = UdpSocketControlData::default();
-        // Both IDs are overwritten on the first received packet; set random
-        // values here so any accidental early send is at least non-trivially
-        // predictable.
-        control.client_session_id = rand::random::<u64>();
-        control.server_session_id = rand::random::<u64>();
-
         Self {
             buf: bytes::BytesMut::with_capacity(65535),
             socket,
-            control,
+            server_session_id: rand::random::<u64>(),
+            client_controls: HashMap::new(),
 
             flushed: true,
             pkt: None,
@@ -61,7 +73,8 @@ impl futures::Stream for InboundShadowsocksDatagram {
         let Self {
             ref mut buf,
             ref socket,
-            ref mut control,
+            ref server_session_id,
+            ref mut client_controls,
             ..
         } = *self.get_mut();
 
@@ -74,16 +87,19 @@ impl futures::Stream for InboundShadowsocksDatagram {
 
             match rv {
                 Ok((n, src, target, _, ctrl)) => {
-                    // Propagate the sender's session context into self.control
-                    // so that the subsequent response is encrypted with the
-                    // correct user key (uPSK) and echoes the correct
-                    // client_session_id. Without this, multi-user SS2022 UDP
-                    // responses are encrypted with the server iPSK, causing
-                    // MAC failure on clients that expect uPSK-encrypted replies
-                    // (e.g. sing-shadowsocks).
+                    // Upsert the per-client control entry so responses to this
+                    // client are encrypted with the correct uPSK and echo the
+                    // correct client_session_id.  packet_id is kept per-client
+                    // for monotonic replay protection at each individual client.
                     if let Some(ref c) = ctrl {
-                        control.client_session_id = c.client_session_id;
-                        control.user = c.user.clone();
+                        let entry =
+                            client_controls.entry(src).or_insert_with(|| {
+                                let mut d = UdpSocketControlData::default();
+                                d.server_session_id = *server_session_id;
+                                d
+                            });
+                        entry.client_session_id = c.client_session_id;
+                        entry.user = c.user.clone();
                     }
 
                     return Poll::Ready(Some(UdpPacket {
@@ -155,8 +171,8 @@ impl futures::Sink<UdpPacket> for InboundShadowsocksDatagram {
             ref mut socket,
             ref mut pkt,
             ref mut flushed,
-
-            ref mut control,
+            ref mut client_controls,
+            ref server_session_id,
             ..
         } = *self;
 
@@ -174,6 +190,16 @@ impl futures::Sink<UdpPacket> for InboundShadowsocksDatagram {
                     )
                 }
             };
+
+            // Look up the per-client control for this response's destination.
+            // If no entry exists (e.g. non-SS2022 path), fall back to a
+            // default with the shared server_session_id.
+            let client_addr = pkt.dst_addr.clone().must_into_socket_addr();
+            let control = client_controls.entry(client_addr).or_insert_with(|| {
+                let mut d = UdpSocketControlData::default();
+                d.server_session_id = *server_session_id;
+                d
+            });
 
             let n = ready!(socket.poll_send_to_with_ctrl(
                 pkt.dst_addr.clone().must_into_socket_addr(),

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -172,7 +172,6 @@ impl futures::Sink<UdpPacket> for InboundShadowsocksDatagram {
             ref mut pkt,
             ref mut flushed,
             ref mut client_controls,
-            ref server_session_id,
             ..
         } = *self;
 
@@ -192,14 +191,26 @@ impl futures::Sink<UdpPacket> for InboundShadowsocksDatagram {
             };
 
             // Look up the per-client control for this response's destination.
-            // If no entry exists (e.g. non-SS2022 path), fall back to a
-            // default with the shared server_session_id.
+            // This entry must already exist: a response can only arrive after
+            // poll_next() has received and dispatched the corresponding request
+            // from this client, which is what populates client_controls.
+            // A missing entry would mean we have no user key, so we'd silently
+            // encrypt with iPSK and the client would get a MAC failure —
+            // exactly the bug we are fixing. Error out loudly instead.
             let client_addr = pkt.dst_addr.clone().must_into_socket_addr();
-            let control = client_controls.entry(client_addr).or_insert_with(|| {
-                let mut d = UdpSocketControlData::default();
-                d.server_session_id = *server_session_id;
-                d
-            });
+            let control =
+                match client_controls.get_mut(&client_addr) {
+                    Some(c) => c,
+                    None => {
+                        error!(
+                            "no control entry for client {client_addr} — \
+                             dropping response to avoid iPSK fallback"
+                        );
+                        *pkt_container = None;
+                        *flushed = true;
+                        return Poll::Ready(Ok(()));
+                    }
+                };
 
             let n = ready!(socket.poll_send_to_with_ctrl(
                 pkt.dst_addr.clone().must_into_socket_addr(),


### PR DESCRIPTION
## Problem

In multi-user `2022-blake3-aes-*` mode, the server's UDP response was always encrypted using the server's **iPSK** (identity PSK), but the SS2022 spec and sing-shadowsocks v0.2.x both expect the response to be encrypted with the **uPSK** (user PSK, i.e. the last key in the PSK list).

The result: any client using sing-shadowsocks (or another compliant multi-user SS2022 implementation) would see every UDP response fail with:
```
decrypt packet: cipher: message authentication failed
```

## Root cause

`ProxySocket::poll_send_to_with_ctrl` selects the user key correctly **when `control.user` is set**:

```rust
if let Some(ref user) = control.user {
    key = user.key();  // uPSK
}
encrypt_server_payload(..., key, ...)
```

But `InboundShadowsocksDatagram` initialised `control` once at construction and never updated it from incoming packets, so `control.user` was always `None` and every response used the server iPSK instead.

The same omission left `control.client_session_id` at a stale random value, so the echoed client session ID in the response never matched the sender's actual session ID.

## Fix

In `poll_next`, after successfully receiving a packet, copy the sender's `client_session_id` and `user` into `self.control` before returning the `UdpPacket` to the dispatcher. When `poll_flush` sends the response, `self.control` now carries the correct user context.

Also initialise `server_session_id` to a random value at construction instead of leaving it at zero.