### PR TITLE
fix(test): guard ring crypto provider install with not(aws-lc-rs)

### DIFF
--- a/clash-dns/src/lib.rs
+++ b/clash-dns/src/lib.rs
@@ -73,7 +73,7 @@ pub(crate) mod tests {
                     .install_default()
                     .unwrap()
             }
-            #[cfg(feature = "ring")]
+            #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
             {
                 rustls::crypto::ring::default_provider()
                     .install_default()


### PR DESCRIPTION
When running `cargo test --all-features`, both `aws-lc-rs` and `ring` features are enabled. The `OnceLock` closure in `setup_default_crypto_provider` ran both `install_default()` blocks — first succeeded, second panicked.

Fix: guard the `ring` block with `#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]` so it only fires when `aws-lc-rs` is absent.

Fixes `test_multiple_dns_server` panic under `--all-features`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved crypto provider initialization to prevent conflicts when multiple cryptographic features are enabled, ensuring the correct provider is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->