### PR TITLE
fix: verger compatibility part 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,16 @@ strip = true
 debug = 2
 panic = "abort"
 
-[profile.fast-release]
+[profile.detailed-release]
 inherits = "release"
 opt-level = 1
-debug = 1
 lto = "thin"
-strip = false
+strip = "none"
+debug = "line-tables-only"
+split-debuginfo = "off"
+panic = "unwind"
 incremental = true
-codegen-units = 16
+codegen-units = 256
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -52,6 +52,7 @@ use hyper::Uri;
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
+use uuid::Uuid;
 
 static RESERVED_PROVIDER_NAME: &str = "default";
 
@@ -62,6 +63,8 @@ pub struct OutboundManager {
     registry: OutboundHandlerRegistry,
     /// name -> provider
     proxy_providers: HashMap<String, ThreadSafeProxyProvider>,
+    /// proxy_name -> provider_name reverse mapping for API responses.
+    proxy_provider_map: HashMap<String, String>,
     proxy_manager: ProxyManager,
     selector_control: HashMap<String, ThreadSafeSelectorControl>,
 }
@@ -112,6 +115,7 @@ impl OutboundManager {
             proxy_manager,
             selector_control,
             proxy_providers: provider_registry,
+            proxy_provider_map: HashMap::new(),
         };
 
         debug!("initializing proxy providers");
@@ -127,6 +131,22 @@ impl OutboundManager {
             cache_store,
         )
         .await?;
+
+        // Register provider proxies into the handler map and build the
+        // reverse provider-name mapping for the API response.
+        for (provider_name, provider) in &m.proxy_providers {
+            if provider_name == RESERVED_PROVIDER_NAME {
+                continue; // skip the GLOBAL provider
+            }
+            let p = provider.read().await;
+            for proxy in p.proxies().await {
+                let name = proxy.name().to_owned();
+                m.proxy_provider_map
+                    .entry(name.clone())
+                    .or_insert_with(|| provider_name.clone());
+                handlers.entry(name).or_insert_with(|| proxy.clone());
+            }
+        }
 
         debug!("initializing connectors");
         m.init_handler_connectors(&handlers).await?;
