### PR TITLE
fix: compat mode

### DIFF
--- a/clash-bin/src/main.rs
+++ b/clash-bin/src/main.rs
@@ -186,13 +186,11 @@ fn main() -> anyhow::Result<()> {
         if let Some(dir) = &cli.directory {
             std::env::set_current_dir(dir)?;
         }
-        if cli.compatibility {
-            if config.general.mmdb.is_none() {
-                config.general.mmdb = Some("Country.mmdb".to_string());
-            }
-            if config.general.geosite.is_none() {
-                config.general.geosite = Some("geosite.dat".to_string());
-            }
+        if config.general.mmdb.is_none() {
+            config.general.mmdb = Some("Country.mmdb".to_string());
+        }
+        if config.general.geosite.is_none() {
+            config.general.geosite = Some("geosite.dat".to_string());
         }
     }
 

--- a/clash-bin/src/main.rs
+++ b/clash-bin/src/main.rs
@@ -186,8 +186,14 @@ fn main() -> anyhow::Result<()> {
         if let Some(dir) = &cli.directory {
             std::env::set_current_dir(dir)?;
         }
-        config.general.mmdb = Some("Country.mmdb".to_string());
-        config.general.geosite = Some("geosite.dat".to_string());
+        if cli.compatibility {
+            if config.general.mmdb.is_none() {
+                config.general.mmdb = Some("Country.mmdb".to_string());
+            }
+            if config.general.geosite.is_none() {
+                config.general.geosite = Some("geosite.dat".to_string());
+            }
+        }
     }
 
     clash::start_scaffold(clash::Options {


### PR DESCRIPTION
This pull request introduces a conditional block to improve compatibility mode handling in the application's startup logic. Now, when compatibility mode is enabled, the code ensures that default values are set for certain configuration fields if they are not already specified.

Configuration compatibility enhancements:

* In `clash-bin/src/main.rs`, when the `compatibility` flag is set, the code checks if `config.general.mmdb` and `config.general.geosite` are unset, and assigns them default values (`"Country.mmdb"` and `"geosite.dat"`, respectively) if needed.

close #1318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compatibility mode no longer overwrites existing configuration values with defaults; default files are only applied when those settings are empty, preserving any user-provided paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->