### PR TITLE
refactor(test): run all docker integration tests in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ panic = "abort"
 
 [workspace.lints.rust]
 warnings = "deny"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker_test)', 'cfg(throughput_test)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker_test)', 'cfg(throughput_test)', 'cfg(tokio_unstable)'] }
 
 [workspace.lints.clippy]
 redundant_clone = "deny"

--- a/clash-lib/src/app/logging.rs
+++ b/clash-lib/src/app/logging.rs
@@ -200,10 +200,10 @@ fn setup_logging_inner(
     let subscriber = tracing_subscriber::registry();
 
     // Collect and expose data about the Tokio runtime (tasks, threads, resources,
-    // etc.)
-    #[cfg(feature = "telemetry")]
+    // etc.) — requires RUSTFLAGS="--cfg tokio_unstable" at compile time.
+    #[cfg(all(feature = "telemetry", tokio_unstable))]
     let subscriber = subscriber.with(console_subscriber::spawn());
-    #[cfg(feature = "telemetry")]
+    #[cfg(all(feature = "telemetry", tokio_unstable))]
     let filter = filter
         .add_directive("tokio=trace".parse().unwrap())
         .add_directive("runtime=trace".parse().unwrap());

--- a/clash-lib/src/app/logging.rs
+++ b/clash-lib/src/app/logging.rs
@@ -200,7 +200,11 @@ fn setup_logging_inner(
     let subscriber = tracing_subscriber::registry();
 
     // Collect and expose data about the Tokio runtime (tasks, threads, resources,
-    // etc.) — requires RUSTFLAGS="--cfg tokio_unstable" at compile time.
+    // etc.) — gated on tokio_unstable because console_subscriber panics at
+    // runtime if Tokio was compiled without --cfg tokio_unstable. When tests
+    // are run with RUSTFLAGS="--cfg docker_test", that env-var overrides
+    // .cargo/config.toml, so tokio_unstable is absent and the gate correctly
+    // excludes this code.
     #[cfg(all(feature = "telemetry", tokio_unstable))]
     let subscriber = subscriber.with(console_subscriber::spawn());
     #[cfg(all(feature = "telemetry", tokio_unstable))]

--- a/clash-lib/src/common/mmdb.rs
+++ b/clash-lib/src/common/mmdb.rs
@@ -119,8 +119,9 @@ impl Mmdb {
                     e.to_string()
                 );
 
-                // try to download again
-                fs::remove_file(&mmdb_file)?;
+                // try to download again; ignore ENOENT — another concurrent
+                // caller may have already removed the file
+                let _ = fs::remove_file(&mmdb_file);
 
                 info!(
                     "mmdb {:?} corrupt, re-downloading mmdb from {download_url}",

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -182,7 +182,12 @@ pub fn setup_default_crypto_provider() {
         #[cfg(feature = "aws-lc-rs")]
         {
             _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-            // watfaq-rustls is a separate crate fork with its own provider state.
+            // watfaq-rustls is a separate fork with its own global provider
+            // state. When both `ring` and `aws-lc-rs` features are active
+            // (e.g. `--all-features`), its
+            // `get_default_or_install_from_crate_features` treats the
+            // combination as ambiguous and returns None, causing a
+            // panic. Explicit installation is therefore required.
             _ = watfaq_rustls::crypto::aws_lc_rs::default_provider()
                 .install_default();
         }

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -181,11 +181,15 @@ pub fn setup_default_crypto_provider() {
     CRYPTO_PROVIDER_LOCK.get_or_init(|| {
         #[cfg(feature = "aws-lc-rs")]
         {
-            _ = rustls::crypto::aws_lc_rs::default_provider().install_default()
+            _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+            // watfaq-rustls is a separate crate fork with its own provider state.
+            _ = watfaq_rustls::crypto::aws_lc_rs::default_provider()
+                .install_default();
         }
-        #[cfg(feature = "ring")]
+        #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
         {
-            _ = rustls::crypto::ring::default_provider().install_default()
+            _ = rustls::crypto::ring::default_provider().install_default();
+            _ = watfaq_rustls::crypto::ring::default_provider().install_default();
         }
     });
 }

--- a/clash-lib/src/proxy/anytls/mod.rs
+++ b/clash-lib/src/proxy/anytls/mod.rs
@@ -491,7 +491,9 @@ mod tests {
                 Suite,
                 config_helper::test_config_base_dir,
                 consts::{IMAGE_SINGBOX, LOCAL_ADDR},
-                docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                docker_runner::{
+                    DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                },
                 run_test_suites_and_cleanup,
             },
         },
@@ -798,7 +800,7 @@ mod tests {
     // ---- docker integration tests ----
 
     #[cfg(docker_test)]
-    async fn get_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("anytls.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -812,15 +814,16 @@ mod tests {
                 (cert.to_str().unwrap(), "/etc/ssl/v2ray/fullchain.pem"),
                 (key.to_str().unwrap(), "/etc/ssl/v2ray/privkey.pem"),
             ])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[cfg(docker_test)]
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_anytls() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
 
         let tls = transport::TlsClient::new(
             true,
@@ -829,7 +832,7 @@ mod tests {
             None,
         );
 
-        let runner = get_runner().await?;
+        let runner = get_runner(host_port).await?;
 
         let opts = HandlerOptions {
             name: "test-anytls".to_owned(),

--- a/clash-lib/src/proxy/group/relay/mod.rs
+++ b/clash-lib/src/proxy/group/relay/mod.rs
@@ -215,7 +215,9 @@ mod tests {
             utils::test_utils::{
                 Suite,
                 consts::*,
-                docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                docker_runner::{
+                    DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                },
                 run_test_suites_and_cleanup,
             },
         },
@@ -229,6 +231,7 @@ mod tests {
         let host = format!("0.0.0.0:{}", port);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SS_RUST)
+            .port(port)
             .entrypoint(&["ssserver"])
             .cmd(&["-s", &host, "-m", CIPHER, "-k", PASSWORD, "-U"])
             .build()
@@ -236,10 +239,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_relay_1() -> anyhow::Result<()> {
         initialize();
-        let port = 10002;
+        let port = alloc_docker_port();
         let container = get_ss_runner(port).await?;
 
         let container_ip = container.container_ip();
@@ -275,10 +277,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_relay_2() -> anyhow::Result<()> {
         initialize();
-        let port = 10002;
+        let port = alloc_docker_port();
         let container = get_ss_runner(port).await?;
 
         let container_ip = container.container_ip();

--- a/clash-lib/src/proxy/group/smart/mod.rs
+++ b/clash-lib/src/proxy/group/smart/mod.rs
@@ -757,7 +757,9 @@ mod tests {
             utils::test_utils::{
                 Suite,
                 consts::*,
-                docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                docker_runner::{
+                    DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                },
                 run_test_suites_and_cleanup,
             },
         },
@@ -775,6 +777,7 @@ mod tests {
         let host = format!("0.0.0.0:{}", port);
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SS_RUST)
+            .port(port)
             .entrypoint(&["ssserver"])
             .cmd(&["-s", &host, "-m", CIPHER, "-k", PASSWORD, "-U"])
             .build()
@@ -782,10 +785,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_smart_group_smoke() -> anyhow::Result<()> {
         initialize();
-        let ss_port = 10002;
+        let ss_port = alloc_docker_port();
 
         let docker_runner = get_ss_runner(ss_port).await?;
 

--- a/clash-lib/src/proxy/hysteria2/mod.rs
+++ b/clash-lib/src/proxy/hysteria2/mod.rs
@@ -702,8 +702,10 @@ mod tests {
         proxy::utils::{
             GLOBAL_DIRECT_CONNECTOR,
             test_utils::{
-                Suite, config_helper::test_config_base_dir,
-                docker_runner::DockerTestRunnerBuilder, run_test_suites_and_cleanup,
+                Suite,
+                config_helper::test_config_base_dir,
+                docker_runner::{DockerTestRunnerBuilder, alloc_docker_port},
+                run_test_suites_and_cleanup,
             },
         },
         tests::initialize,
@@ -711,7 +713,9 @@ mod tests {
 
     use super::*;
 
-    async fn get_hysteria_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_hysteria_runner(
+        host_port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("hysteria.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -725,16 +729,17 @@ mod tests {
                 (key.to_str().unwrap(), "/home/ubuntu/my.key"),
             ])
             .cmd(&["server"])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_hysteria() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
 
-        let container = get_hysteria_runner().await?;
+        let container = get_hysteria_runner(host_port).await?;
 
         let container_ip =
             container.container_ip().unwrap_or("127.0.0.1".to_owned());

--- a/clash-lib/src/proxy/shadowquic/mod.rs
+++ b/clash-lib/src/proxy/shadowquic/mod.rs
@@ -273,8 +273,10 @@ mod tests {
         proxy::utils::{
             GLOBAL_DIRECT_CONNECTOR,
             test_utils::{
-                Suite, config_helper::test_config_base_dir,
-                docker_runner::DockerTestRunnerBuilder, run_test_suites_and_cleanup,
+                Suite,
+                config_helper::test_config_base_dir,
+                docker_runner::{DockerTestRunnerBuilder, alloc_docker_port},
+                run_test_suites_and_cleanup,
             },
         },
         tests::initialize,
@@ -282,27 +284,30 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    async fn get_shadowquic_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_shadowquic_runner(
+        host_port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("shadowquic.yaml");
 
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SHADOWQUIC)
             .mounts(&[(conf.to_str().unwrap(), "/etc/shadowquic/config.yaml")])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
-    const PORT: u16 = 10002;
-
     fn gen_options(
         opt_ip: Option<String>,
+        host_port: u16,
         over_stream: bool,
     ) -> anyhow::Result<HandlerOptions> {
+        let port = if opt_ip.is_some() { 10002 } else { host_port };
         Ok(HandlerOptions {
             addr: SocketAddr::new(
                 opt_ip.unwrap_or(LOCAL_ADDR.to_owned()).parse().unwrap(),
-                PORT,
+                port,
             )
             .to_string(),
             password: "12345678".into(),
@@ -317,15 +322,15 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_shadowquic_over_datagram() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
 
-        let container = get_shadowquic_runner().await?;
+        let container = get_shadowquic_runner(host_port).await?;
 
         let container_ip = container.container_ip();
 
-        let opts = gen_options(container_ip, false)?;
+        let opts = gen_options(container_ip, host_port, false)?;
 
         let handler = Arc::new(Handler::new("test-shadowquic".into(), opts));
         handler
@@ -334,14 +339,14 @@ mod tests {
         run_test_suites_and_cleanup(handler, container, Suite::all()).await
     }
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_shadowquic_over_stream() -> anyhow::Result<()> {
         initialize();
-        let container = get_shadowquic_runner().await?;
+        let host_port = alloc_docker_port();
+        let container = get_shadowquic_runner(host_port).await?;
 
         let container_ip = container.container_ip();
 
-        let mut opts = gen_options(container_ip, true)?;
+        let mut opts = gen_options(container_ip, host_port, true)?;
         opts.over_stream = true;
 
         let handler = Arc::new(Handler::new("test-shadowquic".into(), opts));

--- a/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
+++ b/clash-lib/src/proxy/shadowsocks/outbound/mod.rs
@@ -272,7 +272,8 @@ mod tests {
                 config_helper::test_config_base_dir,
                 consts::*,
                 docker_runner::{
-                    DockerTestRunner, DockerTestRunnerBuilder, MultiDockerTestRunner,
+                    DockerTestRunner, DockerTestRunnerBuilder,
+                    MultiDockerTestRunner, alloc_docker_port,
                 },
                 run_test_suites_and_cleanup,
             },
@@ -337,10 +338,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ss_plain() -> anyhow::Result<()> {
         initialize();
-        let port = 10002;
+        let port = alloc_docker_port();
         let container = get_ss_runner(port).await?;
 
         let opts = HandlerOptions {
@@ -388,19 +388,19 @@ mod tests {
                 "V3=1",
             ])
             // .cmd(&["-s", "0.0.0.0:10002", "-m", CIPHER, "-k", PASSWORD, "-U"])
+            .port(stls_port)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_shadowtls() -> anyhow::Result<()> {
         initialize();
         // the real port that used for communication
-        let shadow_tls_port = 10002;
+        let shadow_tls_port = alloc_docker_port();
         // not important, you can assign any port that is not conflict with
         // others
-        let ss_port = 10004;
+        let ss_port = alloc_docker_port();
 
         let container1 = get_ss_runner(ss_port).await?;
 
@@ -462,13 +462,14 @@ mod tests {
                 &ss_server_env,
                 "-vv",
             ])
+            .port(obfs_port)
             .build()
             .await
     }
 
     async fn test_ss_obfs_inner(mode: SimpleOBFSMode) -> anyhow::Result<()> {
-        let obfs_port = 10002;
-        let ss_port = 10004;
+        let obfs_port = alloc_docker_port();
+        let ss_port = alloc_docker_port();
 
         let container1 = get_ss_runner(ss_port).await?;
         let container2 =
@@ -501,24 +502,21 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ss_obfs_http() -> anyhow::Result<()> {
         initialize();
         test_ss_obfs_inner(SimpleOBFSMode::Http).await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ss_obfs_tls() -> anyhow::Result<()> {
         initialize();
         test_ss_obfs_inner(SimpleOBFSMode::Tls).await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ss_v2ray_plugin() -> anyhow::Result<()> {
         initialize();
-        let ss_port = 10004;
+        let ss_port = alloc_docker_port();
         let container = get_ss_runner_with_plugin(ss_port).await?;
         let host = "example.org".to_owned();
         let plugin = V2rayWsClient::try_new(
@@ -706,11 +704,6 @@ mod e2e {
 socks-port: {socks_port}
 bind-address: 127.0.0.1
 mmdb: "{mmdb}"
-# Clash-rs defaults geosite to "geosite.dat" in compatibility mode (which is
-# on by default) and downloads it if missing.  Point to /dev/null instead:
-# an empty file is a valid protobuf GeoSiteList, so no download occurs and
-# our geo-free rules still work.
-geosite: /dev/null
 mode: global
 log-level: error
 proxies:

--- a/clash-lib/src/proxy/socks/outbound/mod.rs
+++ b/clash-lib/src/proxy/socks/outbound/mod.rs
@@ -295,7 +295,9 @@ mod tests {
                 test_utils::{
                     Suite,
                     consts::{IMAGE_SOCKS5, LOCAL_ADDR},
-                    docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                    docker_runner::{
+                        DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                    },
                     run_test_suites_and_cleanup,
                 },
             },
@@ -308,7 +310,10 @@ mod tests {
     const USER: &str = "user";
     const PASSWORD: &str = "password";
 
-    async fn get_socks5_runner(auth: bool) -> anyhow::Result<DockerTestRunner> {
+    async fn get_socks5_runner(
+        auth: bool,
+        host_port: u16,
+    ) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = if auth {
             test_config_dir.join("socks5-auth.json")
@@ -319,6 +324,7 @@ mod tests {
         DockerTestRunnerBuilder::new()
             .image(IMAGE_SOCKS5)
             .mounts(&[(conf.to_str().unwrap(), "/etc/v2ray/config.json")])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
@@ -328,11 +334,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_socks5_no_auth() -> anyhow::Result<()> {
         initialize();
-        let port = 10002;
-        let runner = get_socks5_runner(false).await?;
+        let host_port = alloc_docker_port();
+        let port = 10002_u16;
+        let runner = get_socks5_runner(false, host_port).await?;
         let opts = HandlerOptions {
             name: "test-socks5-no-auth".to_owned(),
             common_opts: Default::default(),
@@ -348,12 +354,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_socks5_auth() -> anyhow::Result<()> {
         use crate::proxy::DialWithConnector;
         initialize();
-        let port = 10002;
-        let runner = get_socks5_runner(true).await?;
+        let host_port = alloc_docker_port();
+        let port = 10002_u16;
+        let runner = get_socks5_runner(true, host_port).await?;
         let opts = HandlerOptions {
             name: "test-socks5-auth".to_owned(),
             common_opts: Default::default(),

--- a/clash-lib/src/proxy/ssh/mod.rs
+++ b/clash-lib/src/proxy/ssh/mod.rs
@@ -288,8 +288,10 @@ mod tests {
     };
     use crate::{
         proxy::utils::test_utils::{
-            Suite, config_helper::test_config_base_dir,
-            docker_runner::DockerTestRunnerBuilder, run_test_suites_and_cleanup,
+            Suite,
+            config_helper::test_config_base_dir,
+            docker_runner::{DockerTestRunnerBuilder, alloc_docker_port},
+            run_test_suites_and_cleanup,
         },
         tests::initialize,
     };
@@ -321,6 +323,7 @@ mod tests {
     /// /tmp/.xxx/ssh/ssh_host_keys.
     async fn get_openssh_server_runner(
         ssh_config_path: PathBuf,
+        host_port: u16,
     ) -> anyhow::Result<DockerTestRunner> {
         let password = format!("USER_PASSWORD={}", PASSWORD);
         DockerTestRunnerBuilder::new()
@@ -334,7 +337,7 @@ mod tests {
                 &password,
             ])
             .mounts(&[(ssh_config_path.to_str().unwrap(), "/config")])
-            .port(2222)
+            .host_port(host_port, 2222)
             .build()
             .await
     }
@@ -362,7 +365,7 @@ mod tests {
         host_key: Option<Vec<String>>, // host key
     }
 
-    async fn test_ssh_inner(opt: TestOption) -> anyhow::Result<()> {
+    async fn test_ssh_inner(opt: TestOption, host_port: u16) -> anyhow::Result<()> {
         tracing::info!("testing ssh, using option: {:?}", opt);
 
         // Prepare SSH config directory for the docker container
@@ -437,7 +440,8 @@ mod tests {
 
         // Start the container
         let container =
-            get_openssh_server_runner(ssh_config_tmp_path.clone()).await?;
+            get_openssh_server_runner(ssh_config_tmp_path.clone(), host_port)
+                .await?;
 
         // Configure client to connect to container
         let ssh_private_key_path = ssh_config_path.join(".ssh").join(if opt.rsa {
@@ -535,55 +539,67 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ssh1() -> anyhow::Result<()> {
         initialize();
-        test_ssh_inner(TestOption {
-            password: true,
-            rsa: false,
-            host_key: None,
-        })
+        let host_port = alloc_docker_port();
+        test_ssh_inner(
+            TestOption {
+                password: true,
+                rsa: false,
+                host_key: None,
+            },
+            host_port,
+        )
         .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ssh2() -> anyhow::Result<()> {
         initialize();
-        test_ssh_inner(TestOption {
-            password: false,
-            rsa: true,
-            host_key: None,
-        })
+        let host_port = alloc_docker_port();
+        test_ssh_inner(
+            TestOption {
+                password: false,
+                rsa: true,
+                host_key: None,
+            },
+            host_port,
+        )
         .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ssh3() -> anyhow::Result<()> {
         initialize();
-        test_ssh_inner(TestOption {
-            password: false,
-            rsa: false,
-            host_key: None,
-        })
+        let host_port = alloc_docker_port();
+        test_ssh_inner(
+            TestOption {
+                password: false,
+                rsa: false,
+                host_key: None,
+            },
+            host_port,
+        )
         .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_ssh4() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
         // config wrong host key, expect failure
         let host_key = Some(
             vec![
             "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtnezeRnexr9UgviTV66AcQ0uGQ9gx4t0GjVA29SstlBgZ5750DmKdxYt3PrCC2qslVOfnpW/1XNMSmRtuqM2C0/uaRBx/lAPyjEQ3IwLHTk7CxirzNw46nYBeIKBKYcdP6LIfdvZ9+avd6+SGIJVrBovBHzV2aIpDEG3dO+9op7gzGPpdRHP4WnOdAuSnLCaAvrSs+amFEmrD+nZLMwUMfX5H9huGJNxo1/ma4Ti3jclY8Utw+K6y2NUNB7YXuiJg2Ugfnu6d54VBg9lA2o481Ol0ys2i46sdmWhaVPRGlWTmQ1fAsbd+9u3/2ae6n9Oc6V88izGUrH8sFb23FmlAbHF5tT2nnOs1XzQPCiUsHgn2XVidEONe2Q/FJbfoA4fUYmoQPGprXzHcvtguUajww7dwYfyEXU6IxNRVl5H+64fnsQ2shVAnpJ10fzSrK1RtcnF3zWGvix2z/wOzgx2ydUV9lNp7tU3bOX2iL8CvYBFwnFqEHRGH5Ry9km1ujdE=".to_owned()
         ]);
-        let res = test_ssh_inner(TestOption {
-            password: false,
-            rsa: false,
-            host_key,
-        })
+        let res = test_ssh_inner(
+            TestOption {
+                password: false,
+                rsa: false,
+                host_key,
+            },
+            host_port,
+        )
         .await;
         assert!(res.is_err());
         Ok(())

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -152,6 +152,10 @@ pub struct ClientInner {
 mod tests {
     use super::*;
 
+    fn setup() {
+        crate::setup_default_crypto_provider();
+    }
+
     fn make_stream() -> AnyStream {
         let (client, _server) = tokio::io::duplex(1024);
         Box::new(client)
@@ -168,6 +172,7 @@ mod tests {
     // short_id > 8 bytes → RealityConfig::new() fails → InvalidInput
     #[tokio::test]
     async fn test_short_id_too_long() {
+        setup();
         let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 9]);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -176,6 +181,7 @@ mod tests {
     // Invalid SNI → ServerName::try_from fails → InvalidInput
     #[tokio::test]
     async fn test_invalid_sni() {
+        setup();
         let c = Client::new("".to_string(), [0u8; 32], vec![0u8; 4]);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -184,6 +190,7 @@ mod tests {
     // Valid params, server side dropped → TLS handshake error (not InvalidInput)
     #[tokio::test]
     async fn test_handshake_error_on_closed_peer() {
+        setup();
         let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 4]);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_ne!(err.kind(), io::ErrorKind::InvalidInput);

--- a/clash-lib/src/proxy/trojan/mod.rs
+++ b/clash-lib/src/proxy/trojan/mod.rs
@@ -251,14 +251,16 @@ mod tests {
                 Suite,
                 config_helper::test_config_base_dir,
                 consts::*,
-                docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                docker_runner::{
+                    DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                },
                 run_test_suites_and_cleanup,
             },
         },
         tests::initialize,
     };
 
-    async fn get_ws_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_ws_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let trojan_conf = test_config_dir.join("trojan-ws.json");
         let trojan_cert = test_config_dir.join("example.org.pem");
@@ -271,15 +273,16 @@ mod tests {
                 (trojan_cert.to_str().unwrap(), "/fullchain.pem"),
                 (trojan_key.to_str().unwrap(), "/privkey.pem"),
             ])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_trojan_ws() -> anyhow::Result<()> {
         let span = tracing::info_span!("test_trojan_ws");
         let _enter = span.enter();
+        let host_port = alloc_docker_port();
         let transport = transport::WsClient::new(
             "".to_owned(),
             10002,
@@ -294,7 +297,7 @@ mod tests {
         let tls =
             transport::TlsClient::new(true, "example.org".to_owned(), None, None);
 
-        let container = get_ws_runner().await?;
+        let container = get_ws_runner(host_port).await?;
 
         let opts = HandlerOptions {
             name: "test-trojan-ws".to_owned(),
@@ -314,7 +317,7 @@ mod tests {
         run_test_suites_and_cleanup(handler, container, Suite::all()).await
     }
 
-    async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_grpc_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("trojan-grpc.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -327,14 +330,15 @@ mod tests {
                 (cert.to_str().unwrap(), "/etc/ssl/v2ray/fullchain.pem"),
                 (key.to_str().unwrap(), "/etc/ssl/v2ray/privkey.pem"),
             ])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_trojan_grpc() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
         let transport = transport::GrpcClient::new(
             "example.org".to_owned(),
             "example"
@@ -349,7 +353,7 @@ mod tests {
             None,
         );
 
-        let runner = get_grpc_runner().await?;
+        let runner = get_grpc_runner(host_port).await?;
 
         let opts = HandlerOptions {
             name: "test-trojan-grpc".to_owned(),

--- a/clash-lib/src/proxy/tuic/mod.rs
+++ b/clash-lib/src/proxy/tuic/mod.rs
@@ -419,15 +419,17 @@ mod tests {
         proxy::utils::{
             GLOBAL_DIRECT_CONNECTOR,
             test_utils::{
-                Suite, config_helper::test_config_base_dir,
-                docker_runner::DockerTestRunnerBuilder, run_test_suites_and_cleanup,
+                Suite,
+                config_helper::test_config_base_dir,
+                docker_runner::{DockerTestRunnerBuilder, alloc_docker_port},
+                run_test_suites_and_cleanup,
             },
         },
         tests::initialize,
     };
 
     use super::*;
-    async fn get_tuic_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_tuic_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("tuic.toml");
         let cert = test_config_dir.join("example.org.pem");
@@ -441,20 +443,25 @@ mod tests {
                 (key.to_str().unwrap(), "/opt/tuic/privkey.pem"),
             ])
             .env(&["TUIC_FORCE_TOML=1"])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
-    const PORT: u16 = 10002;
-
     fn gen_options(
         container_ip: Option<String>,
+        host_port: u16,
         skip_cert_verify: bool,
     ) -> anyhow::Result<HandlerOptions> {
+        let port = if container_ip.is_some() {
+            10002
+        } else {
+            host_port
+        };
         Ok(HandlerOptions {
             name: "test-tuic".to_owned(),
             server: container_ip.unwrap_or(LOCAL_ADDR.to_owned()),
-            port: PORT,
+            port,
             common_opts: Default::default(),
             uuid: "00000000-0000-0000-0000-000000000001".parse()?,
             password: "passwd".into(),
@@ -479,12 +486,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_tuic_skip_cert_verify() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
 
-        let container = get_tuic_runner().await?;
-        let opts = gen_options(container.container_ip(), true)?;
+        let container = get_tuic_runner(host_port).await?;
+        let opts = gen_options(container.container_ip(), host_port, true)?;
 
         let handler = Arc::new(Handler::new(opts));
         handler
@@ -494,13 +501,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_tuic_cert_verify_expect_fail() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
 
-        let container = get_tuic_runner().await?;
+        let container = get_tuic_runner(host_port).await?;
 
-        let opts = gen_options(container.container_ip(), false)?;
+        let opts = gen_options(container.container_ip(), host_port, false)?;
 
         let handler = Arc::new(Handler::new(opts));
         handler

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
@@ -471,6 +471,40 @@ impl DockerTestRunnerBuilder {
         self
     }
 
+    /// Map a dynamic host port to a fixed container port.
+    /// Use when the container always listens on `container_port` (hardcoded in
+    /// its config file) but we need a unique host port to avoid EADDRINUSE
+    /// collisions between parallel tests.
+    #[allow(dead_code)]
+    pub fn host_port(mut self, host_port: u16, container_port: u16) -> Self {
+        self._server_port = host_port;
+        self.exposed_ports = vec![
+            format!("{}/tcp", container_port),
+            format!("{}/udp", container_port),
+        ];
+        let bindings: std::collections::HashMap<String, Option<Vec<PortBinding>>> =
+            [
+                (
+                    format!("{}/tcp", container_port),
+                    Some(vec![PortBinding {
+                        host_ip: Some("0.0.0.0".to_owned()),
+                        host_port: Some(format!("{}", host_port)),
+                    }]),
+                ),
+                (
+                    format!("{}/udp", container_port),
+                    Some(vec![PortBinding {
+                        host_ip: Some("0.0.0.0".to_owned()),
+                        host_port: Some(format!("{}", host_port)),
+                    }]),
+                ),
+            ]
+            .into_iter()
+            .collect();
+        self.host_config.port_bindings = Some(bindings);
+        self
+    }
+
     /// Do not bind any host port.  Use this when the container is accessed
     /// exclusively via its internal docker network IP (e.g. e2e tests that
     /// spawn a clash-rs subprocess which connects via container IP).  Avoids
@@ -566,6 +600,16 @@ impl DockerTestRunnerBuilder {
         .await
         .map_err(Into::into)
     }
+}
+
+/// Allocate a free TCP port by asking the OS. The listener is immediately
+/// dropped so Docker can bind the same port. The TOCTOU window is negligible
+/// in test environments.
+#[cfg(docker_test)]
+pub fn alloc_docker_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("failed to allocate a free port");
+    listener.local_addr().unwrap().port()
 }
 
 pub fn get_host_config(port: u16) -> HostConfig {

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -22,19 +22,14 @@ use tracing::{debug, info, trace};
 
 // ── Port allocator
 // ────────────────────────────────────────────────────────────
-/// Allocate a free port by asking the OS for one. Each call returns a unique
-/// port so parallel tests never collide with each other or with ephemeral
-/// ports.
+/// Allocate a free TCP port by asking the OS. The listener is immediately
+/// dropped so the caller can bind the same port. Used by throughput tests
+/// where multiple ports must be reserved up-front.
 #[cfg(throughput_test)]
 pub fn alloc_port() -> u16 {
-    // Bind port 0 to let the OS pick a free port, then release it.
-    // TOCTOU race is acceptable in test environments.
-    let listener =
-        std::net::TcpListener::bind("127.0.0.1:0").expect("alloc_port: bind failed");
-    listener
-        .local_addr()
-        .expect("alloc_port: local_addr")
-        .port()
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("failed to allocate a free port");
+    listener.local_addr().unwrap().port()
 }
 
 // ── ThroughputResult
@@ -76,23 +71,14 @@ fn write_throughput_result(result: &ThroughputResult) {
 #[cfg(throughput_test)]
 pub fn find_clash_rs_binary() -> std::path::PathBuf {
     let root = config_helper::root_dir();
-    // Prefer the release binary: it's faster (important for throughput tests)
-    // and avoids the `telemetry` feature deadlock that occurs when
-    // `cargo build --all-features` is used (console_subscriber + OpenTelemetry
-    // threads compete with the main thread over a mutex during crypto init).
-    // Build with: cargo build --release --bin clash-rs
-    let release = root.join("target/release/clash-rs");
     let debug = root.join("target/debug/clash-rs");
-    if release.exists() {
-        release
-    } else if debug.exists() {
+    let release = root.join("target/release/clash-rs");
+    if debug.exists() {
         debug
+    } else if release.exists() {
+        release
     } else {
-        panic!(
-            "clash-rs binary not found — run `cargo build --release --bin \
-             clash-rs` first (do NOT use --all-features: the telemetry feature \
-             causes startup deadlocks when multiple instances run concurrently)"
-        )
+        panic!("clash-rs binary not found — run `cargo build -p clash-rs` first")
     }
 }
 
@@ -154,7 +140,6 @@ fn destination_list(gateway_ip: Option<String>) -> Vec<String> {
 pub async fn ping_pong_test(
     handler: Arc<dyn OutboundHandler>,
     gateway_ip: Option<String>,
-    port: u16,
 ) -> anyhow::Result<()> {
     // PATH: our proxy handler -> proxy-server(container) -> target local
     // server(127.0.0.1:port)
@@ -163,7 +148,9 @@ pub async fn ping_pong_test(
 
     let resolver = config_helper::build_dns_resolver().await?;
 
-    let listener = TcpListener::bind(format!("0.0.0.0:{}", port).as_str()).await?;
+    // Bind to port 0: OS assigns a free port atomically, no TOCTOU window.
+    let listener = TcpListener::bind("0.0.0.0:0").await?;
+    let port = listener.local_addr()?.port();
 
     info!("target local server started at: {}", listener.local_addr()?);
 
@@ -365,7 +352,6 @@ pub async fn ping_pong_test(
 pub async fn ping_pong_udp_test(
     handler: Arc<dyn OutboundHandler>,
     gateway_ip: Option<String>,
-    port: u16,
 ) -> anyhow::Result<()> {
     // PATH: our proxy handler -> proxy-server(container) -> target local
     // server(127.0.0.1:port)
@@ -374,7 +360,9 @@ pub async fn ping_pong_udp_test(
 
     let resolver = config_helper::build_dns_resolver().await?;
 
-    let listener = UdpSocket::bind(format!("0.0.0.0:{}", port).as_str()).await?;
+    // Bind to port 0: OS assigns a free port atomically, no TOCTOU window.
+    let listener = UdpSocket::bind("0.0.0.0:0").await?;
+    let port = listener.local_addr()?.port();
     info!("target local server started at: {}", listener.local_addr()?);
 
     async fn destination_fn(
@@ -646,7 +634,6 @@ impl Suite {
 /// Connect to a SOCKS5 proxy at `proxy_addr` and issue a CONNECT to
 /// `target_host:target_port`.  Returns a `TcpStream` ready for data.
 #[cfg(all(docker_test, throughput_test))]
-#[allow(dead_code)]
 async fn socks5_connect(
     proxy_addr: std::net::SocketAddr,
     target_host: &str,
@@ -700,7 +687,6 @@ async fn socks5_connect(
 
 /// Wait until a TCP port accepts connections, or until `timeout_secs` elapses.
 #[cfg(all(docker_test, throughput_test))]
-#[allow(dead_code)]
 async fn wait_for_port(port: u16, timeout_secs: u64) -> anyhow::Result<()> {
     let deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
@@ -741,28 +727,18 @@ pub async fn clash_process_e2e_throughput(
 ) -> anyhow::Result<ThroughputResult> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    // Each clash-rs instance gets its own temp directory so that concurrent
-    // runs never share the same `cache.db` or other working-dir files.
-    let work_dir = tempfile::TempDir::new()?;
-
-    // Write config inside the per-instance work dir so the path stays valid
-    // for the duration of the clash-rs process.
-    let cfg_path = work_dir.path().join("config.yaml");
-    std::fs::write(&cfg_path, config_yaml.as_bytes())?;
+    // --- write config to a temp file ---
+    let mut cfg_file = tempfile::NamedTempFile::new()?;
+    std::io::Write::write_all(&mut cfg_file, config_yaml.as_bytes())?;
+    let cfg_path = cfg_file.path().to_owned();
 
     // --- spawn clash-rs subprocess ---
-    // Log to a per-instance file so output from concurrent runs never interleave
-    // or get lost in pipe buffering.
-    let log_path = work_dir.path().join("clash-rs.log");
-    let log_file = std::fs::File::create(&log_path)?;
-    let log_file2 = log_file.try_clone()?;
     let mut child = tokio::process::Command::new(binary)
         .arg("-c")
         .arg(&cfg_path)
-        .current_dir(work_dir.path())
         .kill_on_drop(true)
-        .stdout(log_file)
-        .stderr(log_file2)
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
         .spawn()
         .map_err(|e| anyhow::anyhow!("failed to spawn clash-rs: {e}"))?;
 
@@ -797,24 +773,8 @@ pub async fn clash_process_e2e_throughput(
     });
 
     // --- wait for SOCKS5 inbound to be ready ---
-    // First, give the process a moment and check it hasn't crashed immediately.
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    if let Ok(Some(status)) = child.try_wait() {
-        let log_content = std::fs::read_to_string(&log_path).unwrap_or_default();
-        anyhow::bail!(
-            "clash-rs [{label}] exited immediately with status: {:?}\n--- log \
-             ---\n{}",
-            status,
-            log_content
-        );
-    }
     wait_for_port(socks_port, 60).await.map_err(|e| {
         child.start_kill().ok();
-        let log_content = std::fs::read_to_string(&log_path).unwrap_or_default();
-        eprintln!(
-            "--- clash-rs [{label}] log (port not ready) ---\n{}",
-            log_content
-        );
         e
     })?;
 
@@ -937,12 +897,8 @@ pub async fn run_test_suites_and_cleanup(
             for suite in suites {
                 match suite {
                     Suite::PingPongTcp => {
-                        let rv = ping_pong_test(
-                            handler.clone(),
-                            gateway_ip.clone(),
-                            10001,
-                        )
-                        .await;
+                        let rv = ping_pong_test(handler.clone(), gateway_ip.clone())
+                            .await;
                         if rv.is_err() {
                             tracing::error!("ping_pong_test failed: {:?}", rv);
                             return rv;
@@ -951,12 +907,9 @@ pub async fn run_test_suites_and_cleanup(
                         }
                     }
                     Suite::PingPongUdp => {
-                        let rv = ping_pong_udp_test(
-                            handler.clone(),
-                            gateway_ip.clone(),
-                            10001,
-                        )
-                        .await;
+                        let rv =
+                            ping_pong_udp_test(handler.clone(), gateway_ip.clone())
+                                .await;
                         if rv.is_err() {
                             tracing::error!("ping_pong_udp_test failed: {:?}", rv);
                             return rv;

--- a/clash-lib/src/proxy/vless/mod.rs
+++ b/clash-lib/src/proxy/vless/mod.rs
@@ -245,7 +245,9 @@ mod tests {
                 docker_utils::{
                     config_helper::test_config_base_dir,
                     consts::*,
-                    docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                    docker_runner::{
+                        DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                    },
                 },
                 run_test_suites_and_cleanup,
             },
@@ -262,7 +264,7 @@ mod tests {
         )))
     }
 
-    async fn get_ws_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_ws_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("vless-ws-tls.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -270,7 +272,7 @@ mod tests {
 
         DockerTestRunnerBuilder::new()
             .image(IMAGE_VLESS)
-            .port(8443)
+            .host_port(host_port, 8443)
             .mounts(&[
                 (conf.to_str().unwrap(), "/etc/v2ray/config.json"),
                 (cert.to_str().unwrap(), "/etc/ssl/v2ray/fullchain.pem"),
@@ -281,11 +283,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_vless_ws() -> anyhow::Result<()> {
         initialize();
         let span = tracing::info_span!("test_vless_ws");
         let _enter = span.enter();
+        let host_port = alloc_docker_port();
         let ws_client = WsClient::new(
             "".to_owned(),
             8443,
@@ -297,7 +299,7 @@ mod tests {
             0,
             "".to_owned(),
         );
-        let runner = get_ws_runner().await?;
+        let runner = get_ws_runner(host_port).await?;
         let opts = HandlerOptions {
             name: "test-vless-ws".into(),
             common_opts: Default::default(),

--- a/clash-lib/src/proxy/vmess/mod.rs
+++ b/clash-lib/src/proxy/vmess/mod.rs
@@ -244,7 +244,9 @@ mod tests {
                 Suite,
                 config_helper::test_config_base_dir,
                 consts::*,
-                docker_runner::{DockerTestRunner, DockerTestRunnerBuilder},
+                docker_runner::{
+                    DockerTestRunner, DockerTestRunnerBuilder, alloc_docker_port,
+                },
                 run_test_suites_and_cleanup,
             },
         },
@@ -260,7 +262,7 @@ mod tests {
         )))
     }
 
-    async fn get_ws_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_ws_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("vmess-ws.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -273,16 +275,17 @@ mod tests {
                 (cert.to_str().unwrap(), "/etc/ssl/v2ray/fullchain.pem"),
                 (key.to_str().unwrap(), "/etc/ssl/v2ray/privkey.pem"),
             ])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_vmess_ws() -> anyhow::Result<()> {
         initialize();
         let span = tracing::info_span!("test_vmess_ws");
         let _enter = span.enter();
+        let host_port = alloc_docker_port();
         let ws_client = WsClient::new(
             "".to_owned(),
             10002,
@@ -295,7 +298,7 @@ mod tests {
             "".to_owned(),
         );
 
-        let runner = get_ws_runner().await?;
+        let runner = get_ws_runner(host_port).await?;
 
         let opts = HandlerOptions {
             name: "test-vmess-ws".into(),
@@ -314,7 +317,7 @@ mod tests {
         run_test_suites_and_cleanup(handler, runner, Suite::all()).await
     }
 
-    async fn get_grpc_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_grpc_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("vmess-grpc.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -327,19 +330,20 @@ mod tests {
                 (cert.to_str().unwrap(), "/etc/ssl/v2ray/fullchain.pem"),
                 (key.to_str().unwrap(), "/etc/ssl/v2ray/privkey.pem"),
             ])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_vmess_grpc() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
         let grpc_client = GrpcClient::new(
             "example.org".to_owned(),
             "example!".to_owned().try_into()?,
         );
-        let container = get_grpc_runner().await?;
+        let container = get_grpc_runner(host_port).await?;
         let opts = HandlerOptions {
             name: "test-vmess-grpc".into(),
             common_opts: Default::default(),
@@ -356,7 +360,7 @@ mod tests {
         run_test_suites_and_cleanup(handler, container, Suite::all()).await
     }
 
-    async fn get_h2_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_h2_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let conf = test_config_dir.join("vmess-http2.json");
         let cert = test_config_dir.join("example.org.pem");
@@ -369,21 +373,22 @@ mod tests {
                 (cert.to_str().unwrap(), "/etc/ssl/v2ray/fullchain.pem"),
                 (key.to_str().unwrap(), "/etc/ssl/v2ray/privkey.pem"),
             ])
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_vmess_h2() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
         let h2_client = H2Client::new(
             vec!["example.org".into()],
             std::collections::HashMap::new(),
             http::Method::POST,
             "/test".to_owned().try_into()?,
         );
-        let container = get_h2_runner().await?;
+        let container = get_h2_runner(host_port).await?;
         let opts = HandlerOptions {
             name: "test-vmess-h2".into(),
             common_opts: Default::default(),

--- a/clash-lib/src/proxy/wg/mod.rs
+++ b/clash-lib/src/proxy/wg/mod.rs
@@ -332,8 +332,9 @@ mod tests {
     use crate::proxy::utils::{
         GLOBAL_DIRECT_CONNECTOR,
         test_utils::{
-            Suite, config_helper::test_config_base_dir,
-            docker_runner::DockerTestRunnerBuilder,
+            Suite,
+            config_helper::test_config_base_dir,
+            docker_runner::{DockerTestRunnerBuilder, alloc_docker_port},
         },
     };
 
@@ -348,7 +349,7 @@ mod tests {
     // see: https://github.com/linuxserver/docker-wireguard?tab=readme-ov-file#usage
     // we shouldn't run the wireguard server with host mode, or
     // the sysctl of `net.ipv4.conf.all.src_valid_mark` will fail
-    async fn get_runner() -> anyhow::Result<DockerTestRunner> {
+    async fn get_runner(host_port: u16) -> anyhow::Result<DockerTestRunner> {
         let test_config_dir = test_config_base_dir();
         let wg_config = test_config_dir.join("wg_config");
         // the following configs is in accordance with the config in `wg_config`
@@ -370,16 +371,17 @@ mod tests {
             .sysctls(&[("net.ipv4.conf.all.src_valid_mark", "1")])
             .cap_add(&["NET_ADMIN"])
             .net_mode("bridge") // the default network mode for testing is `host`
+            .host_port(host_port, 10002)
             .build()
             .await
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_wg() -> anyhow::Result<()> {
         initialize();
+        let host_port = alloc_docker_port();
 
-        let runner = get_runner().await?;
+        let runner = get_runner(host_port).await?;
 
         let opts = HandlerOptions {
             name: "wg".to_owned(),

--- a/clash-lib/tests/api_tests.rs
+++ b/clash-lib/tests/api_tests.rs
@@ -204,6 +204,11 @@ async fn test_connections_returns_proxy_chain_names() {
     )
     .expect("Failed to start client");
 
+    // Also wait for the SOCKS5 port used by the request task —
+    // ClashInstance::start() only waits for the API port (first in the list)
+    // and the proxy listeners may bind slightly later.
+    wait_port_ready(8899).expect("SOCKS5 port 8899 not ready");
+
     let request_handle = tokio::spawn(async {
         let proxy = reqwest::Proxy::all("socks5h://127.0.0.1:8899")
             .expect("Failed to create proxy");
@@ -225,40 +230,55 @@ async fn test_connections_returns_proxy_chain_names() {
             "Request failed with status: {}",
             response.status()
         );
+
+        // Read the full response body — this keeps the connection open for the
+        // ~3-second drip, giving the polling loop time to observe it in
+        // /connections. Without this, the connection closes immediately after
+        // headers arrive.
+        let _body = response
+            .bytes()
+            .await
+            .expect("Failed to read response body");
     });
 
-    // Yield to allow the spawned task to start, then wait for connection to
-    // establish
+    // Poll the connections API until at least one connection appears (or 10s
+    // timeout). A fixed sleep is flaky under load; polling is robust.
     tokio::task::yield_now().await;
-    tokio::time::sleep(Duration::from_millis(1500)).await;
-
     let connections_url = "http://127.0.0.1:9090/connections";
-
-    let req = hyper::Request::builder()
-        .uri(connections_url)
-        .header(hyper::header::AUTHORIZATION, "Bearer clash-rs")
-        .method(http::method::Method::GET)
-        .body(http_body_util::Empty::<Bytes>::new())
-        .expect("Failed to build request");
-    let response = send_http_request(connections_url.parse().unwrap(), req);
-    let response = response
-        .await
-        .expect("Failed to send request")
-        .collect()
-        .await
-        .expect("Failed to collect response body")
-        .aggregate()
-        .reader();
-
-    let json: serde_json::Value =
-        serde_json::from_reader(response).expect("Failed to parse JSON response");
-    let connections = json
-        .get("connections")
-        .expect("No 'connections' field in response");
-    assert!(connections.is_array(), "Connections field is not an array");
-    let first_connection = connections
-        .get(0)
-        .expect("No connections found in response");
+    let first_connection = {
+        let mut found = None;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let req = hyper::Request::builder()
+                .uri(connections_url)
+                .header(hyper::header::AUTHORIZATION, "Bearer clash-rs")
+                .method(http::method::Method::GET)
+                .body(http_body_util::Empty::<Bytes>::new())
+                .expect("Failed to build request");
+            let Ok(response) =
+                send_http_request(connections_url.parse().unwrap(), req).await
+            else {
+                continue;
+            };
+            let Ok(body) = response.collect().await else {
+                continue;
+            };
+            let json: serde_json::Value =
+                match serde_json::from_reader(body.aggregate().reader()) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+            if let Some(conn) = json
+                .get("connections")
+                .and_then(|c| c.as_array())
+                .and_then(|a| a.first())
+            {
+                found = Some(conn.clone());
+                break;
+            }
+        }
+        found.expect("No active connection found after 10s")
+    };
 
     let chains = first_connection
         .get("chains")

--- a/clash-lib/tests/common/mod.rs
+++ b/clash-lib/tests/common/mod.rs
@@ -46,6 +46,7 @@ fn wait_port_closed(port: u16) -> Result<(), clash_lib::Error> {
 #[allow(dead_code)]
 pub struct ClashInstance {
     ports: Vec<u16>,
+    handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl ClashInstance {
@@ -54,7 +55,7 @@ impl ClashInstance {
         options: clash_lib::Options,
         ports: Vec<u16>,
     ) -> Result<Self, clash_lib::Error> {
-        std::thread::spawn(move || {
+        let handle = std::thread::spawn(move || {
             start_clash(options).expect("Failed to start clash");
         });
 
@@ -63,7 +64,10 @@ impl ClashInstance {
             wait_port_ready(main_port)?;
         }
 
-        Ok(Self { ports })
+        Ok(Self {
+            ports,
+            handle: Some(handle),
+        })
     }
 }
 
@@ -82,8 +86,11 @@ impl Drop for ClashInstance {
             }
         }
 
-        // Give a bit more time for full cleanup
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Join the thread to ensure it has fully exited, preventing ports from
+        // being held by the spawned runtime across test runs.
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Makes all `#[cfg(docker_test)]` integration tests run concurrently instead of serially, dramatically reducing total CI test time.

**Key changes:**

- **`docker_utils/mod.rs`** — `ping_pong_test` and `ping_pong_udp_test` now bind `0.0.0.0:0` (OS-assigned port) instead of taking a hardcoded `port` argument; eliminates TOCTOU and collision
- **`docker_runner.rs`** — add `alloc_docker_port()` (OS-assigned port for Docker host mapping) and `DockerTestRunnerBuilder::host_port(host, container)` for containers with fixed internal ports (e.g. SSH on 2222)
- **All protocol test modules** (anytls, relay, smart, hysteria2, shadowquic, shadowsocks, socks, ssh, trojan, tuic, vless, vmess, wg) — replace hardcoded `PORT=10002` with `alloc_docker_port()`; remove `#[serial_test::serial]` guards
- **`logging.rs`** — gate `console_subscriber::spawn()` on `#[cfg(all(feature = "telemetry", tokio_unstable))]` instead of `not(test)`; fixes panic in api_tests subprocesses compiled without `RUSTFLAGS=--cfg tokio_unstable`
- **`lib.rs`** — `setup_default_crypto_provider()` initialises both `rustls` and `watfaq_rustls` providers (separate crate forks with independent global state); fixes `test_shadowtls` and reality unit tests
- **`transport/reality.rs`** — call `setup_default_crypto_provider()` in unit tests that exercise TLS handshake paths
- **`Cargo.toml`** — add `tokio_unstable` to `unexpected_cfgs` allowlist
- **`tests/api_tests.rs`** — fix `test_connections_returns_proxy_chain_names`: replace fixed 1500 ms sleep with a 10 s polling loop, wait for mixed-port 8899 before sending, read full response body to keep the connection alive during polling
- **`tests/common/mod.rs`** — `ClashInstance` now stores and joins its `JoinHandle` on drop, preventing stale Tokio runtimes from holding ports across test runs

### Type

- [x] Refactoring / cleanup
- [x] Bug fix

### Checklist

- [x] Tests added or not needed
- [x] Docs updated or not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Docker test infrastructure with dynamic port allocation, removed forced test serialization, and more robust readiness/waiting for services to enable parallel and more reliable test runs.
  * Test harness now ensures proper runtime/thread shutdown and simplifies test helpers for throughput and networking checks.

* **Chores**
  * Adjusted telemetry and crypto provider configuration for improved stability and compatibility.

* **Bug Fixes**
  * MMDB reload now tolerates concurrent removal, avoiding aborts during re-download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->