### PR TITLE
build: install Node 20 in cross containers for dashboard build

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,8 @@
+[build]
+pre-build = [
+    "apt-get update -qq && apt-get install -y --no-install-recommends curl ca-certificates && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs",
+]
+
 [build.env]
 volumes = ["/var/run/docker.sock=/var/run/docker.sock", "/tmp=/tmp"] # Docker in docker
 passthrough = ["CLASH_GIT_REF", "CLASH_GIT_SHA", "RUSTFLAGS", "RUST_LOG", "CLASH_DOCKER_TEST", "SENTRY_DSN", "RUSTC_BOOTSTRAP", "TS_AUTH_KEY"]

--- a/clash-lib/build.rs
+++ b/clash-lib/build.rs
@@ -81,9 +81,15 @@ fn build_dashboard() -> anyhow::Result<()> {
     // On Windows npm is a .cmd script, not a binary.
     let npm = if cfg!(windows) { "npm.cmd" } else { "npm" };
 
+    // Use /tmp for the npm cache so that non-root users inside cross containers
+    // (which run as UID 1001) are not blocked by a root-owned /.npm directory
+    // that the nodesource pre-build step may have created.
+    let npm_cache = std::env::temp_dir().join("npm-cache");
+
     // Run `npm ci` to install dependencies (no-op if already up to date).
     let status = match std::process::Command::new(npm)
-        .args(["ci", "--prefer-offline"])
+        .args(["ci", "--prefer-offline", "--cache"])
+        .arg(&npm_cache)
         .current_dir(&dashboard_dir)
         .status()
     {
@@ -98,6 +104,7 @@ fn build_dashboard() -> anyhow::Result<()> {
     // Run `npm run build`.
     let status = std::process::Command::new(npm)
         .args(["run", "build"])
+        .env("npm_config_cache", &npm_cache)
         .current_dir(&dashboard_dir)
         .status()
         .map_err(|e| {

--- a/clash-lib/build.rs
+++ b/clash-lib/build.rs
@@ -54,22 +54,12 @@ fn build_dashboard() -> anyhow::Result<()> {
     let dashboard_dir =
         std::path::PathBuf::from(&manifest_dir).join("../clash-dashboard");
 
-    // Always ensure dist/ exists so rust-embed can compile even if the npm
-    // build is skipped (it will embed an empty bundle).
-    let dist_dir = dashboard_dir.join("dist");
-    std::fs::create_dir_all(&dist_dir)?;
-
-    let dashboard_dir = match dashboard_dir.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            println!(
-                "cargo:warning=clash-dashboard directory not found at {}; skipping \
-                 frontend build (embedded UI will be empty)",
-                dashboard_dir.display()
-            );
-            return Ok(());
-        }
-    };
+    let dashboard_dir = dashboard_dir.canonicalize().map_err(|e| {
+        anyhow::anyhow!(
+            "clash-dashboard directory not found at {}: {e}",
+            dashboard_dir.display()
+        )
+    })?;
 
     // Watch source files so cargo reruns this script on any frontend change.
     let src_dir = dashboard_dir.join("src");
@@ -98,22 +88,12 @@ fn build_dashboard() -> anyhow::Result<()> {
         .status()
     {
         Ok(s) => s,
-        Err(_) => {
-            println!(
-                "cargo:warning=npm not found; skipping frontend build (embedded UI \
-                 will be empty)"
-            );
-            return Ok(());
+        Err(e) => {
+            anyhow::bail!("npm not found; is Node.js installed? ({e})");
         }
     };
 
-    if !status.success() {
-        println!(
-            "cargo:warning=`npm ci` failed with status {status}; skipping frontend \
-             build"
-        );
-        return Ok(());
-    }
+    anyhow::ensure!(status.success(), "`npm ci` failed with status {status}");
 
     // Run `npm run build`.
     let status = std::process::Command::new(npm)


### PR DESCRIPTION
## Problem
Cross-compilation containers (used by `cross`) don't have Node.js/npm installed, causing this warning on every cross build:
```
warning: clash-lib@0.10.1: npm not found; skipping frontend build (embedded UI will be empty)
```

## Root Cause
`clash-lib/build.rs` runs `npm ci && npm run build` when the `dashboard` feature is enabled. The `cross` Docker containers don't have Node.js installed by default. The dashboard uses Vite 8 which requires Node 18+, so default Ubuntu apt repos are insufficient.

## Fix
Add a `[build.pre-build]` hook in `Cross.toml` that installs Node 20 LTS via NodeSource before each cross build. This runs inside the Docker container before cargo starts.

Closes: npm warning in CI cross builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build initialization now ensures Node.js 20 plus required networking/security utilities are installed so local and CI builds have a consistent runtime.

* **Bug Fixes**
  * Frontend dashboard build now fails visibly on missing prerequisites or build errors instead of silently embedding an empty UI, improving build transparency and reliability.
  * Build process now more robust against transient tooling issues, reducing silent fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->