### PR TITLE
fix: support domain in proxy-server-nameserver

### DIFF
--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -314,14 +314,15 @@ impl TryFrom<&crate::config::def::Config> for Config {
             }
         }
 
+        // Domain hostnames are allowed here: they are bootstrapped through
+        // `default-nameserver` at client-construction time, mirroring how
+        // `nameserver` resolves its own DoH/DoT hosts.
         let proxy_server_nameserver = if !dc.proxy_server_nameserver.is_empty() {
             let ns = Config::parse_nameserver(&dc.proxy_server_nameserver)?;
-            for n in &ns {
-                if let url::Host::Domain(_) = n.host {
-                    return Err(Error::InvalidConfig(String::from(
-                        "proxy server nameserver must be ip address",
-                    )));
-                }
+            if ns.is_empty() {
+                return Err(Error::InvalidConfig(String::from(
+                    "proxy-server-nameserver has no usable entries (all skipped)",
+                )));
             }
             Some(ns)
         } else {

--- a/clash-lib/src/app/dns/resolver/enhanced.rs
+++ b/clash-lib/src/app/dns/resolver/enhanced.rs
@@ -130,16 +130,24 @@ impl EnhancedResolver {
 
         let proxy_resolver =
             if let Some(proxy_resolver) = cfg.proxy_server_nameserver {
-                Some(
-                    make_clients(
-                        proxy_resolver,
-                        None,
-                        Arc::new(RwLock::new(std::collections::HashMap::new())),
-                        edns_client_subnet.clone(),
-                        cfg.fw_mark,
-                    )
-                    .await,
+                let clients = make_clients(
+                    proxy_resolver,
+                    Some(default_resolver.clone()),
+                    outbounds.clone(),
+                    edns_client_subnet.clone(),
+                    cfg.fw_mark,
                 )
+                .await;
+                if clients.is_empty() {
+                    warn!(
+                        "no usable proxy-server-nameserver clients were \
+                         initialized; proxy server domain resolution will fall \
+                         back to the main nameservers"
+                    );
+                    None
+                } else {
+                    Some(clients)
+                }
             } else {
                 None
             };
@@ -305,6 +313,12 @@ impl EnhancedResolver {
         clients: &Vec<ThreadSafeDNSClient>,
         message: &op::Message,
     ) -> anyhow::Result<op::Message> {
+        if clients.is_empty() {
+            return Err(Error::DNSError(
+                "no DNS clients available for query".into(),
+            )
+            .into());
+        }
         let mut queries = Vec::new();
         for c in clients {
             queries.push(


### PR DESCRIPTION
This pull request improves the handling and validation of the `proxy-server-nameserver` configuration in the DNS resolver. The changes ensure that domain hostnames are properly supported, empty or unusable nameserver lists are detected early, and the system gracefully falls back or errors out when no valid DNS clients are available.

**Validation and error handling improvements:**

* Updated the parsing logic in `Config` to allow domain hostnames for `proxy-server-nameserver`, and now returns a clear error if no usable entries are found after parsing.
* In `EnhancedResolver`, added a check to log a warning and fall back to main nameservers if no proxy-server-nameserver clients are initialized, instead of proceeding with an empty list.
* Added a guard in the DNS query method to return an explicit error if there are no DNS clients available for a query, preventing potential panics or undefined behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS nameserver validation now accepts domain hostnames in addition to IP addresses for proxy server configurations.
  * Improved error messaging when nameserver entries fail to parse.
  * Enhanced fallback behavior: if proxy-server nameserver initialization fails, DNS resolution automatically reverts to main nameservers for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->