### PR TITLE
feat: API improvements - config reload, rule providers, log stability

### DIFF
--- a/clash-lib/src/app/api/handlers/config.rs
+++ b/clash-lib/src/app/api/handlers/config.rs
@@ -71,9 +71,9 @@ pub fn routes(
 
 async fn get_configs(State(state): State<ConfigState>) -> impl IntoResponse {
     let run_mode = state.dispatcher.get_mode().await;
-    let log_level = {
+    let (log_level, config_path) = {
         let global_state = state.global_state.lock().await;
-        global_state.log_level
+        (global_state.log_level, global_state.config_path.clone())
     };
     let inbound_manager = state.inbound_manager.clone();
 
@@ -134,6 +134,7 @@ async fn get_configs(State(state): State<ConfigState>) -> impl IntoResponse {
         listeners: Some(listeners),
         lan_ips,
         dns_listen,
+        config_path,
     })
 }
 
@@ -162,8 +163,15 @@ async fn update_configs(
             let cfg = crate::Config::Str(payload);
             match g.reload_tx.send((cfg, done)).await {
                 Ok(_) => {
-                    wait.await.unwrap();
-                    (StatusCode::NO_CONTENT, msg).into_response()
+                    drop(g);
+                    match wait.await {
+                        Ok(_) => (StatusCode::NO_CONTENT, msg).into_response(),
+                        Err(_) => (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "config reload failed",
+                        )
+                            .into_response(),
+                    }
                 }
                 Err(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -172,38 +180,70 @@ async fn update_configs(
                     .into_response(),
             }
         }
-        (Some(mut path), None) => {
-            if !PathBuf::from(&path).is_absolute() {
-                path = PathBuf::from(g.cwd.clone())
-                    .join(path)
-                    .to_string_lossy()
-                    .to_string();
-            }
-            if !PathBuf::from(&path).exists() {
+        // Empty string path means "reload from the original config file".
+        (path, None) => {
+            let resolved = match path.as_deref() {
+                Some("") | None => {
+                    // Use the path the binary was started with, if available.
+                    match &g.config_path {
+                        Some(p) => p.clone(),
+                        None => {
+                            return (
+                                StatusCode::BAD_REQUEST,
+                                "no config path provided and no original config \
+                                 file known",
+                            )
+                                .into_response();
+                        }
+                    }
+                }
+                Some(p) => {
+                    let mut resolved = p.to_string();
+                    if !PathBuf::from(&resolved).is_absolute() {
+                        resolved = PathBuf::from(g.cwd.clone())
+                            .join(resolved)
+                            .to_string_lossy()
+                            .to_string();
+                    }
+                    resolved
+                }
+            };
+
+            if !PathBuf::from(&resolved).exists() {
                 return (
                     StatusCode::BAD_REQUEST,
-                    format!("config file {path} not found"),
+                    format!("config file {resolved} not found"),
+                )
+                    .into_response();
+            }
+            if !PathBuf::from(&resolved).is_file() {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    format!("{resolved} is not a file"),
                 )
                     .into_response();
             }
 
-            let msg = format!("config reloading from file {path}");
-            let cfg: crate::Config = crate::Config::File(path);
+            let msg = format!("config reloading from file {resolved}");
+            let cfg: crate::Config = crate::Config::File(resolved);
             match g.reload_tx.send((cfg, done)).await {
                 Ok(_) => {
-                    wait.await.unwrap();
-                    (StatusCode::NO_CONTENT, msg).into_response()
+                    drop(g);
+                    match wait.await {
+                        Ok(_) => (StatusCode::NO_CONTENT, msg).into_response(),
+                        Err(_) => (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "config reload failed",
+                        )
+                            .into_response(),
+                    }
                 }
-
                 Err(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "could not signal config reload",
                 )
                     .into_response(),
             }
-        }
-        (None, None) => {
-            (StatusCode::BAD_REQUEST, "no path or payload provided").into_response()
         }
     }
 }
@@ -227,6 +267,8 @@ struct GetConfigResponse {
     lan_ips: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     dns_listen: Option<DnsListenInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_path: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -277,6 +319,7 @@ async fn patch_configs(
         }
     }
 
+    let mut port_changed = false;
     if payload.rebuild_listeners() {
         let ports = Ports {
             port: payload.port,
@@ -285,8 +328,8 @@ async fn patch_configs(
             tproxy_port: payload.tproxy_port,
             mixed_port: payload.mixed_port,
         };
-        let changed = inbound_manager.change_ports(ports).await;
-        need_restart |= changed;
+        port_changed = inbound_manager.change_ports(ports).await;
+        need_restart |= port_changed;
     }
 
     if let Some(allow_lan) = payload.allow_lan
@@ -296,6 +339,7 @@ async fn patch_configs(
         // TODO: can be done with AtomicBool in each inbound manager, but requires
         // more changes
         need_restart = true;
+        port_changed = false; // force full restart
     }
 
     // Apply mode change before restarting listeners so that new connections
@@ -305,7 +349,13 @@ async fn patch_configs(
     }
 
     if need_restart {
-        let _ = inbound_manager.restart().await;
+        if port_changed {
+            // Port-only change: restart only the affected listener(s).
+            // Unchanged listeners keep running — no EADDRINUSE.
+            let _ = inbound_manager.restart_idle().await;
+        } else {
+            let _ = inbound_manager.restart().await;
+        }
     }
 
     if let Some(ipv6) = payload.ipv6 {

--- a/clash-lib/src/app/api/handlers/log.rs
+++ b/clash-lib/src/app/api/handlers/log.rs
@@ -19,18 +19,26 @@ pub async fn handle(
     })
     .on_upgrade(move |mut socket| async move {
         let mut rx = state.log_source_tx.subscribe();
-        while let Ok(evt) = rx.recv().await {
-            let res_str = match serde_json::to_string(&evt) {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!("Failed to serialize log event: {}", e);
-                    continue; // Skip this event but keep the connection open
+        loop {
+            match rx.recv().await {
+                Ok(evt) => {
+                    let res_str = match serde_json::to_string(&evt) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!("Failed to serialize log event: {}", e);
+                            continue;
+                        }
+                    };
+                    if let Err(e) = socket.send(Message::Text(res_str.into())).await
+                    {
+                        warn!("ws send error: {}", e);
+                        break;
+                    }
                 }
-            };
-
-            if let Err(e) = socket.send(Message::Text(res_str.into())).await {
-                warn!("ws send error: {}", e);
-                break;
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!("log ws: receiver lagged {} messages", n);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
         }
     })

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{
     Extension, Router,
@@ -8,14 +14,16 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     app::{
         api::AppState, outbound::manager::ThreadSafeOutboundManager,
         remote_content_manager::providers::proxy_provider::ThreadSafeProxyProvider,
+        router::ArcRouter,
     },
     proxy::AnyOutboundHandler,
+    session::{Network, Session, SocksAddr, Type},
 };
 #[derive(Clone)]
 struct ProviderState {
@@ -197,4 +205,146 @@ async fn get_proxy_delay(
         )
             .into_response(),
     }
+}
+
+// ── Rule provider routes ────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct RuleProviderState {
+    router: ArcRouter,
+}
+
+pub fn rule_routes(router: ArcRouter) -> Router<Arc<AppState>> {
+    let state = RuleProviderState { router };
+    Router::new()
+        .route("/", get(get_rule_providers))
+        .route(
+            "/{provider_name}",
+            get(get_rule_provider).put(update_rule_provider),
+        )
+        .route("/{provider_name}/rules", get(get_rule_provider_rules))
+        .route("/{provider_name}/match", get(match_rule_provider))
+        .with_state(state)
+}
+
+async fn get_rule_providers(
+    State(state): State<RuleProviderState>,
+) -> impl IntoResponse {
+    let mut providers = HashMap::new();
+    for (name, p) in state.router.get_rule_providers() {
+        providers.insert(name.clone(), p.as_map().await);
+    }
+    let mut res = HashMap::new();
+    res.insert("providers", providers);
+    axum::response::Json(res)
+}
+
+#[derive(Deserialize)]
+struct RuleProviderNamePath {
+    provider_name: String,
+}
+
+async fn get_rule_provider(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+) -> impl IntoResponse {
+    match state.router.get_rule_providers().get(&provider_name) {
+        Some(p) => axum::response::Json(p.as_map().await).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response(),
+    }
+}
+
+async fn update_rule_provider(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+) -> impl IntoResponse {
+    match state.router.get_rule_providers().get(&provider_name) {
+        Some(p) => match p.update().await {
+            Ok(_) => (StatusCode::ACCEPTED, "rule provider update started")
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("update rule provider {provider_name} failed: {err}"),
+            )
+                .into_response(),
+        },
+        None => (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_rule_provider_rules(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+) -> impl IntoResponse {
+    match state.router.get_rule_providers().get(&provider_name) {
+        Some(p) => {
+            let rules = p.list_rules(500).await;
+            let mut res = HashMap::new();
+            res.insert("rules", rules);
+            axum::response::Json(res).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct MatchQuery {
+    target: String,
+}
+
+#[derive(Serialize)]
+struct MatchResponse {
+    #[serde(rename = "match")]
+    matched: bool,
+}
+
+async fn match_rule_provider(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+    Query(q): Query<MatchQuery>,
+) -> impl IntoResponse {
+    let Some(p) = state.router.get_rule_providers().get(&provider_name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response();
+    };
+
+    let destination = match SocksAddr::from_str(&q.target) {
+        Ok(addr) => addr,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, "invalid target").into_response();
+        }
+    };
+
+    let sess = Session {
+        network: Network::Tcp,
+        typ: Type::Http,
+        source: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        destination,
+        resolved_ip: None,
+        so_mark: None,
+        iface: None,
+        asn: None,
+        traffic_stats: None,
+        inbound_user: None,
+    };
+
+    axum::response::Json(MatchResponse {
+        matched: p.search(&sess),
+    })
+    .into_response()
 }

--- a/clash-lib/src/app/api/runner.rs
+++ b/clash-lib/src/app/api/runner.rs
@@ -158,7 +158,7 @@ impl Runner for ApiRunner {
                         dns_enabled,
                     ),
                 )
-                .nest("/rules", handlers::rule::routes(router))
+                .nest("/rules", handlers::rule::routes(router.clone()))
                 .nest("/group", handlers::group::routes(outbound_manager.clone()))
                 .nest(
                     "/proxies",
@@ -168,6 +168,7 @@ impl Runner for ApiRunner {
                     "/providers/proxies",
                     handlers::provider::routes(outbound_manager),
                 )
+                .nest("/providers/rules", handlers::provider::rule_routes(router))
                 .nest(
                     "/connections",
                     handlers::connection::routes(statistics_manager),

--- a/clash-lib/src/app/inbound/manager.rs
+++ b/clash-lib/src/app/inbound/manager.rs
@@ -345,24 +345,82 @@ impl InboundManager {
         }
     }
 
-    async fn stop_all_listeners(&self) {
-        for (opt, l) in self.inbound_handlers.write().await.iter_mut() {
-            if let Some(handler) = l.take() {
-                warn!("Shutting down inbound handler: {}", opt.common_opts().name);
-                handler.abort();
+    /// Like `start_all_listeners` but skips listeners that already have a
+    /// running handle. Used after a targeted port change so that only the
+    /// affected listener is (re-)started.
+    async fn start_idle_listeners(
+        dispatcher: Arc<Dispatcher>,
+        authenticator: ThreadSafeAuthenticator,
+        inbound_handlers: Arc<RwLock<HashMap<InboundOpts, Option<JoinHandle<()>>>>>,
+        cancellation_token: tokio_util::sync::CancellationToken,
+    ) {
+        for (opts, handler) in inbound_handlers.write().await.iter_mut() {
+            if handler.as_ref().is_some_and(|h| !h.is_finished()) {
+                continue; // already running — do not touch
             }
-            *l = None;
+            let cancellation_token = cancellation_token.clone();
+            let name = opts.common_opts().name.clone();
+            *handler = build_network_listeners(
+                opts,
+                dispatcher.clone(),
+                authenticator.clone(),
+                None,
+            )
+            .map(|r| {
+                tokio::spawn(async move {
+                    tokio::select! {
+                        _ = futures::future::join_all(r) => {
+                            warn!("Inbound handler {} has exited", name);
+                        },
+                        _ = cancellation_token.cancelled() => {
+                            info!("Inbound handler {} is closed", name);
+                        },
+                    }
+                })
+            });
         }
-        for handles in self.provider_handles.write().await.values_mut() {
-            for (opt, entry) in handles.iter_mut() {
-                if let Some(h) = entry.handle.take() {
+    }
+
+    async fn stop_all_listeners(&self) {
+        let mut handles_to_await: Vec<JoinHandle<()>> = Vec::new();
+
+        // Abort static inbound handlers, collect handles for awaiting.
+        {
+            let mut guard = self.inbound_handlers.write().await;
+            for (opt, l) in guard.iter_mut() {
+                if let Some(handler) = l.take() {
                     warn!(
-                        "Shutting down provider inbound handler: {}",
+                        "Shutting down inbound handler: {}",
                         opt.common_opts().name
                     );
-                    h.abort();
+                    handler.abort();
+                    handles_to_await.push(handler);
+                }
+                *l = None;
+            }
+        }
+
+        // Abort provider inbound handlers.
+        {
+            let mut provider_guard = self.provider_handles.write().await;
+            for handles in provider_guard.values_mut() {
+                for (opt, entry) in handles.iter_mut() {
+                    if let Some(h) = entry.handle.take() {
+                        warn!(
+                            "Shutting down provider inbound handler: {}",
+                            opt.common_opts().name
+                        );
+                        h.abort();
+                        handles_to_await.push(h);
+                    }
                 }
             }
+        }
+
+        // Wait for all aborted tasks to finish so the OS ports are released
+        // before new listeners bind to the same addresses.
+        for h in handles_to_await {
+            let _ = h.await;
         }
     }
 
@@ -406,6 +464,9 @@ impl InboundManager {
     }
 
     // RESTFUL API handlers below
+
+    /// Full restart — stops ALL listeners then starts them all again.
+    /// Use for bind-address or allow-lan changes that affect every listener.
     pub async fn restart(&self) -> Result<(), crate::Error> {
         self.stop_all_listeners().await;
 
@@ -414,6 +475,24 @@ impl InboundManager {
         let authenticator = self.authenticator.clone();
         let cancellation_token = self.cancellation_token.clone();
         Self::start_all_listeners(
+            dispatcher,
+            authenticator,
+            inbound_handlers,
+            cancellation_token,
+        )
+        .await;
+        Ok(())
+    }
+
+    /// Partial restart — starts only listeners whose handle is missing or
+    /// finished. Call this after `change_ports` so that unchanged listeners
+    /// are not interrupted.
+    pub async fn restart_idle(&self) -> Result<(), crate::Error> {
+        let inbound_handlers = self.inbound_handlers.clone();
+        let dispatcher = self.dispatcher.clone();
+        let authenticator = self.authenticator.clone();
+        let cancellation_token = self.cancellation_token.clone();
+        Self::start_idle_listeners(
             dispatcher,
             authenticator,
             inbound_handlers,
@@ -533,34 +612,27 @@ impl InboundManager {
 
         let listeners: HashMap<InboundOpts, Option<_>> = guard
             .extract_if(|opts, _| match &opts {
-                InboundOpts::Http { common_opts } => {
-                    ports.port.is_some() && Some(common_opts.port) == ports.port
-                }
-                InboundOpts::Socks { common_opts, .. } => {
-                    ports.socks_port.is_some()
-                        && Some(common_opts.port) == ports.socks_port
-                }
-                InboundOpts::Mixed { common_opts, .. } => {
-                    ports.mixed_port.is_some()
-                        && Some(common_opts.port) == ports.mixed_port
-                }
+                InboundOpts::Http { .. } => ports.port.is_some(),
+                InboundOpts::Socks { .. } => ports.socks_port.is_some(),
+                InboundOpts::Mixed { .. } => ports.mixed_port.is_some(),
                 #[cfg(feature = "tproxy")]
-                InboundOpts::TProxy { common_opts, .. } => {
-                    ports.tproxy_port.is_some()
-                        && Some(common_opts.port) == ports.tproxy_port
-                }
+                InboundOpts::TProxy { .. } => ports.tproxy_port.is_some(),
                 #[cfg(feature = "redir")]
-                InboundOpts::Redir { common_opts } => {
-                    ports.redir_port.is_some()
-                        && Some(common_opts.port) == ports.redir_port
-                }
+                InboundOpts::Redir { .. } => ports.redir_port.is_some(),
                 _ => false,
             })
             .collect();
 
         let changed = !listeners.is_empty();
 
+        let mut old_handles: Vec<JoinHandle<()>> = Vec::new();
+
         for (mut opts, handle) in listeners {
+            if let Some(h) = handle {
+                h.abort();
+                old_handles.push(h);
+            }
+
             // extract_if already guarantees the matching port field is Some.
             // Use a plain match + if-let (stable) rather than if-let guards
             // in match arms (which require the nightly `if_let_guard` feature).
@@ -588,7 +660,17 @@ impl InboundManager {
                 continue;
             };
             opts.common_opts_mut().port = port;
-            guard.insert(opts, handle);
+            // Insert with None so restart_idle will start a new listener.
+            guard.insert(opts, None);
+        }
+
+        // Release the write lock before awaiting so other readers aren't blocked.
+        drop(guard);
+
+        // Wait for the old tasks to finish, which ensures their OS port bindings
+        // are released before restart_idle binds the new port.
+        for h in old_handles {
+            let _ = h.await;
         }
 
         changed

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/mrs.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/mrs.rs
@@ -133,7 +133,7 @@ fn parse_domain_payload<R: Read>(reader: &mut R) -> Result<RuleContent> {
     let labels = read_byte_vec(reader, labels_len, "Labels")?;
 
     let domain_set = DomainSet::from_mrs_parts(leaves, label_bitmap, labels);
-    Ok(RuleContent::Domain(domain_set))
+    Ok(RuleContent::Domain(domain_set, leaves_len))
 }
 
 // --- IPCIDR Payload Parsing ---
@@ -196,7 +196,7 @@ fn parse_ipcidr_payload<R: Read>(reader: &mut R) -> Result<RuleContent> {
         "Successfully parsed and inserted CIDRs from {} ranges.",
         ranges_len
     );
-    Ok(RuleContent::Ipcidr(Box::new(cidr_trie)))
+    Ok(RuleContent::Ipcidr(Box::new(cidr_trie), ranges_len))
 }
 
 // --- Helper Functions for Reading Data ---

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -77,8 +77,8 @@ impl Display for RuleSetBehavior {
 
 pub enum RuleContent {
     // the left will converted into a right
-    Domain(succinct_set::DomainSet),
-    Ipcidr(Box<CidrTrie>),
+    Domain(succinct_set::DomainSet, usize),
+    Ipcidr(Box<CidrTrie>, usize),
     Classical(Vec<Box<dyn RuleMatcher>>),
 }
 
@@ -86,10 +86,18 @@ struct Inner {
     content: RuleContent,
 }
 
+#[async_trait]
 pub trait RuleProvider: Provider {
     fn search(&self, sess: &Session) -> bool;
     fn behavior(&self) -> RuleSetBehavior;
     fn format(&self) -> RuleSetFormat;
+    /// Returns up to `limit` rules as strings. Only Classical providers return
+    /// non-empty results; Domain/IPCIDR data structures don't support
+    /// enumeration.
+    async fn list_rules(&self, limit: usize) -> Vec<String> {
+        let _ = limit;
+        vec![]
+    }
 }
 
 pub type ThreadSafeRuleProvider = Arc<dyn RuleProvider + Send + Sync>;
@@ -127,10 +135,10 @@ impl RuleProviderImpl {
         let inner = Arc::new(tokio::sync::RwLock::new(Inner {
             content: match behavior {
                 RuleSetBehavior::Domain => {
-                    RuleContent::Domain(succinct_set::DomainSet::default())
+                    RuleContent::Domain(succinct_set::DomainSet::default(), 0)
                 }
                 RuleSetBehavior::Ipcidr => {
-                    RuleContent::Ipcidr(Box::new(CidrTrie::new()))
+                    RuleContent::Ipcidr(Box::new(CidrTrie::new()), 0)
                 }
                 RuleSetBehavior::Classical => RuleContent::Classical(vec![]),
             },
@@ -266,8 +274,8 @@ impl RuleProvider for RuleProviderImpl {
 
         match inner {
             Ok(inner) => match &inner.content {
-                RuleContent::Domain(set) => set.has(&sess.destination.host()),
-                RuleContent::Ipcidr(trie) => trie.contains(
+                RuleContent::Domain(set, _) => set.has(&sess.destination.host()),
+                RuleContent::Ipcidr(trie, _) => trie.contains(
                     sess.destination
                         .ip()
                         .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
@@ -294,6 +302,18 @@ impl RuleProvider for RuleProviderImpl {
 
     fn format(&self) -> RuleSetFormat {
         self.format
+    }
+
+    async fn list_rules(&self, limit: usize) -> Vec<String> {
+        let inner = self.inner.read().await;
+        match &inner.content {
+            RuleContent::Classical(rules) => rules
+                .iter()
+                .take(limit)
+                .map(|r| format!("{},{}", r.type_name(), r.payload()))
+                .collect(),
+            _ => vec![],
+        }
     }
 }
 
@@ -384,6 +404,16 @@ impl Provider for RuleProviderImpl {
         m.insert("behavior".to_owned(), Box::new(self.behavior().to_string()));
         m.insert("format".to_owned(), Box::new(self.format().to_string()));
 
+        let rule_count = {
+            let inner = self.inner.read().await;
+            match &inner.content {
+                RuleContent::Classical(rules) => rules.len(),
+                RuleContent::Domain(_, n) => *n,
+                RuleContent::Ipcidr(_, n) => *n,
+            }
+        };
+        m.insert("ruleCount".to_owned(), Box::new(rule_count));
+
         m
     }
 }
@@ -397,11 +427,16 @@ fn make_rules(
 ) -> Result<RuleContent, Error> {
     match behavior {
         RuleSetBehavior::Domain => {
+            let count = rules.len();
             let s = make_domain_rules(rules)?;
-            Ok(RuleContent::Domain(s.into()))
+            Ok(RuleContent::Domain(s.into(), count))
         }
         RuleSetBehavior::Ipcidr => {
-            Ok(RuleContent::Ipcidr(Box::new(make_ip_cidr_rules(rules)?)))
+            let count = rules.len();
+            Ok(RuleContent::Ipcidr(
+                Box::new(make_ip_cidr_rules(rules)?),
+                count,
+            ))
         }
         RuleSetBehavior::Classical => Ok(RuleContent::Classical(
             make_classical_rules(rules, mmdb, geodata)?,

--- a/clash-lib/src/app/router/mod.rs
+++ b/clash-lib/src/app/router/mod.rs
@@ -32,6 +32,7 @@ pub struct Router {
     dns_resolver: ThreadSafeDNSResolver,
 
     asn_mmdb: Option<MmdbLookup>,
+    rule_providers: HashMap<String, ThreadSafeRuleProvider>,
 }
 
 pub type ArcRouter = Arc<Router>;
@@ -81,6 +82,7 @@ impl Router {
             dns_resolver,
 
             asn_mmdb,
+            rule_providers: rule_provider_registry,
         }
     }
 
@@ -239,6 +241,10 @@ impl Router {
     /// API handlers
     pub fn get_all_rules(&self) -> &Vec<Box<dyn RuleMatcher>> {
         &self.rules
+    }
+
+    pub fn get_rule_providers(&self) -> &HashMap<String, ThreadSafeRuleProvider> {
+        &self.rule_providers
     }
 }
 

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -123,6 +123,7 @@ pub struct GlobalState {
     dns_listener: ArcRunner,
     reload_tx: mpsc::Sender<(Config, oneshot::Sender<()>)>,
     cwd: String,
+    config_path: Option<String>,
 }
 
 pub fn start_scaffold(opts: Options) -> Result<()> {
@@ -133,6 +134,11 @@ pub fn start_scaffold(opts: Options) -> Result<()> {
         TokioRuntime::SingleThread => tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?,
+    };
+    let config_path: Option<String> = if let Config::File(ref p) = opts.config {
+        Some(p.clone())
+    } else {
+        None
     };
     let config: InternalConfig = opts.config.try_parse()?;
     let cwd = opts.cwd.unwrap_or_else(|| ".".to_string());
@@ -148,7 +154,7 @@ pub fn start_scaffold(opts: Options) -> Result<()> {
     );
 
     rt.block_on(async {
-        match start(config, cwd, log_tx).await {
+        match start(config, cwd, config_path, log_tx).await {
             Err(e) => {
                 eprintln!("start error: {e}");
                 Err(e)
@@ -202,6 +208,7 @@ pub fn setup_default_crypto_provider() {
 pub async fn start(
     config: InternalConfig,
     cwd: String,
+    config_path: Option<String>,
     log_tx: broadcast::Sender<LogEvent>,
 ) -> Result<()> {
     setup_default_crypto_provider();
@@ -230,6 +237,7 @@ pub async fn start(
         dns_listener: components.dns_listener.clone(),
         reload_tx,
         cwd: cwd.to_string_lossy().to_string(),
+        config_path,
     }));
 
     let mut api_listener: ArcRunner = Arc::new(app::api::ApiRunner::new(


### PR DESCRIPTION
## Overview

API improvements for the clash-rs backend, extracted from the dashboard branch.

## Changes

### Config reload
- Add `config_path` to `GlobalState` so the API can track which config file was loaded
- `PUT /configs` (reload) now correctly finds the original config file path

### Rule provider endpoints
- `GET /providers/rules` – list all rule providers
- `PUT /providers/rules/:name` – reload a rule provider
- `GET /providers/rules/:name/match?target=<domain|ip>` – test if a target matches a rule provider

### Log stability
- Handle `Lagged` broadcast errors in log WS handler instead of silently dropping the connection

### InboundManager improvements
- Add `start_idle_listeners` / `restart_idle` to only restart listeners whose port/address changed, avoiding `EADDRINUSE` when patching config for unchanged ports

### Router
- Add `get_rule_providers()` to expose the rule provider map to API handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints to list, fetch, and match rule providers with update capabilities.
  * Implemented selective listener restart for improved performance when only port settings change.
  * Added ability to list and view rule counts from providers.

* **Bug Fixes**
  * Improved config reload error handling with proper validation and error responses instead of crashes.
  * Enhanced websocket log streaming with better connection stability and lag detection.
  * Fixed port configuration changes to avoid unnecessary full service restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->