### PR TITLE
feat: e2e throughput tests for SS outbound + transport Poll::Pending bug fixes

### DIFF
--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -57,6 +57,13 @@ jobs:
           docker pull gists/simple-obfs:latest
           docker pull ghcr.io/ihciah/shadow-tls:latest
 
+      # Download once so parallel clash-rs instances don't race to fetch it
+      - name: Download Country.mmdb
+        run: |
+          mmdb_path="clash-bin/tests/data/config/Country.mmdb"
+          curl -fL https://github.com/Loyalsoldier/geoip/releases/latest/download/Country.mmdb \
+            -o "$mmdb_path"
+
       - name: Run throughput tests
         env:
           THROUGHPUT_RESULTS_FILE: ${{ env.THROUGHPUT_RESULTS_FILE }}

--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -55,6 +55,21 @@ jobs:
       - name: Build clash-rs binary (release)
         run: cargo build --release --bin clash-rs
 
+      - name: Print environment info
+        run: |
+          echo "=== Runner environment ==="
+          echo "OS:     $(uname -a)"
+          echo "CPUs:   $(nproc) logical, $(lscpu | awk '/^Model name/{sub(/.*: */,""); print}')"
+          echo "Memory: $(free -h | awk '/^Mem/{print $2, "total,", $7, "available"}')"
+          echo "Disk:   $(df -h / | awk 'NR==2{print $4, "free on /"}')"
+          echo "=== Docker ==="
+          docker version --format 'Client: {{.Client.Version}}  Server: {{.Server.Version}}'
+          echo "=== Rust ==="
+          rustc --version
+          cargo --version
+          echo "=== Results file will be written to ==="
+          echo "  ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}"
+
       # Pull docker images in advance so test startup is faster
       - name: Pull docker images
         run: |
@@ -71,14 +86,15 @@ jobs:
 
       - name: Run throughput tests
         env:
-          # Use an absolute path so the file lands at a known location
-          # regardless of which directory cargo test sets as the CWD for
-          # the test binary (cargo test -p clash-lib uses clash-lib/ as CWD).
+          # Absolute path: cargo test -p clash-lib sets the test binary's CWD
+          # to clash-lib/, so a relative path would land there instead of the
+          # workspace root.  Using an absolute path avoids this ambiguity.
           THROUGHPUT_RESULTS_FILE: ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}
           RUST_LOG: ${{ env.RUST_LOG }}
           CLASH_RS_CI: "true"
         run: |
           set -o pipefail
+          echo "Results will be written to: ${THROUGHPUT_RESULTS_FILE}"
           RUSTFLAGS="--cfg docker_test --cfg throughput_test" \
           cargo test -p clash-lib --release --all-features \
             e2e_throughput \

--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -63,11 +63,11 @@ jobs:
           RUST_LOG: ${{ env.RUST_LOG }}
           CLASH_RS_CI: "true"
         run: |
+          set -o pipefail
           RUSTFLAGS="--cfg docker_test --cfg throughput_test" \
           cargo test -p clash-lib --release --all-features \
             e2e_throughput \
             -- --test-threads=8 --nocapture 2>&1 | tee throughput-test.log
-        continue-on-error: true
 
       - name: Format results as Markdown
         if: always()
@@ -99,7 +99,7 @@ jobs:
           retention-days: 90
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
   RUST_LOG: "clash_lib=info"
   RUST_TOOLCHAIN: "stable"
-  THROUGHPUT_RESULTS_FILE: throughput-results.json
+  RESULTS_FILE_NAME: throughput-results.json
 
 jobs:
   throughput:
@@ -71,7 +71,10 @@ jobs:
 
       - name: Run throughput tests
         env:
-          THROUGHPUT_RESULTS_FILE: ${{ env.THROUGHPUT_RESULTS_FILE }}
+          # Use an absolute path so the file lands at a known location
+          # regardless of which directory cargo test sets as the CWD for
+          # the test binary (cargo test -p clash-lib uses clash-lib/ as CWD).
+          THROUGHPUT_RESULTS_FILE: ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}
           RUST_LOG: ${{ env.RUST_LOG }}
           CLASH_RS_CI: "true"
         run: |
@@ -84,9 +87,10 @@ jobs:
       - name: Format results as Markdown
         if: always()
         run: |
-          if [ -f "${{ env.THROUGHPUT_RESULTS_FILE }}" ]; then
+          results_file="${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}"
+          if [ -f "$results_file" ]; then
             python3 bench/format_throughput.py \
-              "${{ env.THROUGHPUT_RESULTS_FILE }}" \
+              "$results_file" \
               --output throughput-comment.md
             # Also write to GitHub step summary
             cat throughput-comment.md >> $GITHUB_STEP_SUMMARY
@@ -105,7 +109,7 @@ jobs:
         with:
           name: throughput-results
           path: |
-            throughput-results.json
+            ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}
             throughput-comment.md
             throughput-test.log
           retention-days: 90

--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
   RUST_LOG: "clash_lib=info"
   RUST_TOOLCHAIN: "stable"
-  RESULTS_FILE_NAME: throughput-results.json
+  THROUGHPUT_RESULTS_FILE: ${{ github.workspace }}/throughput-results.json
 
 jobs:
   throughput:
@@ -68,7 +68,7 @@ jobs:
           rustc --version
           cargo --version
           echo "=== Results file will be written to ==="
-          echo "  ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}"
+          echo "  ${{ env.THROUGHPUT_RESULTS_FILE }}"
 
       # Pull docker images in advance so test startup is faster
       - name: Pull docker images
@@ -88,8 +88,8 @@ jobs:
         env:
           # Absolute path: cargo test -p clash-lib sets the test binary's CWD
           # to clash-lib/, so a relative path would land there instead of the
-          # workspace root.  Using an absolute path avoids this ambiguity.
-          THROUGHPUT_RESULTS_FILE: ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}
+          # workspace root.  The workflow-level env sets an absolute path.
+          THROUGHPUT_RESULTS_FILE: ${{ env.THROUGHPUT_RESULTS_FILE }}
           RUST_LOG: ${{ env.RUST_LOG }}
           CLASH_RS_CI: "true"
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Format results as Markdown
         if: always()
         run: |
-          results_file="${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}"
+          results_file="${{ env.THROUGHPUT_RESULTS_FILE }}"
           if [ -f "$results_file" ]; then
             python3 bench/format_throughput.py \
               "$results_file" \
@@ -125,7 +125,7 @@ jobs:
         with:
           name: throughput-results
           path: |
-            ${{ github.workspace }}/${{ env.RESULTS_FILE_NAME }}
+            ${{ env.THROUGHPUT_RESULTS_FILE }}
             throughput-comment.md
             throughput-test.log
           retention-days: 90

--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -46,9 +46,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake libclang-dev protobuf-compiler
 
-      # Build the binary that the tests will spawn as a subprocess
+      # Build the binary that the tests will spawn as a subprocess.
+      # Do NOT use --all-features here: the `telemetry` feature enables
+      # console_subscriber and OpenTelemetry threads that deadlock with the
+      # main thread during crypto initialization when multiple instances start
+      # concurrently.  Default features already include shadowsocks, tuic,
+      # wireguard, and everything else needed for these tests.
       - name: Build clash-rs binary (release)
-        run: cargo build --release --bin clash-rs --all-features
+        run: cargo build --release --bin clash-rs
 
       # Pull docker images in advance so test startup is faster
       - name: Pull docker images

--- a/.github/workflows/proxy-throughput.yml
+++ b/.github/workflows/proxy-throughput.yml
@@ -1,0 +1,145 @@
+name: Proxy Throughput Tests
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths:
+      - "clash-lib/src/proxy/**"
+      - "clash-lib/src/app/**"
+      - ".github/workflows/proxy-throughput.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUST_LOG: "clash_lib=info"
+  RUST_TOOLCHAIN: "stable"
+  THROUGHPUT_RESULTS_FILE: throughput-results.json
+
+jobs:
+  throughput:
+    name: SS E2E Throughput
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: throughput-${{ runner.os }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libclang-dev protobuf-compiler
+
+      # Build the binary that the tests will spawn as a subprocess
+      - name: Build clash-rs binary (release)
+        run: cargo build --release --bin clash-rs --all-features
+
+      # Pull docker images in advance so test startup is faster
+      - name: Pull docker images
+        run: |
+          docker pull teddysun/shadowsocks-rust:alpine-1.22.0
+          docker pull gists/simple-obfs:latest
+          docker pull ghcr.io/ihciah/shadow-tls:latest
+
+      - name: Run throughput tests
+        env:
+          THROUGHPUT_RESULTS_FILE: ${{ env.THROUGHPUT_RESULTS_FILE }}
+          RUST_LOG: ${{ env.RUST_LOG }}
+          CLASH_RS_CI: "true"
+        run: |
+          RUSTFLAGS="--cfg docker_test --cfg throughput_test" \
+          cargo test -p clash-lib --release --all-features \
+            e2e_throughput \
+            -- --test-threads=8 --nocapture 2>&1 | tee throughput-test.log
+        continue-on-error: true
+
+      - name: Format results as Markdown
+        if: always()
+        run: |
+          if [ -f "${{ env.THROUGHPUT_RESULTS_FILE }}" ]; then
+            python3 bench/format_throughput.py \
+              "${{ env.THROUGHPUT_RESULTS_FILE }}" \
+              --output throughput-comment.md
+            # Also write to GitHub step summary
+            cat throughput-comment.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## 📊 Proxy Throughput Results" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ No results file found — tests may have failed before producing output." >> $GITHUB_STEP_SUMMARY
+            echo "## 📊 Proxy Throughput Results" > throughput-comment.md
+            echo "" >> throughput-comment.md
+            echo "⚠️ No results file found — tests may have failed before producing output." >> throughput-comment.md
+          fi
+
+      - name: Upload result artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: throughput-results
+          path: |
+            throughput-results.json
+            throughput-comment.md
+            throughput-test.log
+          retention-days: 90
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            let body;
+            if (fs.existsSync('throughput-comment.md')) {
+              body = fs.readFileSync('throughput-comment.md', 'utf8');
+            } else {
+              body = '## 📊 Proxy Throughput Results\n\n⚠️ No results produced — check workflow logs.';
+            }
+
+            // Append a link to the full log artifact
+            body += '\n\n<details><summary>Full test log</summary>\n\n';
+            body += 'Download the `throughput-results` artifact for the full log.\n\n</details>';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('Proxy Throughput Results')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ panic = "abort"
 
 [workspace.lints.rust]
 warnings = "deny"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker_test)', 'cfg(throughput_test)'] }
 
 [workspace.lints.clippy]
 redundant_clone = "deny"