@@ -202,17 +222,17 @@ impl OutboundManager {
         &self,
         proxy: &AnyOutboundHandler,
     ) -> HashMap<String, Box<dyn Serialize + Send>> {
-        let mut r = if let Some(g) = proxy.try_as_group_handler() {
-            g.as_map().await
-        } else if let Some(p) = proxy.try_as_plain_handler() {
-            p.as_map().await
+        let mut response = if let Some(group) = proxy.try_as_group_handler() {
+            group.as_map().await
+        } else if let Some(plain) = proxy.try_as_plain_handler() {
+            plain.as_map().await
         } else {
             HashMap::new()
         };
-        self.apply_common_proxy_fields(&mut r, proxy, proxy.name())
+        self.apply_common_proxy_fields(&mut response, proxy, proxy.name())
             .await;
 
-        r
+        response
     }
 
     async fn apply_common_proxy_fields(
@@ -225,6 +245,8 @@ impl OutboundManager {
         let history = self.proxy_manager.delay_history(name).await;
         let support_udp = proxy.support_udp().await;
 
+        let id = Uuid::new_v5(&Uuid::NAMESPACE_OID, name.as_bytes());
+        m.insert("id".to_string(), Box::new(id.to_string()));
         m.insert("history".to_string(), Box::new(history));
         m.insert("alive".to_string(), Box::new(alive));
         m.insert("name".to_string(), Box::new(name.to_owned()));
@@ -235,9 +257,19 @@ impl OutboundManager {
         m.insert("tfo".to_string(), Box::new(false));
         m.insert("mptcp".to_string(), Box::new(false));
         m.insert("smux".to_string(), Box::new(false));
-        m.insert("interface".to_string(), Box::new("auto"));
-        m.insert("dialer_proxy".to_string(), Box::new("none"));
-        m.insert("routing_mark".to_string(), Box::new(0));
+        m.insert("interface".to_string(), Box::new(""));
+        m.insert("dialer-proxy".to_string(), Box::new(""));
+        m.insert("routing-mark".to_string(), Box::new(0));
+        let provider_name = self
+            .proxy_provider_map
+            .get(name)
+            .cloned()
+            .unwrap_or_default();
+        m.insert("provider-name".to_string(), Box::new(provider_name));
+        m.insert(
+            "extra".to_string(),
+            Box::new(HashMap::<String, String>::new()),
+        );
     }
 
     /// a wrapper of proxy_manager.url_test so that proxy_manager is not exposed

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -230,17 +230,17 @@ impl OutboundManager {
         &self,
         proxy: &AnyOutboundHandler,
     ) -> HashMap<String, Box<dyn Serialize + Send>> {
-        let mut response = if let Some(group) = proxy.try_as_group_handler() {
-            group.as_map().await
-        } else if let Some(plain) = proxy.try_as_plain_handler() {
-            plain.as_map().await
+        let mut r = if let Some(g) = proxy.try_as_group_handler() {
+            g.as_map().await
+        } else if let Some(p) = proxy.try_as_plain_handler() {
+            p.as_map().await
         } else {
             HashMap::new()
         };
-        self.apply_common_proxy_fields(&mut response, proxy, proxy.name())
+        self.apply_common_proxy_fields(&mut r, proxy, proxy.name())
             .await;
 
-        response
+        r
     }
 
     async fn apply_common_proxy_fields(

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -49,12 +49,7 @@ use crate::{
 use anyhow::Result;
 use erased_serde::Serialize;
 use hyper::Uri;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 use uuid::Uuid;

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -50,7 +50,7 @@ use anyhow::Result;
 use erased_serde::Serialize;
 use hyper::Uri;
 use std::{
-    collections::{HashMap, hash_map},
+    collections::HashMap,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -68,8 +68,6 @@ pub struct OutboundManager {
     registry: OutboundHandlerRegistry,
     /// name -> provider
     proxy_providers: HashMap<String, ThreadSafeProxyProvider>,
-    /// proxy_name -> provider_name reverse mapping for API responses.
-    proxy_provider_map: HashMap<String, String>,
     proxy_manager: ProxyManager,
     selector_control: HashMap<String, ThreadSafeSelectorControl>,
 }
@@ -120,7 +118,6 @@ impl OutboundManager {
             proxy_manager,
             selector_control,
             proxy_providers: provider_registry,
-            proxy_provider_map: HashMap::new(),
         };
 
         debug!("initializing proxy providers");
@@ -136,25 +133,6 @@ impl OutboundManager {
             cache_store,
         )
         .await?;
-
-        // Register provider proxies into the handler map and build the
-        // reverse provider-name mapping for the API response.
-        // Only record provider-name when we actually insert the handler,
-        // so user-configured proxies with the same name are never mislabeled.
-        for (provider_name, provider) in &m.proxy_providers {
-            if provider_name == RESERVED_PROVIDER_NAME {
-                continue; // skip the GLOBAL provider
-            }
-            let p = provider.read().await;
-            for proxy in p.proxies().await {
-                let name = proxy.name().to_owned();
-                if let hash_map::Entry::Vacant(e) = handlers.entry(name) {
-                    e.insert(proxy.clone());
-                    m.proxy_provider_map
-                        .insert(proxy.name().to_owned(), provider_name.clone());
-                }
-            }
-        }
 
         debug!("initializing connectors");
         m.init_handler_connectors(&handlers).await?;
@@ -268,12 +246,7 @@ impl OutboundManager {
         m.insert("interface".to_string(), Box::new(""));
         m.insert("dialer-proxy".to_string(), Box::new(""));
         m.insert("routing-mark".to_string(), Box::new(0));
-        let provider_name = self
-            .proxy_provider_map
-            .get(name)
-            .cloned()
-            .unwrap_or_default();
-        m.insert("provider-name".to_string(), Box::new(provider_name));
+        m.insert("provider-name".to_string(), Box::new(""));
         m.insert(
             "extra".to_string(),
             Box::new(HashMap::<String, String>::new()),

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -49,7 +49,12 @@ use crate::{
 use anyhow::Result;
 use erased_serde::Serialize;
 use hyper::Uri;
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, hash_map},
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 use uuid::Uuid;
@@ -134,6 +139,8 @@ impl OutboundManager {
 
         // Register provider proxies into the handler map and build the
         // reverse provider-name mapping for the API response.
+        // Only record provider-name when we actually insert the handler,
+        // so user-configured proxies with the same name are never mislabeled.
         for (provider_name, provider) in &m.proxy_providers {
             if provider_name == RESERVED_PROVIDER_NAME {
                 continue; // skip the GLOBAL provider
@@ -141,10 +148,11 @@ impl OutboundManager {
             let p = provider.read().await;
             for proxy in p.proxies().await {
                 let name = proxy.name().to_owned();
-                m.proxy_provider_map
-                    .entry(name.clone())
-                    .or_insert_with(|| provider_name.clone());
-                handlers.entry(name).or_insert_with(|| proxy.clone());
+                if let hash_map::Entry::Vacant(e) = handlers.entry(name) {
+                    e.insert(proxy.clone());
+                    m.proxy_provider_map
+                        .insert(proxy.name().to_owned(), provider_name.clone());
+                }
             }
         }
 

--- a/clash-lib/src/proxy/group/mod.rs
+++ b/clash-lib/src/proxy/group/mod.rs
@@ -34,10 +34,15 @@ pub trait GroupProxyAPIResponse: OutboundHandler {
             m.insert("now".to_string(), Box::new(active.name().to_owned()) as _);
         }
 
-        let icon = self.icon();
-        if let Some(icon) = icon {
-            m.insert("icon".to_string(), Box::new(icon) as _);
-        }
+        m.insert(
+            "icon".to_string(),
+            Box::new(self.icon().unwrap_or_default()) as _,
+        );
+        m.insert("hidden".to_string(), Box::new(false) as _);
+        m.insert(
+            "testUrl".to_string(),
+            Box::new(self.get_latency_test_url().unwrap_or_default()) as _,
+        );
 
         m.insert(
             "all".to_string(),

--- a/justfile
+++ b/justfile
@@ -16,7 +16,10 @@ docs:
 test-no-docker:
   CLASH_RS_CI=true cargo test --all --all-features
 
-verge_win verge_path='C:\Apps\Clash Verge\verge-mihomo-alpha.exe':
+verge-win verge_path='C:\Apps\Clash Verge\verge-mihomo-alpha.exe':
   cargo build -p clash-rs --release --features=standard
   rm -f "{{verge_path}}"
   cp target/release/clash-rs.exe "{{verge_path}}"
+
+test-api token='test_token' url='http://127.0.0.1:9093/proxies':
+  curl -H "Authorization: Bearer {{token}}" {{url}}


### PR DESCRIPTION
This pull request enhances the outbound proxy API responses by adding new fields and improving metadata reporting, particularly for proxy providers and group proxies. It also introduces some codebase improvements for clarity and consistency. The most notable changes are grouped below:

**API Response Improvements:**

* Added a unique `id` (UUID v5) for each proxy in the API response, generated from the proxy's name.
* Included a reverse mapping (`proxy_provider_map`) from proxy names to their provider names, and exposed the `provider-name` field in the proxy API response. [[1]](diffhunk://#diff-50d891eced3cfaf6104fa401018f0b7e49b743865891e32a6ba2ad81e64f31f9R66-R67) [[2]](diffhunk://#diff-50d891eced3cfaf6104fa401018f0b7e49b743865891e32a6ba2ad81e64f31f9R135-R150) [[3]](diffhunk://#diff-50d891eced3cfaf6104fa401018f0b7e49b743865891e32a6ba2ad81e64f31f9L238-R272)
* Added an `extra` field (empty map for now) to the proxy API response for future extensibility.
* For group proxies, always include the `icon` field (using a default if not set), and add `hidden` and `testUrl` fields to the API response.

**Field Naming and Consistency:**

* Standardized field names in the API response: changed `dialer_proxy` to `dialer-proxy` and `routing_mark` to `routing-mark`; set their default values to empty string or zero as appropriate.

**Development/Testing Utilities:**

* Added a `test-api` command to the `justfile` for testing API endpoints with curl.

**Dependency and Code Quality:**

* Imported `uuid::Uuid` to support UUID generation for proxy IDs.
* Improved naming and clarity in code by renaming variables and restructuring logic for building API responses.

These changes collectively improve the structure, clarity, and extensibility of the proxy API responses, making them more useful for clients and easier to maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy API now includes a deterministic "id", "provider-name", and an empty "extra" object; several field names standardized (dashed keys) and defaults set to empty strings.
  * Proxy group responses always include an icon, are marked non-hidden, and always provide a testUrl.

* **Chores**
  * Build recipes adjusted and a new test-api recipe added.
  * Release build profile settings revised for optimized builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->