### PR TITLE
fix: rename user_hosts to use_hosts in DNS config

### DIFF
--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -425,7 +425,7 @@ impl TryFrom<&crate::config::def::Config> for Config {
             fake_ip_filter: dc.fake_ip_filter.clone(),
             store_fake_ip: c.profile.store_fake_ip,
             store_smart_stats: c.profile.store_smart_stats,
-            hosts: if dc.user_hosts && !c.hosts.is_empty() {
+            hosts: if dc.use_hosts && !c.hosts.is_empty() {
                 Config::parse_hosts(&c.hosts).ok()
             } else {
                 let mut tree = trie::StringTrie::new();

--- a/clash-lib/src/config/def.rs
+++ b/clash-lib/src/config/def.rs
@@ -551,9 +551,9 @@ pub struct DNS {
     pub enable: bool,
     /// When false, response to AAAA questions will be empty
     pub ipv6: bool,
-    /// Whether to `Config::hosts` as when resolving hostnames
+    /// Whether to use `Config::hosts` when resolving hostnames
     #[educe(Default = true)]
-    pub user_hosts: bool,
+    pub use_hosts: bool,
     /// DNS servers
     pub nameserver: Vec<String>,
     /// Fallback DNS servers


### PR DESCRIPTION
## Problem

The DNS config struct field was accidentally named `user_hosts` instead of `use_hosts`. Because the struct derives `#[serde(rename_all = "kebab-case")]`, this caused serde to deserialize the field as `user-hosts` rather than the intended `use-hosts`.

All official example configs and source comments already document this field as `use-hosts`:
- `clash-lib/src/config/def.rs` (the inline doc example)
- `clash-bin/tests/data/config/*.yaml` (all test configs)

## Fix

Rename `user_hosts` → `use_hosts` in:
- `clash-lib/src/config/def.rs` — the struct field definition
- `clash-lib/src/app/dns/config.rs` — the one usage site

Also fix the doc comment on the field while here.

## Impact

- Users who had `use-hosts: true` in their config: no change (it was being silently ignored and defaulting to `true` anyway)
- Users who had `use-hosts: false` in their config: this now correctly disables host file lookup (previously it was being ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * DNS configuration option renamed from `user_hosts` to `use_hosts`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->