--- a/bench/format_throughput.py
+++ b/bench/format_throughput.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Format throughput test JSON-lines results as a Markdown table.
+
+Usage:
+    python3 bench/format_throughput.py results.json [--output comment.md]
+
+Each line of results.json must be a JSON object with:
+    label         – human-readable test name
+    upload_mbps   – upload throughput in Mbps
+    download_mbps – download throughput in Mbps
+    total_bytes   – payload size in bytes
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results", help="JSON-lines result file")
+    parser.add_argument("--output", "-o", help="Write markdown to this file (default: stdout)")
+    args = parser.parse_args()
+
+    rows = []
+    with open(args.results) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"Warning: skipping invalid JSON line: {e}", file=sys.stderr)
+
+    if not rows:
+        md = "## 📊 Proxy Throughput Results\n\n_No results recorded._\n"
+    else:
+        rows.sort(key=lambda r: r.get("label", ""))
+        lines = [
+            "## 📊 Proxy Throughput Results",
+            "",
+            "| Transport | Payload | Upload (Mbps) | Download (Mbps) |",
+            "|-----------|---------|:-------------:|:---------------:|",
+        ]
+        for r in rows:
+            label = r.get("label", "?")
+            payload_mb = r.get("total_bytes", 0) // (1024 * 1024)
+            upload = r.get("upload_mbps", 0.0)
+            download = r.get("download_mbps", 0.0)
+            lines.append(f"| `{label}` | {payload_mb} MB | {upload:.1f} | {download:.1f} |")
+
+        lines += [
+            "",
+            f"_Tests ran {len(rows)} variant(s) in parallel; each direction transfers the full payload._",
+            "",
+        ]
+        md = "\n".join(lines)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(md)
+        print(f"Written to {args.output}")
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/clash-lib/src/proxy/converters/shadowsocks.rs
+++ b/clash-lib/src/proxy/converters/shadowsocks.rs
@@ -141,11 +141,6 @@ impl TryFrom<HashMap<String, serde_yaml::Value>> for V2RayOBFSOption {
             .get("mode")
             .and_then(|x| x.as_str())
             .ok_or(Error::InvalidConfig("obfs mode is required".to_owned()))?;
-        let port = value
-            .get("port")
-            .and_then(|x| x.as_u64())
-            .ok_or(Error::InvalidConfig("obfs port is required".to_owned()))?
-            as u16;
 
         if mode != "websocket" {
             return Err(Error::InvalidConfig(format!("invalid obfs mode: {mode}")));
@@ -154,6 +149,14 @@ impl TryFrom<HashMap<String, serde_yaml::Value>> for V2RayOBFSOption {
         let path = value.get("path").and_then(|x| x.as_str()).unwrap_or("");
         let mux = value.get("mux").and_then(|x| x.as_bool()).unwrap_or(false);
         let tls = value.get("tls").and_then(|x| x.as_bool()).unwrap_or(false);
+        // port is optional in plugin-opts; real Clash configs omit it and rely
+        // on the main proxy port for the actual TCP connection. The value here
+        // is only used for the WebSocket HTTP Upgrade Host header, so default
+        // to the standard port for the chosen scheme.
+        let port = value
+            .get("port")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(if tls { 443 } else { 80 }) as u16;
         let skip_cert_verify = value
             .get("skip-cert-verify")
             .and_then(|x| x.as_bool())

--- a/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
@@ -644,6 +644,7 @@ mod e2e {
         let password = format!("PASSWORD={}", SHADOW_TLS_PASSWORD);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SHADOW_TLS)
+            .port(stls_port)
             .env(&[
                 "MODE=server",
                 &listen_env,
@@ -674,6 +675,7 @@ mod e2e {
         };
         DockerTestRunnerBuilder::new()
             .image(IMAGE_OBFS)
+            .port(obfs_port)
             .cmd(&[
                 "obfs-server",
                 "-p",
@@ -767,13 +769,17 @@ rules:
         let echo_port = alloc_port();
 
         let c1 = get_ss_runner(ss_port).await?;
-        let c2 = get_obfs_runner(
-            c1.container_ip(),
-            ss_port,
-            obfs_port,
-            SimpleOBFSMode::Http,
-        )
-        .await?;
+        let c1_ip = c1.container_ip();
+        let c2 =
+            match get_obfs_runner(c1_ip, ss_port, obfs_port, SimpleOBFSMode::Http)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    c1.cleanup().await.ok();
+                    return Err(e);
+                }
+            };
         let server = c2.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
         let gateway_ip = c2.docker_gateway_ip();
 
@@ -813,13 +819,17 @@ rules:
         let echo_port = alloc_port();
 
         let c1 = get_ss_runner(ss_port).await?;
-        let c2 = get_obfs_runner(
-            c1.container_ip(),
-            ss_port,
-            obfs_port,
-            SimpleOBFSMode::Tls,
-        )
-        .await?;
+        let c1_ip = c1.container_ip();
+        let c2 =
+            match get_obfs_runner(c1_ip, ss_port, obfs_port, SimpleOBFSMode::Tls)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    c1.cleanup().await.ok();
+                    return Err(e);
+                }
+            };
         let server = c2.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
         let gateway_ip = c2.docker_gateway_ip();
 
@@ -897,7 +907,14 @@ rules:
         let echo_port = alloc_port();
 
         let c1 = get_ss_runner(ss_port).await?;
-        let c2 = get_shadowtls_runner(c1.container_ip(), ss_port, stls_port).await?;
+        let c1_ip = c1.container_ip();
+        let c2 = match get_shadowtls_runner(c1_ip, ss_port, stls_port).await {
+            Ok(c) => c,
+            Err(e) => {
+                c1.cleanup().await.ok();
+                return Err(e);
+            }
+        };
         let server = c2.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
         let gateway_ip = c2.docker_gateway_ip();
 

--- a/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
@@ -545,3 +545,387 @@ mod tests {
         run_test_suites_and_cleanup(handler, container, Suite::tcp_tests()).await
     }
 }
+
+// ── E2E throughput tests
+// ────────────────────────────────────────────────────── These start clash-rs
+// as a subprocess and exercise the full stack:   test client → SOCKS5 inbound →
+// dispatcher → SS outbound   → docker proxy server → echo server → back
+//
+// Ports are allocated dynamically so all tests can run in parallel — no
+// #[serial_test::serial] needed.
+// Gate: --cfg docker_test --cfg throughput_test (see proxy-throughput.yml)
+#[cfg(all(test, docker_test, throughput_test))]
+mod e2e {
+    use crate::{
+        proxy::utils::test_utils::{
+            config_helper,
+            consts::*,
+            docker_runner::{
+                DockerTestRunner, DockerTestRunnerBuilder, MultiDockerTestRunner,
+                RunAndCleanup,
+            },
+            docker_utils::{
+                alloc_port, clash_process_e2e_throughput, find_clash_rs_binary,
+            },
+        },
+        tests::initialize,
+    };
+
+    use crate::proxy::transport::SimpleOBFSMode;
+
+    const PASSWORD: &str = "FzcLbKs2dY9mhL";
+    const CIPHER: &str = "aes-256-gcm";
+    const SHADOW_TLS_PASSWORD: &str = "password";
+
+    const E2E_PAYLOAD_BYTES: usize = 32 * 1024 * 1024; // 32 MB
+
+    async fn get_ss_runner(port: u16) -> anyhow::Result<DockerTestRunner> {
+        let host = format!("0.0.0.0:{}", port);
+        DockerTestRunnerBuilder::new()
+            .image(IMAGE_SS_RUST)
+            .port(port)
+            .entrypoint(&["ssserver"])
+            .cmd(&["-s", &host, "-m", CIPHER, "-k", PASSWORD, "-U", "-vvv"])
+            .build()
+            .await
+    }
+
+    async fn get_ss_runner_with_plugin(
+        port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
+        use crate::proxy::utils::test_utils::config_helper::test_config_base_dir;
+        let test_config_dir = test_config_base_dir();
+        let cert = test_config_dir.join("example.org.pem");
+        let key = test_config_dir.join("example.org-key.pem");
+        let host = format!("0.0.0.0:{}", port);
+        DockerTestRunnerBuilder::new()
+            .image(IMAGE_SS_RUST)
+            .port(port)
+            .entrypoint(&["ssserver"])
+            .cmd(&[
+                "-s",
+                &host,
+                "-m",
+                CIPHER,
+                "-k",
+                PASSWORD,
+                "-U",
+                "-vvv",
+                "--plugin",
+                "v2ray-plugin",
+                "--plugin-opts",
+                "server;tls;host=example.org;mux=0",
+            ])
+            .mounts(&[
+                (
+                    cert.to_str().unwrap(),
+                    "/root/.acme.sh/example.org/fullchain.cer",
+                ),
+                (
+                    key.to_str().unwrap(),
+                    "/root/.acme.sh/example.org/example.org.key",
+                ),
+            ])
+            .build()
+            .await
+    }
+
+    async fn get_shadowtls_runner(
+        ss_ip: Option<String>,
+        ss_port: u16,
+        stls_port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
+        let ss_server_env = format!(
+            "SERVER={}:{}",
+            ss_ip.unwrap_or("host.docker.internal".to_owned()),
+            ss_port
+        );
+        let listen_env = format!("LISTEN=0.0.0.0:{}", stls_port);
+        let password = format!("PASSWORD={}", SHADOW_TLS_PASSWORD);
+        DockerTestRunnerBuilder::new()
+            .image(IMAGE_SHADOW_TLS)
+            .env(&[
+                "MODE=server",
+                &listen_env,
+                &ss_server_env,
+                "TLS=www.feishu.cn:443",
+                &password,
+                "V3=1",
+            ])
+            .build()
+            .await
+    }
+
+    async fn get_obfs_runner(
+        ss_ip: Option<String>,
+        ss_port: u16,
+        obfs_port: u16,
+        mode: SimpleOBFSMode,
+    ) -> anyhow::Result<DockerTestRunner> {
+        let ss_server_env = format!(
+            "{}:{}",
+            ss_ip.unwrap_or("host.docker.internal".to_owned()),
+            ss_port
+        );
+        let port = format!("{}", obfs_port);
+        let mode_str = match mode {
+            SimpleOBFSMode::Http => "http",
+            SimpleOBFSMode::Tls => "tls",
+        };
+        DockerTestRunnerBuilder::new()
+            .image(IMAGE_OBFS)
+            .cmd(&[
+                "obfs-server",
+                "-p",
+                &port,
+                "--obfs",
+                mode_str,
+                "-r",
+                &ss_server_env,
+                "-vv",
+            ])
+            .build()
+            .await
+    }
+
+    fn ss_base_config(
+        server: &str,
+        port: u16,
+        socks_port: u16,
+        extra_plugin_yaml: &str,
+    ) -> String {
+        let mmdb = config_helper::test_config_base_dir()
+            .join("Country.mmdb")
+            .to_str()
+            .unwrap()
+            .to_owned();
+        format!(
+            r#"
+socks-port: {socks_port}
+bind-address: 127.0.0.1
+mmdb: "{mmdb}"
+mode: global
+log-level: error
+proxies:
+  - name: proxy
+    type: ss
+    server: {server}
+    port: {port}
+    cipher: {cipher}
+    password: {password}
+    udp: false
+{extra}
+rules:
+  - MATCH,proxy
+"#,
+            socks_port = socks_port,
+            mmdb = mmdb,
+            server = server,
+            port = port,
+            cipher = CIPHER,
+            password = PASSWORD,
+            extra = extra_plugin_yaml,
+        )
+    }
+
+    #[tokio::test]
+    async fn e2e_throughput_ss_plain() -> anyhow::Result<()> {
+        initialize();
+        let container_port = alloc_port();
+        let socks_port = alloc_port();
+        let echo_port = alloc_port();
+
+        let container = get_ss_runner(container_port).await?;
+        let server = container.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
+        let gateway_ip = container.docker_gateway_ip();
+        let config = ss_base_config(&server, container_port, socks_port, "");
+        let binary = find_clash_rs_binary();
+
+        container
+            .run_and_cleanup(async move {
+                clash_process_e2e_throughput(
+                    &binary,
+                    &config,
+                    "ss-plain",
+                    socks_port,
+                    echo_port,
+                    gateway_ip,
+                    E2E_PAYLOAD_BYTES,
+                )
+                .await
+                .map(|_| ())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn e2e_throughput_ss_obfs_http() -> anyhow::Result<()> {
+        initialize();
+        let ss_port = alloc_port();
+        let obfs_port = alloc_port();
+        let socks_port = alloc_port();
+        let echo_port = alloc_port();
+
+        let c1 = get_ss_runner(ss_port).await?;
+        let c2 = get_obfs_runner(
+            c1.container_ip(),
+            ss_port,
+            obfs_port,
+            SimpleOBFSMode::Http,
+        )
+        .await?;
+        let server = c2.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
+        let gateway_ip = c2.docker_gateway_ip();
+
+        let plugin_yaml = r#"    plugin: obfs
+    plugin-opts:
+      mode: http
+      host: www.bing.com"#;
+        let config = ss_base_config(&server, obfs_port, socks_port, plugin_yaml);
+        let binary = find_clash_rs_binary();
+
+        let mut chained = MultiDockerTestRunner::default();
+        chained.add_with_runner(c1);
+        chained.add_with_runner(c2);
+        chained
+            .run_and_cleanup(async move {
+                clash_process_e2e_throughput(
+                    &binary,
+                    &config,
+                    "ss-obfs-http",
+                    socks_port,
+                    echo_port,
+                    gateway_ip,
+                    E2E_PAYLOAD_BYTES,
+                )
+                .await
+                .map(|_| ())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn e2e_throughput_ss_obfs_tls() -> anyhow::Result<()> {
+        initialize();
+        let ss_port = alloc_port();
+        let obfs_port = alloc_port();
+        let socks_port = alloc_port();
+        let echo_port = alloc_port();
+
+        let c1 = get_ss_runner(ss_port).await?;
+        let c2 = get_obfs_runner(
+            c1.container_ip(),
+            ss_port,
+            obfs_port,
+            SimpleOBFSMode::Tls,
+        )
+        .await?;
+        let server = c2.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
+        let gateway_ip = c2.docker_gateway_ip();
+
+        let plugin_yaml = r#"    plugin: obfs
+    plugin-opts:
+      mode: tls
+      host: www.bing.com"#;
+        let config = ss_base_config(&server, obfs_port, socks_port, plugin_yaml);
+        let binary = find_clash_rs_binary();
+
+        let mut chained = MultiDockerTestRunner::default();
+        chained.add_with_runner(c1);
+        chained.add_with_runner(c2);
+        chained
+            .run_and_cleanup(async move {
+                clash_process_e2e_throughput(
+                    &binary,
+                    &config,
+                    "ss-obfs-tls",
+                    socks_port,
+                    echo_port,
+                    gateway_ip,
+                    E2E_PAYLOAD_BYTES,
+                )
+                .await
+                .map(|_| ())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn e2e_throughput_ss_v2ray_plugin() -> anyhow::Result<()> {
+        initialize();
+        let ss_port = alloc_port();
+        let socks_port = alloc_port();
+        let echo_port = alloc_port();
+
+        let container = get_ss_runner_with_plugin(ss_port).await?;
+        let server = container.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
+        let gateway_ip = container.docker_gateway_ip();
+
+        let plugin_yaml = r#"    plugin: v2ray-plugin
+    plugin-opts:
+      mode: websocket
+      tls: true
+      host: example.org
+      skip-cert-verify: true
+      path: /"#;
+        let config = ss_base_config(&server, ss_port, socks_port, plugin_yaml);
+        let binary = find_clash_rs_binary();
+
+        container
+            .run_and_cleanup(async move {
+                clash_process_e2e_throughput(
+                    &binary,
+                    &config,
+                    "ss-v2ray-plugin-ws-tls",
+                    socks_port,
+                    echo_port,
+                    gateway_ip,
+                    E2E_PAYLOAD_BYTES,
+                )
+                .await
+                .map(|_| ())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn e2e_throughput_ss_shadowtls() -> anyhow::Result<()> {
+        initialize();
+        let ss_port = alloc_port();
+        let stls_port = alloc_port();
+        let socks_port = alloc_port();
+        let echo_port = alloc_port();
+
+        let c1 = get_ss_runner(ss_port).await?;
+        let c2 = get_shadowtls_runner(c1.container_ip(), ss_port, stls_port).await?;
+        let server = c2.container_ip().unwrap_or(LOCAL_ADDR.to_owned());
+        let gateway_ip = c2.docker_gateway_ip();
+
+        let plugin_yaml = r#"    plugin: shadow-tls
+    plugin-opts:
+      host: www.feishu.cn
+      password: password
+      version: 3"#;
+        let config = ss_base_config(&server, stls_port, socks_port, plugin_yaml);
+        let binary = find_clash_rs_binary();
+
+        let mut chained = MultiDockerTestRunner::default();
+        chained.add_with_runner(c1);
+        chained.add_with_runner(c2);
+        chained
+            .run_and_cleanup(async move {
+                clash_process_e2e_throughput(
+                    &binary,
+                    &config,
+                    "ss-shadow-tls-v3",
+                    socks_port,
+                    echo_port,
+                    gateway_ip,
+                    E2E_PAYLOAD_BYTES,
+                )
+                .await
+                .map(|_| ())
+            })
+            .await
+    }
+}

--- a/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
@@ -583,7 +583,7 @@ mod e2e {
         let host = format!("0.0.0.0:{}", port);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SS_RUST)
-            .port(port)
+            .no_port()
             .entrypoint(&["ssserver"])
             .cmd(&["-s", &host, "-m", CIPHER, "-k", PASSWORD, "-U", "-vvv"])
             .build()
@@ -600,7 +600,7 @@ mod e2e {
         let host = format!("0.0.0.0:{}", port);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SS_RUST)
-            .port(port)
+            .no_port()
             .entrypoint(&["ssserver"])
             .cmd(&[
                 "-s",
@@ -644,7 +644,7 @@ mod e2e {
         let password = format!("PASSWORD={}", SHADOW_TLS_PASSWORD);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SHADOW_TLS)
-            .port(stls_port)
+            .no_port()
             .env(&[
                 "MODE=server",
                 &listen_env,
@@ -675,7 +675,7 @@ mod e2e {
         };
         DockerTestRunnerBuilder::new()
             .image(IMAGE_OBFS)
-            .port(obfs_port)
+            .no_port()
             .cmd(&[
                 "obfs-server",
                 "-p",

--- a/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
@@ -706,6 +706,11 @@ mod e2e {
 socks-port: {socks_port}
 bind-address: 127.0.0.1
 mmdb: "{mmdb}"
+# Clash-rs defaults geosite to "geosite.dat" in compatibility mode (which is
+# on by default) and downloads it if missing.  Point to /dev/null instead:
+# an empty file is a valid protobuf GeoSiteList, so no download occurs and
+# our geo-free rules still work.
+geosite: /dev/null
 mode: global
 log-level: error
 proxies:

--- a/clash-lib/src/proxy/transport/simple_obfs/http.rs
+++ b/clash-lib/src/proxy/transport/simple_obfs/http.rs
@@ -2,8 +2,12 @@ use async_trait::async_trait;
 use base64::Engine;
 use bytes::{BufMut, BytesMut};
 use rand::Rng;
-use std::pin::Pin;
-use tokio::io::{AsyncRead, AsyncWrite};
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::proxy::{AnyStream, transport::Transport};
 
@@ -32,27 +36,70 @@ pub struct HTTPObfs {
 
     first_request: bool,
     first_response: bool,
+    // write-side: in-flight HTTP-wrapped buffer and how many source bytes it
+    // represents (> 0 while a first-request chunk is being drained)
+    write_buf: Vec<u8>,
+    write_pos: usize,
+    write_committed: usize,
+    // read-side: accumulates response bytes until \r\n\r\n is located
     read_buf: BytesMut,
+}
+
+/// Drain `this.write_buf[this.write_pos..]` into the inner stream, advancing
+/// `this.write_pos` with each partial write.  Returns `Poll::Ready(Ok(()))`
+/// once all bytes have been sent.
+fn drain_write_buf(
+    this: &mut HTTPObfs,
+    cx: &mut Context<'_>,
+) -> Poll<io::Result<()>> {
+    while this.write_pos < this.write_buf.len() {
+        let n = ready!(
+            Pin::new(&mut this.inner)
+                .poll_write(cx, &this.write_buf[this.write_pos..])
+        )?;
+        if n == 0 {
+            return Poll::Ready(Err(io::Error::from(io::ErrorKind::WriteZero)));
+        }
+        this.write_pos += n;
+    }
+    Poll::Ready(Ok(()))
 }
 
 impl AsyncWrite for HTTPObfs {
     fn poll_write(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> std::task::Poll<Result<usize, std::io::Error>> {
-        let pin = self.get_mut();
-        if pin.first_request {
+    ) -> Poll<Result<usize, io::Error>> {
+        let this = self.get_mut();
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        // If a previous first-request chunk is still being drained, finish it
+        // before accepting new data.  The caller will supply the same `buf`
+        // again (AsyncWrite contract), so returning `Ok(write_committed)` is
+        // correct: it tells the caller those source bytes were consumed.
+        if this.write_committed > 0 {
+            ready!(drain_write_buf(this, cx))?;
+            let committed = this.write_committed;
+            this.write_committed = 0;
+            return Poll::Ready(Ok(committed));
+        }
+
+        if this.first_request {
+            // Build the HTTP upgrade request: headers + payload in one buffer.
             let rand_bytes = rand::random::<[u8; 16]>();
             let mut buffer = Vec::new();
             buffer.put_slice(b"GET / HTTP/1.1\r\n");
             buffer.put_slice(
                 format!(
                     "Host: {}\r\n",
-                    if pin.port != 80 {
-                        format!("{}:{}", pin.host, pin.port)
+                    if this.port != 80 {
+                        format!("{}:{}", this.host, this.port)
                     } else {
-                        pin.host.clone()
+                        this.host.clone()
                     }
                 )
                 .as_bytes(),
@@ -79,90 +126,110 @@ impl AsyncWrite for HTTPObfs {
             buffer.put_slice(b"\r\n");
             buffer.put_slice(buf);
 
-            pin.first_request = false;
-            Pin::new(&mut pin.inner).poll_write(cx, &buffer)
+            let n = buf.len(); // source bytes consumed (payload only)
+            this.first_request = false;
+            this.write_buf = buffer;
+            this.write_pos = 0;
+            this.write_committed = n;
+
+            // Attempt to drain synchronously; if Pending, write_buf/write_pos
+            // and write_committed survive in the struct for the next poll.
+            ready!(drain_write_buf(this, cx))?;
+            this.write_committed = 0;
+            Poll::Ready(Ok(n))
         } else {
-            Pin::new(&mut pin.inner).poll_write(cx, buf)
+            // Subsequent writes: forward directly, no buffering needed.
+            Pin::new(&mut this.inner).poll_write(cx, buf)
         }
     }
 
     fn poll_flush(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), std::io::Error>> {
-        let pin = self.get_mut();
-        Pin::new(&mut pin.inner).poll_flush(cx)
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        let this = self.get_mut();
+        // Drain any in-flight first-request write before flushing.
+        ready!(drain_write_buf(this, cx))?;
+        this.write_committed = 0;
+        Pin::new(&mut this.inner).poll_flush(cx)
     }
 
     fn poll_shutdown(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), std::io::Error>> {
-        let pin = self.get_mut();
-        Pin::new(&mut pin.inner).poll_shutdown(cx)
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        let this = self.get_mut();
+        // Drain any in-flight first-request write before shutting down.
+        ready!(drain_write_buf(this, cx))?;
+        this.write_committed = 0;
+        Pin::new(&mut this.inner).poll_shutdown(cx)
     }
 }
 
 impl AsyncRead for HTTPObfs {
     fn poll_read(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        let pin = self.get_mut();
-        // as long as the buffer is not empty, we should return the data in the
-        // buffer first
-        if !pin.read_buf.is_empty() {
-            let to_read = std::cmp::min(buf.remaining(), pin.read_buf.len());
-            if to_read == 0 {
-                assert!(buf.remaining() > 0);
-                return std::task::Poll::Pending;
-            }
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
 
-            let data = pin.read_buf.split_to(to_read);
-            buf.put_slice(&data[..]);
-            return std::task::Poll::Ready(Ok(()));
+        // Deliver any leftover body bytes from a previous read first.
+        if !this.read_buf.is_empty() {
+            let to_read = std::cmp::min(buf.remaining(), this.read_buf.len());
+            // to_read > 0 because read_buf is non-empty and buf.remaining() > 0
+            // (the caller would not call poll_read with a full buffer).
+            let data = this.read_buf.split_to(to_read);
+            buf.put_slice(&data);
+            return Poll::Ready(Ok(()));
         }
 
-        if pin.first_response {
-            // TODO: move this static buffer size to global constant
-            // maximum packet size of vmess/shadowsocks is about 16 KiB so
-            // define a buffer of 20 KiB to reduce the memory of each TCP relay
-            let mut b = [0; 20 * 1024];
-            let mut b = tokio::io::ReadBuf::new(&mut b);
-            match Pin::new(&mut pin.inner).poll_read(cx, &mut b) {
-                std::task::Poll::Ready(rv) => match rv {
-                    Ok(_) => {
-                        let needle = b"\r\n\r\n";
-                        let idx = b
-                            .filled()
+        if this.first_response {
+            // Accumulate response bytes in `this.read_buf` until the HTTP
+            // response header terminator (\r\n\r\n) is found.  A single read
+            // may not contain the full header, so we loop until we either find
+            // the delimiter, hit an error, or the inner stream returns Pending.
+            let needle = b"\r\n\r\n";
+            loop {
+                let mut tmp = [0u8; 4096];
+                let mut tmp_buf = ReadBuf::new(&mut tmp);
+                match Pin::new(&mut this.inner).poll_read(cx, &mut tmp_buf) {
+                    Poll::Ready(Ok(())) => {
+                        let filled = tmp_buf.filled();
+                        if filled.is_empty() {
+                            // Peer closed the connection before sending headers.
+                            return Poll::Ready(Err(io::Error::from(
+                                io::ErrorKind::UnexpectedEof,
+                            )));
+                        }
+                        this.read_buf.put_slice(filled);
+
+                        let idx = this
+                            .read_buf
                             .windows(needle.len())
-                            .position(|window| window == needle);
+                            .position(|w| w == needle);
 
                         if let Some(idx) = idx {
-                            pin.first_response = false;
-                            let body = &b.filled()[idx + 4..b.filled().len()];
-                            if body.len() < buf.remaining() {
-                                buf.put_slice(body);
-                                std::task::Poll::Ready(Ok(()))
-                            } else {
-                                let to_read = &body[..buf.remaining()];
-                                let to_buf = &body[buf.remaining()..];
-                                buf.put_slice(to_read);
-                                // use put_slice instead of clone_from_slice
-                                pin.read_buf.put_slice(to_buf);
-                                std::task::Poll::Ready(Ok(()))
+                            this.first_response = false;
+                            // Discard everything up to and including \r\n\r\n.
+                            let _ = this.read_buf.split_to(idx + needle.len());
+                            // Deliver what remains of the body to the caller.
+                            let to_read =
+                                std::cmp::min(buf.remaining(), this.read_buf.len());
+                            if to_read > 0 {
+                                let data = this.read_buf.split_to(to_read);
+                                buf.put_slice(&data);
                             }
-                        } else {
-                            std::task::Poll::Ready(Err(std::io::Error::other("EOF")))
+                            return Poll::Ready(Ok(()));
                         }
+                        // Delimiter not yet seen — read more.
                     }
-                    Err(e) => std::task::Poll::Ready(Err(e)),
-                },
-                std::task::Poll::Pending => std::task::Poll::Pending,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => return Poll::Pending,
+                }
             }
         } else {
-            Pin::new(&mut pin.inner).poll_read(cx, buf)
+            Pin::new(&mut this.inner).poll_read(cx, buf)
         }
     }
 }
@@ -176,6 +243,9 @@ impl HTTPObfs {
 
             first_request: true,
             first_response: true,
+            write_buf: Vec::new(),
+            write_pos: 0,
+            write_committed: 0,
             read_buf: BytesMut::new(),
         }
     }

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
@@ -15,7 +15,7 @@ use bytes::Bytes;
 use futures::{Future, StreamExt, TryStreamExt};
 use tar;
 
-const TIMEOUT_DURATION: u64 = 30;
+const TIMEOUT_DURATION: u64 = 120;
 
 /// Creates a tar archive from a source path with the given target path.
 /// This is a blocking operation and should be called from `spawn_blocking`.

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
@@ -471,6 +471,18 @@ impl DockerTestRunnerBuilder {
         self
     }
 
+    /// Do not bind any host port.  Use this when the container is accessed
+    /// exclusively via its internal docker network IP (e.g. e2e tests that
+    /// spawn a clash-rs subprocess which connects via container IP).  Avoids
+    /// EADDRINUSE errors that occur when Docker tries to bind a host port in
+    /// the OS ephemeral range.
+    #[allow(dead_code)]
+    pub fn no_port(mut self) -> Self {
+        self.exposed_ports = vec![];
+        self.host_config.port_bindings = Some(HashMap::new());
+        self
+    }
+
     pub fn cmd(mut self, cmd: &[&str]) -> Self {
         self.cmd = Some(cmd.iter().map(|x| x.to_string()).collect());
         self

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -10,7 +10,10 @@ use crate::{
 use anyhow::{anyhow, bail};
 use futures::{SinkExt, StreamExt, future::select_all};
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU16, Ordering},
+    },
     time::{Duration, Instant},
 };
 use sysinfo::Networks;
@@ -19,6 +22,64 @@ use tokio::{
     net::{TcpListener, UdpSocket},
 };
 use tracing::{debug, info, trace};
+
+// ── Port allocator
+// ────────────────────────────────────────────────────────────
+/// Global port counter starting at 52000. Each call returns a unique port so
+/// parallel tests never collide.
+static NEXT_PORT: AtomicU16 = AtomicU16::new(52000);
+
+pub fn alloc_port() -> u16 {
+    NEXT_PORT.fetch_add(1, Ordering::Relaxed)
+}
+
+// ── ThroughputResult
+// ──────────────────────────────────────────────────────────
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ThroughputResult {
+    pub label: String,
+    pub upload_mbps: f64,
+    pub download_mbps: f64,
+    pub total_bytes: usize,
+}
+
+/// Append one result line to the file named by `THROUGHPUT_RESULTS_FILE` (if
+/// set).  Each line is a self-contained JSON object so the file can be parsed
+/// incrementally even when multiple tests run in parallel.
+#[cfg(all(docker_test, throughput_test))]
+fn write_throughput_result(result: &ThroughputResult) {
+    let Some(path) = std::env::var_os("THROUGHPUT_RESULTS_FILE") else {
+        return;
+    };
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .expect("THROUGHPUT_RESULTS_FILE: cannot open for append");
+    let mut line = serde_json::to_string(result)
+        .expect("ThroughputResult serialization failed");
+    line.push('\n');
+    file.write_all(line.as_bytes())
+        .expect("THROUGHPUT_RESULTS_FILE: write failed");
+}
+
+// ── find_clash_rs_binary
+// ──────────────────────────────────────────────────────
+/// Locate the clash-rs binary.  Prefers the debug build (faster iteration) and
+/// falls back to the release build.  Panics if neither exists.
+pub fn find_clash_rs_binary() -> std::path::PathBuf {
+    let root = config_helper::root_dir();
+    let debug = root.join("target/debug/clash-rs");
+    let release = root.join("target/release/clash-rs");
+    if debug.exists() {
+        debug
+    } else if release.exists() {
+        release
+    } else {
+        panic!("clash-rs binary not found — run `cargo build -p clash-rs` first")
+    }
+}
 
 pub mod config_helper;
 pub mod consts;
@@ -564,6 +625,238 @@ impl Suite {
         &[Suite::PingPongTcp, Suite::LatencyTcp]
     }
 }
+
+// ── SOCKS5 / process-level e2e helpers (docker_test only) ────────────────────
+
+/// Connect to a SOCKS5 proxy at `proxy_addr` and issue a CONNECT to
+/// `target_host:target_port`.  Returns a `TcpStream` ready for data.
+#[cfg(docker_test)]
+async fn socks5_connect(
+    proxy_addr: std::net::SocketAddr,
+    target_host: &str,
+    target_port: u16,
+) -> std::io::Result<tokio::net::TcpStream> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::TcpStream::connect(proxy_addr).await?;
+    // Greeting: VER=5, NMETHODS=1, METHOD=NO_AUTH(0)
+    stream.write_all(&[0x05, 0x01, 0x00]).await?;
+    let mut resp = [0u8; 2];
+    stream.read_exact(&mut resp).await?;
+    if resp[0] != 0x05 || resp[1] != 0x00 {
+        return Err(std::io::Error::other("SOCKS5 auth negotiation failed"));
+    }
+    // CONNECT request: VER=5, CMD=CONNECT(1), RSV=0, ATYP=DOMAIN(3)
+    let host_bytes = target_host.as_bytes();
+    let mut req = Vec::with_capacity(7 + host_bytes.len());
+    req.extend_from_slice(&[0x05, 0x01, 0x00, 0x03, host_bytes.len() as u8]);
+    req.extend_from_slice(host_bytes);
+    req.extend_from_slice(&target_port.to_be_bytes());
+    stream.write_all(&req).await?;
+    // Response header: VER, REP, RSV, ATYP
+    let mut hdr = [0u8; 4];
+    stream.read_exact(&mut hdr).await?;
+    if hdr[1] != 0x00 {
+        return Err(std::io::Error::other(format!(
+            "SOCKS5 CONNECT failed: REP={}",
+            hdr[1]
+        )));
+    }
+    // Skip bound address
+    match hdr[3] {
+        0x01 => {
+            let mut _skip = [0u8; 6];
+            stream.read_exact(&mut _skip).await?;
+        }
+        0x03 => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await?;
+            let mut skip = vec![0u8; len[0] as usize + 2];
+            stream.read_exact(&mut skip).await?;
+        }
+        0x04 => {
+            let mut _skip = [0u8; 18];
+            stream.read_exact(&mut _skip).await?;
+        }
+        _ => {}
+    }
+    Ok(stream)
+}
+
+/// Wait until a TCP port accepts connections, or until `timeout_secs` elapses.
+#[cfg(docker_test)]
+async fn wait_for_port(port: u16, timeout_secs: u64) -> anyhow::Result<()> {
+    let deadline =
+        tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    loop {
+        if tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("port {} not ready after {}s", port, timeout_secs);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
+/// Start clash-rs as a subprocess with `config_yaml`, then run a full-stack
+/// upload+download throughput test through its SOCKS5 inbound.
+///
+/// The echo server is bound locally on `echo_port`; the SOCKS5 CONNECT target
+/// is resolved using `destination_list(gateway_ip)` so docker containers can
+/// reach back to the host.
+///
+/// `payload_bytes` is transferred in each direction (upload then download).
+/// Results are logged with `tracing::info!` and — when
+/// `THROUGHPUT_RESULTS_FILE` is set — appended as a JSON line to that file for
+/// CI collection.
+#[cfg(all(docker_test, throughput_test))]
+pub async fn clash_process_e2e_throughput(
+    binary: &std::path::Path,
+    config_yaml: &str,
+    label: &str,
+    socks_port: u16,
+    echo_port: u16,
+    gateway_ip: Option<String>,
+    payload_bytes: usize,
+) -> anyhow::Result<ThroughputResult> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // --- write config to a temp file ---
+    let mut cfg_file = tempfile::NamedTempFile::new()?;
+    std::io::Write::write_all(&mut cfg_file, config_yaml.as_bytes())?;
+    let cfg_path = cfg_file.path().to_owned();
+
+    // --- spawn clash-rs subprocess ---
+    let mut child = tokio::process::Command::new(binary)
+        .arg("-c")
+        .arg(&cfg_path)
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to spawn clash-rs: {e}"))?;
+
+    // --- start echo server on echo_port ---
+    let echo_listener =
+        tokio::net::TcpListener::bind(format!("0.0.0.0:{}", echo_port)).await?;
+    let payload_bytes_echo = payload_bytes;
+    let echo_task = tokio::spawn(async move {
+        // Accept one connection
+        let (mut stream, _) = echo_listener.accept().await?;
+        let chunk_size = 64 * 1024_usize;
+        let mut buf = vec![0u8; chunk_size];
+        // Phase 1: receive payload_bytes
+        let mut received = 0usize;
+        while received < payload_bytes_echo {
+            let n = stream.read(&mut buf).await?;
+            if n == 0 {
+                anyhow::bail!("echo server: premature EOF on receive");
+            }
+            received += n;
+        }
+        // Phase 2: send payload_bytes back
+        let data = vec![0x42u8; chunk_size];
+        let mut sent = 0usize;
+        while sent < payload_bytes_echo {
+            let to_send = chunk_size.min(payload_bytes_echo - sent);
+            stream.write_all(&data[..to_send]).await?;
+            sent += to_send;
+        }
+        stream.flush().await?;
+        anyhow::Ok(())
+    });
+
+    // --- wait for SOCKS5 inbound to be ready ---
+    wait_for_port(socks_port, 30).await.map_err(|e| {
+        child.start_kill().ok();
+        e
+    })?;
+
+    // --- find a target address reachable from docker ---
+    let destinations = destination_list(gateway_ip);
+    let mut last_err = anyhow::anyhow!("no destinations");
+
+    'dest: for dest in &destinations {
+        let proxy_addr: std::net::SocketAddr =
+            format!("127.0.0.1:{}", socks_port).parse().unwrap();
+
+        let mut conn = match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            socks5_connect(proxy_addr, dest, echo_port),
+        )
+        .await
+        {
+            Ok(Ok(c)) => c,
+            Ok(Err(e)) => {
+                last_err = e.into();
+                continue 'dest;
+            }
+            Err(_) => {
+                last_err = anyhow::anyhow!("socks5_connect timeout");
+                continue 'dest;
+            }
+        };
+
+        let chunk_size = 64 * 1024_usize;
+        let upload_data = vec![0x42u8; chunk_size];
+        let mut read_buf = vec![0u8; chunk_size];
+
+        // Upload
+        let upload_start = std::time::Instant::now();
+        let mut sent = 0usize;
+        while sent < payload_bytes {
+            let to_send = chunk_size.min(payload_bytes - sent);
+            conn.write_all(&upload_data[..to_send]).await?;
+            sent += to_send;
+        }
+        conn.flush().await?;
+        let upload_elapsed = upload_start.elapsed();
+
+        // Download
+        let download_start = std::time::Instant::now();
+        let mut received = 0usize;
+        while received < payload_bytes {
+            let n = conn.read(&mut read_buf).await?;
+            if n == 0 {
+                anyhow::bail!("premature EOF on download");
+            }
+            received += n;
+        }
+        let download_elapsed = download_start.elapsed();
+
+        let mb = payload_bytes as f64 / 1024.0 / 1024.0;
+        let upload_mbps = mb * 8.0 / upload_elapsed.as_secs_f64();
+        let download_mbps = mb * 8.0 / download_elapsed.as_secs_f64();
+
+        tracing::info!(
+            "e2e throughput [{}] ({} MB): upload={:.1} Mbps  download={:.1} Mbps",
+            label,
+            payload_bytes / 1024 / 1024,
+            upload_mbps,
+            download_mbps,
+        );
+
+        echo_task.await??;
+        child.start_kill().ok();
+        let result = ThroughputResult {
+            label: label.to_owned(),
+            upload_mbps,
+            download_mbps,
+            total_bytes: payload_bytes,
+        };
+        write_throughput_result(&result);
+        return Ok(result);
+    }
+
+    echo_task.abort();
+    child.start_kill().ok();
+    Err(last_err)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 pub async fn run_test_suites_and_cleanup(
     handler: Arc<dyn OutboundHandler>,

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -9,8 +9,6 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use futures::{SinkExt, StreamExt, future::select_all};
-#[cfg(throughput_test)]
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -24,14 +22,19 @@ use tracing::{debug, info, trace};
 
 // ── Port allocator
 // ────────────────────────────────────────────────────────────
-/// Global port counter starting at 52000. Each call returns a unique port so
-/// parallel tests never collide.
-#[cfg(throughput_test)]
-static NEXT_PORT: AtomicU16 = AtomicU16::new(52000);
-
+/// Allocate a free port by asking the OS for one. Each call returns a unique
+/// port so parallel tests never collide with each other or with ephemeral
+/// ports.
 #[cfg(throughput_test)]
 pub fn alloc_port() -> u16 {
-    NEXT_PORT.fetch_add(1, Ordering::Relaxed)
+    // Bind port 0 to let the OS pick a free port, then release it.
+    // TOCTOU race is acceptable in test environments.
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("alloc_port: bind failed");
+    listener
+        .local_addr()
+        .expect("alloc_port: local_addr")
+        .port()
 }
 
 // ── ThroughputResult
@@ -73,14 +76,23 @@ fn write_throughput_result(result: &ThroughputResult) {
 #[cfg(throughput_test)]
 pub fn find_clash_rs_binary() -> std::path::PathBuf {
     let root = config_helper::root_dir();
-    let debug = root.join("target/debug/clash-rs");
+    // Prefer the release binary: it's faster (important for throughput tests)
+    // and avoids the `telemetry` feature deadlock that occurs when
+    // `cargo build --all-features` is used (console_subscriber + OpenTelemetry
+    // threads compete with the main thread over a mutex during crypto init).
+    // Build with: cargo build --release --bin clash-rs
     let release = root.join("target/release/clash-rs");
-    if debug.exists() {
-        debug
-    } else if release.exists() {
+    let debug = root.join("target/debug/clash-rs");
+    if release.exists() {
         release
+    } else if debug.exists() {
+        debug
     } else {
-        panic!("clash-rs binary not found — run `cargo build -p clash-rs` first")
+        panic!(
+            "clash-rs binary not found — run `cargo build --release --bin \
+             clash-rs` first (do NOT use --all-features: the telemetry feature \
+             causes startup deadlocks when multiple instances run concurrently)"
+        )
     }
 }
 
@@ -727,18 +739,28 @@ pub async fn clash_process_e2e_throughput(
 ) -> anyhow::Result<ThroughputResult> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    // --- write config to a temp file ---
-    let mut cfg_file = tempfile::NamedTempFile::new()?;
-    std::io::Write::write_all(&mut cfg_file, config_yaml.as_bytes())?;
-    let cfg_path = cfg_file.path().to_owned();
+    // Each clash-rs instance gets its own temp directory so that concurrent
+    // runs never share the same `cache.db` or other working-dir files.
+    let work_dir = tempfile::TempDir::new()?;
+
+    // Write config inside the per-instance work dir so the path stays valid
+    // for the duration of the clash-rs process.
+    let cfg_path = work_dir.path().join("config.yaml");
+    std::fs::write(&cfg_path, config_yaml.as_bytes())?;
 
     // --- spawn clash-rs subprocess ---
+    // Log to a per-instance file so output from concurrent runs never interleave
+    // or get lost in pipe buffering.
+    let log_path = work_dir.path().join("clash-rs.log");
+    let log_file = std::fs::File::create(&log_path)?;
+    let log_file2 = log_file.try_clone()?;
     let mut child = tokio::process::Command::new(binary)
         .arg("-c")
         .arg(&cfg_path)
+        .current_dir(work_dir.path())
         .kill_on_drop(true)
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
+        .stdout(log_file)
+        .stderr(log_file2)
         .spawn()
         .map_err(|e| anyhow::anyhow!("failed to spawn clash-rs: {e}"))?;
 
@@ -773,8 +795,24 @@ pub async fn clash_process_e2e_throughput(
     });
 
     // --- wait for SOCKS5 inbound to be ready ---
+    // First, give the process a moment and check it hasn't crashed immediately.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    if let Ok(Some(status)) = child.try_wait() {
+        let log_content = std::fs::read_to_string(&log_path).unwrap_or_default();
+        anyhow::bail!(
+            "clash-rs [{label}] exited immediately with status: {:?}\n--- log \
+             ---\n{}",
+            status,
+            log_content
+        );
+    }
     wait_for_port(socks_port, 60).await.map_err(|e| {
         child.start_kill().ok();
+        let log_content = std::fs::read_to_string(&log_path).unwrap_or_default();
+        eprintln!(
+            "--- clash-rs [{label}] log (port not ready) ---\n{}",
+            log_content
+        );
         e
     })?;
 

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -646,6 +646,7 @@ impl Suite {
 /// Connect to a SOCKS5 proxy at `proxy_addr` and issue a CONNECT to
 /// `target_host:target_port`.  Returns a `TcpStream` ready for data.
 #[cfg(all(docker_test, throughput_test))]
+#[allow(dead_code)]
 async fn socks5_connect(
     proxy_addr: std::net::SocketAddr,
     target_host: &str,
@@ -699,6 +700,7 @@ async fn socks5_connect(
 
 /// Wait until a TCP port accepts connections, or until `timeout_secs` elapses.
 #[cfg(all(docker_test, throughput_test))]
+#[allow(dead_code)]
 async fn wait_for_port(port: u16, timeout_secs: u64) -> anyhow::Result<()> {
     let deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -737,8 +737,8 @@ pub async fn clash_process_e2e_throughput(
         .arg("-c")
         .arg(&cfg_path)
         .kill_on_drop(true)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
         .spawn()
         .map_err(|e| anyhow::anyhow!("failed to spawn clash-rs: {e}"))?;
 
@@ -773,7 +773,7 @@ pub async fn clash_process_e2e_throughput(
     });
 
     // --- wait for SOCKS5 inbound to be ready ---
-    wait_for_port(socks_port, 30).await.map_err(|e| {
+    wait_for_port(socks_port, 60).await.map_err(|e| {
         child.start_kill().ok();
         e
     })?;

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -633,7 +633,7 @@ impl Suite {
 
 /// Connect to a SOCKS5 proxy at `proxy_addr` and issue a CONNECT to
 /// `target_host:target_port`.  Returns a `TcpStream` ready for data.
-#[cfg(docker_test)]
+#[cfg(all(docker_test, throughput_test))]
 async fn socks5_connect(
     proxy_addr: std::net::SocketAddr,
     target_host: &str,
@@ -686,7 +686,7 @@ async fn socks5_connect(
 }
 
 /// Wait until a TCP port accepts connections, or until `timeout_secs` elapses.
-#[cfg(docker_test)]
+#[cfg(all(docker_test, throughput_test))]
 async fn wait_for_port(port: u16, timeout_secs: u64) -> anyhow::Result<()> {
     let deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -9,11 +9,10 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use futures::{SinkExt, StreamExt, future::select_all};
+#[cfg(throughput_test)]
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicU16, Ordering},
-    },
+    sync::Arc,
     time::{Duration, Instant},
 };
 use sysinfo::Networks;
@@ -27,14 +26,17 @@ use tracing::{debug, info, trace};
 // ────────────────────────────────────────────────────────────
 /// Global port counter starting at 52000. Each call returns a unique port so
 /// parallel tests never collide.
+#[cfg(throughput_test)]
 static NEXT_PORT: AtomicU16 = AtomicU16::new(52000);
 
+#[cfg(throughput_test)]
 pub fn alloc_port() -> u16 {
     NEXT_PORT.fetch_add(1, Ordering::Relaxed)
 }
 
 // ── ThroughputResult
 // ──────────────────────────────────────────────────────────
+#[cfg(throughput_test)]
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ThroughputResult {
     pub label: String,
@@ -68,6 +70,7 @@ fn write_throughput_result(result: &ThroughputResult) {
 // ──────────────────────────────────────────────────────
 /// Locate the clash-rs binary.  Prefers the debug build (faster iteration) and
 /// falls back to the release build.  Panics if neither exists.
+#[cfg(throughput_test)]
 pub fn find_clash_rs_binary() -> std::path::PathBuf {
     let root = config_helper::root_dir();
     let debug = root.join("target/debug/clash-rs");
@@ -804,26 +807,50 @@ pub async fn clash_process_e2e_throughput(
         let upload_data = vec![0x42u8; chunk_size];
         let mut read_buf = vec![0u8; chunk_size];
 
-        // Upload
+        // Upload — any error means this destination is unusable; try the next
         let upload_start = std::time::Instant::now();
         let mut sent = 0usize;
+        let mut transfer_ok = true;
         while sent < payload_bytes {
             let to_send = chunk_size.min(payload_bytes - sent);
-            conn.write_all(&upload_data[..to_send]).await?;
-            sent += to_send;
+            match conn.write_all(&upload_data[..to_send]).await {
+                Ok(()) => sent += to_send,
+                Err(e) => {
+                    last_err = e.into();
+                    transfer_ok = false;
+                    break;
+                }
+            }
         }
-        conn.flush().await?;
+        if !transfer_ok {
+            continue 'dest;
+        }
+        if let Err(e) = conn.flush().await {
+            last_err = e.into();
+            continue 'dest;
+        }
         let upload_elapsed = upload_start.elapsed();
 
         // Download
         let download_start = std::time::Instant::now();
         let mut received = 0usize;
         while received < payload_bytes {
-            let n = conn.read(&mut read_buf).await?;
-            if n == 0 {
-                anyhow::bail!("premature EOF on download");
+            match conn.read(&mut read_buf).await {
+                Ok(0) => {
+                    last_err = anyhow::anyhow!("premature EOF on download");
+                    transfer_ok = false;
+                    break;
+                }
+                Ok(n) => received += n,
+                Err(e) => {
+                    last_err = e.into();
+                    transfer_ok = false;
+                    break;
+                }
             }
-            received += n;
+        }
+        if !transfer_ok {
+            continue 'dest;
         }
         let download_elapsed = download_start.elapsed();
 

--- a/clash-lib/src/proxy/vmess/vmess_impl/http.rs
+++ b/clash-lib/src/proxy/vmess/vmess_impl/http.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, io, pin::Pin};
+use std::{
+    collections::HashMap,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use bytes::{BufMut, BytesMut};
 use futures::ready;
@@ -29,14 +34,37 @@ impl HttpConfig {
     }
 }
 
+/// HTTP obfuscation stream for VMess.
+///
+/// **Write side**: the first `poll_write` prepends HTTP request headers to the
+/// caller's data.  Subsequent writes pass through as-is.  The in-flight buffer
+/// is stored in `write_buf`/`write_pos`/`write_committed` so a `Poll::Pending`
+/// from the inner stream never causes the encoded bytes to be lost.
+///
+/// **Read side**: `buf` accumulates raw bytes from the inner stream until a
+/// complete HTTP response header has been parsed and skipped.  Any body bytes
+/// that arrived in the same read as the last header chunk are held in `buf`
+/// and delivered on the next `poll_read` call.  Because `buf` lives in the
+/// struct, a `Poll::Pending` return never discards already-received bytes.
 pub struct HttpStream {
     bufio: BufStream<AnyStream>,
     host: String,
     path: String,
     headers: HashMap<String, String>,
+    /// Before `header_consumed`: accumulates incoming bytes while we search
+    /// for the end of the HTTP response header.
+    /// After `header_consumed`: holds any body bytes that arrived together
+    /// with the last header chunk, to be delivered on the next read.
     buf: BytesMut,
     header_consumed: bool,
+    /// True once the HTTP request headers have been sent at least once.
     header_sent: bool,
+    /// Encoded wire bytes waiting to be drained into `bufio`.
+    write_buf: BytesMut,
+    /// How many bytes of `write_buf` have already been accepted by `bufio`.
+    write_pos: usize,
+    /// How many bytes of the *caller's* `buf` the current `write_buf` encodes.
+    write_committed: usize,
 }
 
 impl HttpStream {
@@ -51,117 +79,149 @@ impl HttpStream {
             host,
             path,
             headers,
-            buf: BytesMut::with_capacity(16),
+            buf: BytesMut::new(),
             header_consumed: false,
             header_sent: false,
+            write_buf: BytesMut::new(),
+            write_pos: 0,
+            write_committed: 0,
         }
     }
 }
 
+/// Drain `this.write_buf[this.write_pos..]` into the inner buffered stream,
+/// advancing `this.write_pos` after each partial write.
+fn drain_write_buf(this: &mut HttpStream, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    while this.write_pos < this.write_buf.len() {
+        let n = ready!(
+            Pin::new(&mut this.bufio).poll_write(cx, &this.write_buf[this.write_pos..])
+        )?;
+        if n == 0 {
+            return Poll::Ready(Err(io::Error::from(io::ErrorKind::WriteZero)));
+        }
+        this.write_pos += n;
+    }
+    Poll::Ready(Ok(()))
+}
+
 impl AsyncRead for HttpStream {
     fn poll_read(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        let Self {
-            bufio,
-            buf: read_buf,
-            header_consumed,
-            ..
-        } = self.get_mut();
-        let mut pin = Pin::new(bufio);
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let mut pin = Pin::new(&mut this.bufio);
 
-        if !*header_consumed {
-            let mut headers = [httparse::EMPTY_HEADER; 0];
-            let mut req = httparse::Request::new(&mut headers);
-            let mut header_buf = BytesMut::with_capacity(1024);
-            while req.parse(&header_buf).map_err(map_io_error)?.is_partial() {
-                let mut read_buf = ReadBuf::new(read_buf);
-                ready!(pin.as_mut().poll_read(cx, &mut read_buf))?;
-                header_buf.extend_from_slice(read_buf.filled());
+        if !this.header_consumed {
+            // Accumulate bytes in `this.buf` until we can parse a complete
+            // HTTP response header.  `this.buf` survives Poll::Pending so no
+            // bytes already pulled from the inner stream are ever lost.
+            loop {
+                {
+                    let mut headers = [httparse::EMPTY_HEADER; 16];
+                    let mut resp = httparse::Response::new(&mut headers);
+                    match resp.parse(&this.buf).map_err(map_io_error)? {
+                        httparse::Status::Complete(offset) => {
+                            // Split header bytes off; keep only the trailing
+                            // body bytes (if any) for the next poll_read call.
+                            let body = this.buf.split_off(offset);
+                            this.buf = body;
+                            this.header_consumed = true;
+                            break;
+                        }
+                        httparse::Status::Partial => { /* need more bytes */ }
+                    }
+                }
+                // Use a stack-allocated scratch buffer so the inner stream
+                // has real capacity to write into.  Passing a ReadBuf built
+                // from a zero-length BytesMut (as the original code did)
+                // gives the inner stream 0 capacity and can never make
+                // progress.
+                let mut tmp = [0u8; 1024];
+                let mut rb = ReadBuf::new(&mut tmp);
+                ready!(pin.as_mut().poll_read(cx, &mut rb))?;
+                let filled = rb.filled();
+                if filled.is_empty() {
+                    return Poll::Ready(Err(io::Error::from(io::ErrorKind::UnexpectedEof)));
+                }
+                this.buf.extend_from_slice(filled);
             }
-
-            *header_consumed = true;
-
-            let offset = req.parse(&header_buf).map_err(map_io_error)?.unwrap();
-            let body = &header_buf[offset..];
-
-            if body.len() < buf.remaining() {
-                buf.put_slice(body);
-                return std::task::Poll::Ready(Ok(()));
-            } else {
-                buf.put_slice(&body[..buf.remaining()]);
-                read_buf.reserve(body.len() - buf.remaining());
-                read_buf.clone_from_slice(&body[buf.remaining()..]);
-                return std::task::Poll::Ready(Ok(()));
-            }
-        } else {
-            if !read_buf.is_empty() {
-                let to_read = std::cmp::min(read_buf.len(), buf.remaining());
-                let data = read_buf.split_to(to_read);
-                buf.put_slice(&data[..to_read]);
-                return std::task::Poll::Ready(Ok(()));
-            }
-
-            pin.poll_read(cx, buf)
         }
+
+        // Deliver any body bytes that arrived alongside the last header chunk.
+        if !this.buf.is_empty() {
+            let to_read = this.buf.len().min(buf.remaining());
+            buf.put_slice(&this.buf[..to_read]);
+            let _ = this.buf.split_to(to_read);
+            return Poll::Ready(Ok(()));
+        }
+
+        // No buffered bytes — read directly from the inner stream.
+        pin.poll_read(cx, buf)
     }
 }
 
 impl AsyncWrite for HttpStream {
     fn poll_write(
         self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
+        cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> std::task::Poll<std::io::Result<usize>> {
-        let Self {
-            bufio,
-            buf: write_buf,
-            header_sent,
-            ..
-        } = self.get_mut();
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
 
-        if !*header_sent {
-            let mut req = BytesMut::new();
-            let req_line = format!("GET {} HTTP/1.1\r\n", self.path);
-            req.reserve(req_line.len());
-            req.put_slice(req_line.as_bytes());
-
-            let header_line = format!("Host: {}\r\n", self.host);
-            req.reserve(header_line.len());
-            req.put_slice(header_line.as_bytes());
-
-            for (k, v) in self.headers.iter() {
-                let header_line = format!("{}: {}\r\n", k, v);
-                req.reserve(header_line.len());
-                req.put_slice(header_line.as_bytes());
-            }
-
-            req.put_slice(buf);
-
-            let result = Pin::new(&mut *bufio).poll_write(cx, req.as_ref());
-
-            *header_sent = true;
-            result
-        } else {
-            Pin::new(bufio).poll_write(cx, buf)
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
         }
+
+        // A previous write is still being drained (we returned Poll::Pending
+        // last time).  Finish sending those bytes first, then report how many
+        // of the caller's source bytes they represented.  The caller will
+        // re-issue poll_write with the same buf once it gets Poll::Ready.
+        if this.write_committed > 0 {
+            ready!(drain_write_buf(this, cx))?;
+            let committed = this.write_committed;
+            this.write_committed = 0;
+            this.write_pos = 0;
+            this.write_buf.clear();
+            return Poll::Ready(Ok(committed));
+        }
+
+        // Build the wire buffer: HTTP request headers (first write only)
+        // followed by the caller's payload.
+        this.write_buf.clear();
+        if !this.header_sent {
+            this.header_sent = true;
+            let req_line = format!("GET {} HTTP/1.1\r\n", this.path);
+            this.write_buf.put_slice(req_line.as_bytes());
+            let host_line = format!("Host: {}\r\n", this.host);
+            this.write_buf.put_slice(host_line.as_bytes());
+            for (k, v) in this.headers.iter() {
+                let header_line = format!("{}: {}\r\n", k, v);
+                this.write_buf.put_slice(header_line.as_bytes());
+            }
+        }
+        this.write_buf.put_slice(buf);
+        this.write_pos = 0;
+        this.write_committed = buf.len();
+
+        ready!(drain_write_buf(this, cx))?;
+        let committed = this.write_committed;
+        this.write_committed = 0;
+        Poll::Ready(Ok(committed))
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        let Self { bufio, .. } = self.get_mut();
-        Pin::new(&mut bufio).poll_flush(cx)
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        ready!(drain_write_buf(this, cx))?;
+        this.write_committed = 0;
+        Pin::new(&mut this.bufio).poll_flush(cx)
     }
 
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), std::io::Error>> {
-        let Self { bufio, .. } = self.get_mut();
-        Pin::new(&mut bufio).poll_shutdown(cx)
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        ready!(drain_write_buf(this, cx))?;
+        this.write_committed = 0;
+        Pin::new(&mut this.bufio).poll_shutdown(cx)
     }
 }


### PR DESCRIPTION
## Summary

### Bug fixes (spotted by reviewing #1330 pattern)

- **`simple_obfs/http.rs`**: Fixed two `Poll::Pending` state-loss bugs:
  - `poll_write`: HTTP upgrade header was rebuilt on every call — lost if inner write returned `Pending`
  - `poll_read`: Partial HTTP response header accumulated in a stack-local buffer — lost on `Pending`, causing parse errors on fragmented responses

- **`vmess/vmess_impl/http.rs`**: Fixed four bugs in the HTTP transport:
  - `poll_write`: Same header rebuild issue as above
  - `poll_read`: Local `header_buf` lost on `Pending`; `BytesMut` with len=0 → 0-capacity `ReadBuf` (inner stream could never deliver bytes); `httparse::Request` used instead of `httparse::Response`; zero header slots allocated

### E2E throughput test harness

Full-stack tests: test client → SOCKS5 inbound → dispatcher → SS outbound → docker proxy container → local echo server → back. 32 MB payload each direction.

**5 parallel tests** (no `#[serial_test::serial]`):
| Test | Transport |
|------|-----------|
| `e2e_throughput_ss_plain` | aes-256-gcm |
| `e2e_throughput_ss_obfs_http` | simple-obfs HTTP |
| `e2e_throughput_ss_obfs_tls` | simple-obfs TLS |
| `e2e_throughput_ss_v2ray_plugin` | WebSocket + TLS |
| `e2e_throughput_ss_shadowtls` | shadow-tls v3 |

Ports allocated via a global `AtomicU16` counter (starting at 52000) — no port collisions possible.

### CI pipeline (`.github/workflows/proxy-throughput.yml`)

- Gated by `--cfg docker_test --cfg throughput_test` (separate from regular docker tests)
- Triggers on PRs touching `clash-lib/src/proxy/**` or manual dispatch
- Results written as JSON lines to `THROUGHPUT_RESULTS_FILE`, formatted as a Markdown table by `bench/format_throughput.py`
- Posts results as a PR comment (upsert) + writes to `$GITHUB_STEP_SUMMARY`
- Uploads raw JSON + log as a 90-day artifact

### Run locally
```bash
cargo build --release -p clash-rs
THROUGHPUT_RESULTS_FILE=results.json RUSTFLAGS="--cfg docker_test --cfg throughput_test" cargo test -p clash-lib --release --all-features e2e_throughput -- --nocapture
python3 bench/format_throughput.py results.json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end throughput tests covering multiple proxy variants and transports
  * Added CI workflow ("Proxy Throughput Tests") to run benchmarks on PRs, upload artifacts, and post formatted summaries

* **Bug Fixes**
  * Improved HTTP obfuscation to correctly handle partial reads/writes, draining, flushing, and shutdown

* **Chores**
  * Added test utilities for port allocation, binary discovery, result persistence, orchestration, and container networking builder options

* **New Features**
  * Added CLI to format raw throughput results into Markdown summaries for artifacts and PR comments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->