### PR TITLE
feat: netflow-like flows dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11439,7 +11439,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",

--- a/clash-dashboard/package-lock.json
+++ b/clash-dashboard/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@fontsource-variable/geist": "^5.2.8",
+        "@nivo/core": "^0.99.0",
+        "@nivo/sankey": "^0.99.0",
         "@tailwindcss/forms": "^0.5.11",
         "@tanstack/react-query": "^5.100.1",
         "class-variance-authority": "^0.7.1",
@@ -1202,6 +1204,135 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nivo/colors": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
+      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
+      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "use-debounce": "^10.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/legends": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
+      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/sankey": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/sankey/-/sankey-0.99.0.tgz",
+      "integrity": "sha512-u5hySywsachjo9cHdUxCR9qwD6gfRVPEAcpuIUKiA0WClDjdGbl3vkrQcQcFexJUBThqSSbwGCDWR+2INXSbTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-sankey": "^0.11.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-sankey": "^0.12.3",
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/text": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
+      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
+      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
+      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
@@ -1306,6 +1437,78 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.3.tgz",
+      "integrity": "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.3.tgz",
+      "integrity": "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.3.tgz",
+      "integrity": "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.3.tgz",
+      "integrity": "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.3.tgz",
+      "integrity": "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.3.tgz",
+      "integrity": "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.3",
+        "@react-spring/core": "~10.0.3",
+        "@react-spring/shared": "~10.0.3",
+        "@react-spring/types": "~10.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1921,6 +2124,72 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-sankey": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.11.2.tgz",
+      "integrity": "sha512-U6SrTWUERSlOhnpSrgvMX64WblX1AxX6nEjI2t3mLK2USpQrnbwYYK+AS9SwiE7wgYmOsSSKoSdr8aoKBH0HgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-shape": "^1"
+      }
+    },
+    "node_modules/@types/d3-sankey/node_modules/@types/d3-path": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+      "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^1"
+      }
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2874,6 +3143,147 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "2"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -4103,6 +4513,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -4737,6 +5153,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",
@@ -5623,6 +6045,16 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -6501,6 +6933,18 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/clash-dashboard/package.json
+++ b/clash-dashboard/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@fontsource-variable/geist": "^5.2.8",
+    "@nivo/core": "^0.99.0",
+    "@nivo/sankey": "^0.99.0",
     "@tailwindcss/forms": "^0.5.11",
     "@tanstack/react-query": "^5.100.1",
     "class-variance-authority": "^0.7.1",

--- a/clash-dashboard/src/App.tsx
+++ b/clash-dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from './components/Layout';
 import { Overview } from './pages/Overview';
 import { Providers } from './pages/Providers';
 import { Connections } from './pages/Connections';
+import { Flows } from './pages/Flows';
 import { Rules } from './pages/Rules';
 import { Logs } from './pages/Logs';
 import { DNS } from './pages/DNS';
@@ -27,6 +28,7 @@ export default function App() {
             <Route index element={<Overview />} />
             <Route path="providers" element={<Providers />} />
             <Route path="connections" element={<Connections />} />
+            <Route path="flows" element={<Flows />} />
             <Route path="rules" element={<Rules />} />
             <Route path="logs" element={<Logs />} />
             <Route path="dns" element={<DNS />} />

--- a/clash-dashboard/src/components/Layout.tsx
+++ b/clash-dashboard/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getVersion } from '../lib/api';
 import {
   LayoutDashboard, Activity, Filter, Terminal,
-  Server, SlidersHorizontal, Package,
+  Server, SlidersHorizontal, Package, GitBranch,
 } from 'lucide-react';
 import logoUrl from '../assets/logo.png';
 
@@ -11,6 +11,7 @@ const navItems = [
   { to: '/', label: 'Overview', icon: LayoutDashboard, end: true },
   { to: '/providers', label: 'Providers', icon: Package },
   { to: '/connections', label: 'Connections', icon: Activity },
+  { to: '/flows', label: 'Flows', icon: GitBranch },
   { to: '/rules', label: 'Rules', icon: Filter },
   { to: '/logs', label: 'Logs', icon: Terminal },
   { to: '/dns', label: 'DNS', icon: Server },

--- a/clash-dashboard/src/hooks/useFlows.ts
+++ b/clash-dashboard/src/hooks/useFlows.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useWebSocket } from './useWebSocket';
+import { getWsUrl } from '../lib/api';
+
+export interface FlowRecord {
+  dstHost: string;
+  dstPort: number;
+  protocol: string;
+  srcIps: string[];
+  connCount: number;
+  uploadTotal: number;
+  downloadTotal: number;
+  bytesTotal: number;
+  rule: string;
+  chains: string[];
+  lastSeen: string;
+}
+
+interface UseFlowsReturn {
+  flows: FlowRecord[];
+  readyState: import('./useWebSocket').ReadyState;
+}
+
+export function useFlows(): UseFlowsReturn {
+  const url = getWsUrl('/ws/flows?interval=5');
+  const { lastMessage, readyState } = useWebSocket<FlowRecord[]>(url);
+
+  const [flows, setFlows] = useState<FlowRecord[]>([]);
+
+  useEffect(() => {
+    if (!lastMessage) return;
+    setFlows(lastMessage);
+  }, [lastMessage]);
+
+  return { flows, readyState };
+}

--- a/clash-dashboard/src/pages/Flows.tsx
+++ b/clash-dashboard/src/pages/Flows.tsx
@@ -302,7 +302,7 @@ export function Flows() {
             data={sankeyData}
             margin={{ top: 20, right: 140, bottom: 20, left: 140 }}
             align="justify"
-            colors={(node: SankeyNodeDatum<FlowNode, FlowLink>) =>
+            colors={(node) =>
               node.id.startsWith('src:') ? '#5ac8fa' : '#0071e3'
             }
             nodeOpacity={0.85}

--- a/clash-dashboard/src/pages/Flows.tsx
+++ b/clash-dashboard/src/pages/Flows.tsx
@@ -1,0 +1,447 @@
+import { useMemo, useState } from 'react';
+import { ResponsiveSankey } from '@nivo/sankey';
+import { Activity, ArrowUp, ArrowDown, GitBranch, ChevronUp, ChevronDown } from 'lucide-react';
+import { useFlows } from '../hooks/useFlows';
+import type { FlowRecord } from '../hooks/useFlows';
+import type { DefaultLink, DefaultNode, SankeyLinkDatum, SankeyNodeDatum } from '@nivo/sankey';
+
+// ─── Formatting ────────────────────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)}MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+
+// ─── Protocol colours ───────────────────────────────────────────────────────────
+
+const PROTOCOL_COLORS: Record<string, string> = {
+  TCP: '#0071e3',
+  UDP: '#ff9500',
+  QUIC: '#5ac8fa',
+  HTTP: '#34c759',
+  HTTPS: '#30d158',
+};
+
+function protocolColor(protocol: string): string {
+  return PROTOCOL_COLORS[protocol.toUpperCase()] ?? '#8e8e93';
+}
+
+// ─── Sankey types ───────────────────────────────────────────────────────────────
+
+type FlowNode = DefaultNode;
+
+interface FlowLink extends DefaultLink {
+  protocol: string;
+  uploadTotal: number;
+  downloadTotal: number;
+  connCount: number;
+  rule: string;
+}
+
+// ─── Sankey data builder ────────────────────────────────────────────────────────
+
+interface SankeyData {
+  nodes: FlowNode[];
+  links: FlowLink[];
+}
+
+function buildSankeyData(flows: FlowRecord[]): SankeyData {
+  if (flows.length === 0) return { nodes: [], links: [] };
+
+  const top15 = [...flows].sort((a, b) => b.bytesTotal - a.bytesTotal).slice(0, 15);
+
+  const allSrcIps = new Set<string>();
+  top15.forEach(f => f.srcIps.forEach(ip => allSrcIps.add(ip)));
+  const groupSrcs = allSrcIps.size > 5;
+
+  interface LinkAgg {
+    bytes: number;
+    upload: number;
+    download: number;
+    connCount: number;
+    protocol: string;
+    rule: string;
+  }
+
+  const linkAgg = new Map<string, Map<string, LinkAgg>>();
+
+  for (const flow of top15) {
+    const dstId = `dst:${flow.dstHost || `port-${flow.dstPort}`}`;
+    const srcIps = flow.srcIps.length > 0 ? flow.srcIps : ['unknown'];
+    const perIp = 1 / srcIps.length;
+
+    for (const ip of srcIps) {
+      const srcId = groupSrcs ? 'src:Local Network' : `src:${ip}`;
+      if (!linkAgg.has(srcId)) linkAgg.set(srcId, new Map());
+      const dstMap = linkAgg.get(srcId)!;
+      const existing = dstMap.get(dstId);
+      if (existing) {
+        existing.bytes += flow.bytesTotal * perIp;
+        existing.upload += flow.uploadTotal * perIp;
+        existing.download += flow.downloadTotal * perIp;
+        existing.connCount += flow.connCount;
+      } else {
+        dstMap.set(dstId, {
+          bytes: flow.bytesTotal * perIp,
+          upload: flow.uploadTotal * perIp,
+          download: flow.downloadTotal * perIp,
+          connCount: flow.connCount,
+          protocol: flow.protocol,
+          rule: flow.rule,
+        });
+      }
+    }
+  }
+
+  const nodeIds = new Set<string>();
+  const links: FlowLink[] = [];
+
+  for (const [srcId, dstMap] of linkAgg) {
+    nodeIds.add(srcId);
+    for (const [dstId, agg] of dstMap) {
+      nodeIds.add(dstId);
+      const color = protocolColor(agg.protocol);
+      links.push({
+        source: srcId,
+        target: dstId,
+        value: Math.max(1, Math.round(agg.bytes)),
+        startColor: color,
+        endColor: color,
+        protocol: agg.protocol,
+        uploadTotal: Math.round(agg.upload),
+        downloadTotal: Math.round(agg.download),
+        connCount: agg.connCount,
+        rule: agg.rule,
+      });
+    }
+  }
+
+  const nodes: FlowNode[] = Array.from(nodeIds).map(id => ({ id }));
+  return { nodes, links };
+}
+
+// ─── Sankey tooltip ─────────────────────────────────────────────────────────────
+
+function LinkTooltip({ link }: { link: SankeyLinkDatum<FlowNode, FlowLink> }) {
+  return (
+    <div
+      className="rounded-xl px-3 py-2 text-[13px] space-y-1"
+      style={{
+        background: 'rgba(255,255,255,0.97)',
+        backdropFilter: 'blur(8px)',
+        border: '1px solid rgba(0,0,0,0.08)',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
+      }}
+    >
+      <div className="font-semibold text-[14px]" style={{ color: '#1d1d1f' }}>
+        {link.source.id.replace(/^src:/, '')} → {link.target.id.replace(/^dst:/, '')}
+      </div>
+      <div className="flex gap-3" style={{ color: '#6e6e73' }}>
+        <span>↑ {formatBytes(link.uploadTotal)}</span>
+        <span>↓ {formatBytes(link.downloadTotal)}</span>
+      </div>
+      <div className="flex gap-3" style={{ color: '#6e6e73' }}>
+        <span>Conns: {link.connCount}</span>
+        <span style={{ color: protocolColor(link.protocol) }}>{link.protocol}</span>
+      </div>
+      <div className="text-[12px]" style={{ color: '#8e8e93' }}>Rule: {link.rule}</div>
+    </div>
+  );
+}
+
+// ─── Summary icon badge ─────────────────────────────────────────────────────────
+
+function IconBadge({ bg, children }: { bg: string; children: React.ReactNode }) {
+  return (
+    <div
+      className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
+      style={{ background: bg }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ─── Sort helpers ───────────────────────────────────────────────────────────────
+
+type SortField = 'bytesTotal' | 'uploadTotal' | 'downloadTotal' | 'connCount';
+type SortDir = 'asc' | 'desc';
+
+function SortIcon({ field, active, dir }: { field: SortField; active: SortField; dir: SortDir }) {
+  if (field !== active) return <ChevronUp size={11} style={{ opacity: 0.3 }} />;
+  return dir === 'asc'
+    ? <ChevronUp size={11} style={{ color: '#0071e3' }} />
+    : <ChevronDown size={11} style={{ color: '#0071e3' }} />;
+}
+
+// ─── Main page ──────────────────────────────────────────────────────────────────
+
+export function Flows() {
+  const { flows } = useFlows();
+  const [sortField, setSortField] = useState<SortField>('bytesTotal');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const totalBytes = useMemo(() => flows.reduce((s, f) => s + f.bytesTotal, 0), [flows]);
+  const topDst = useMemo(
+    () => flows.length > 0
+      ? [...flows].sort((a, b) => b.bytesTotal - a.bytesTotal)[0].dstHost
+      : '—',
+    [flows],
+  );
+
+  const sankeyData = useMemo(() => buildSankeyData(flows), [flows]);
+  const hasSankeyData = sankeyData.nodes.length >= 2 && sankeyData.links.length >= 1;
+
+  const sortedFlows = useMemo(() => {
+    const sorted = [...flows].sort((a, b) => {
+      const diff = a[sortField] - b[sortField];
+      return sortDir === 'asc' ? diff : -diff;
+    });
+    return sorted.slice(0, 50);
+  }, [flows, sortField, sortDir]);
+
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDir('desc');
+    }
+  }
+
+  const usedProtocols = useMemo(
+    () => [...new Set(flows.map(f => f.protocol.toUpperCase()))],
+    [flows],
+  );
+
+  return (
+    <div className="p-6 space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <GitBranch size={20} style={{ color: '#0071e3' }} />
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Flows</h1>
+      </div>
+
+      {/* Summary cards */}
+      <div
+        className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
+        style={{ color: '#6e6e73' }}
+      >
+        Summary
+      </div>
+      <div
+        className="liquid-glass-card rounded-xl overflow-hidden"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
+      >
+        {[
+          {
+            icon: <Activity size={14} className="text-white" />,
+            bg: '#0071e3',
+            label: 'Unique Flows',
+            value: String(flows.length),
+          },
+          {
+            icon: <ArrowDown size={14} className="text-white" />,
+            bg: '#34c759',
+            label: 'Top Destination',
+            value: topDst,
+          },
+          {
+            icon: <ArrowUp size={14} className="text-white" />,
+            bg: '#ff9500',
+            label: 'Total Bytes',
+            value: formatBytes(totalBytes),
+          },
+        ].map((row, idx, arr) => (
+          <div
+            key={row.label}
+            className="flex items-center gap-3 px-4"
+            style={{
+              minHeight: 52,
+              borderBottom: idx < arr.length - 1 ? '1px solid rgba(0,0,0,0.06)' : 'none',
+            }}
+          >
+            <IconBadge bg={row.bg}>{row.icon}</IconBadge>
+            <span className="text-[15px] flex-1" style={{ color: '#1d1d1f' }}>{row.label}</span>
+            <span className="text-[15px] font-mono truncate max-w-48" style={{ color: '#6e6e73' }}>{row.value}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Sankey diagram */}
+      <div
+        className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
+        style={{ color: '#6e6e73' }}
+      >
+        Flow Map (top 15 destinations)
+      </div>
+
+      {/* Protocol legend */}
+      {usedProtocols.length > 0 && (
+        <div className="flex items-center gap-3 px-1 flex-wrap">
+          {usedProtocols.map(proto => (
+            <div key={proto} className="flex items-center gap-1.5">
+              <div
+                className="w-2.5 h-2.5 rounded-sm"
+                style={{ background: protocolColor(proto) }}
+              />
+              <span className="text-[12px]" style={{ color: '#6e6e73' }}>{proto}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div
+        className="liquid-glass-card rounded-xl overflow-hidden"
+        style={{ height: 420, boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
+      >
+        {hasSankeyData ? (
+          <ResponsiveSankey<FlowNode, FlowLink>
+            data={sankeyData}
+            margin={{ top: 20, right: 140, bottom: 20, left: 140 }}
+            align="justify"
+            colors={(node: SankeyNodeDatum<FlowNode, FlowLink>) =>
+              node.id.startsWith('src:') ? '#5ac8fa' : '#0071e3'
+            }
+            nodeOpacity={0.85}
+            nodeHoverOpacity={1}
+            nodeThickness={14}
+            nodeSpacing={20}
+            nodeBorderWidth={0}
+            nodeBorderRadius={4}
+            linkOpacity={0.35}
+            linkHoverOpacity={0.7}
+            linkBlendMode="normal"
+            enableLinkGradient={true}
+            label={(node: Omit<SankeyNodeDatum<FlowNode, FlowLink>, 'color' | 'label'>) =>
+              node.id.replace(/^(src:|dst:)/, '')
+            }
+            labelPosition="outside"
+            labelPadding={12}
+            labelTextColor={{ from: 'color', modifiers: [['darker', 1]] }}
+            linkTooltip={LinkTooltip}
+            animate={true}
+            motionConfig="gentle"
+          />
+        ) : (
+          <div className="h-full flex items-center justify-center">
+            <span className="text-[15px]" style={{ color: '#8e8e93' }}>
+              {flows.length === 0 ? 'Waiting for flow data…' : 'Not enough data to render diagram'}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Flow table */}
+      <div
+        className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
+        style={{ color: '#6e6e73' }}
+      >
+        Flow Table (top 50)
+      </div>
+      <div
+        className="liquid-glass-card rounded-xl overflow-hidden overflow-x-auto"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
+      >
+        <table className="table-fixed w-full text-sm">
+          <thead>
+            <tr style={{ borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-48" style={{ color: '#6e6e73' }}>Destination</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-16" style={{ color: '#6e6e73' }}>Port</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Protocol</th>
+              <SortHeader field="connCount" label="Conns" current={sortField} dir={sortDir} onClick={toggleSort} width="w-20" />
+              <SortHeader field="uploadTotal" label="↑ Upload" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
+              <SortHeader field="downloadTotal" label="↓ Download" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
+              <SortHeader field="bytesTotal" label="Total" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-28" style={{ color: '#6e6e73' }}>Rule</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-40" style={{ color: '#6e6e73' }}>Proxy Chain</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedFlows.length === 0 ? (
+              <tr>
+                <td colSpan={9} className="text-center py-10 text-[15px]" style={{ color: '#8e8e93' }}>
+                  No flow data yet
+                </td>
+              </tr>
+            ) : (
+              sortedFlows.map((flow: FlowRecord, idx: number) => (
+                <tr
+                  key={`${flow.dstHost}-${flow.dstPort}-${flow.protocol}-${idx}`}
+                  className="group transition-colors"
+                  style={{ borderBottom: '1px solid rgba(0,0,0,0.04)' }}
+                >
+                  <td className="px-4 py-3">
+                    <div className="text-[14px] font-medium truncate" style={{ color: '#1d1d1f' }}>
+                      {flow.dstHost || '—'}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 font-mono text-[13px]" style={{ color: '#8e8e93' }}>
+                    {flow.dstPort}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className="text-[12px] font-medium px-2 py-0.5 rounded-full"
+                      style={{
+                        background: `${protocolColor(flow.protocol)}18`,
+                        color: protocolColor(flow.protocol),
+                      }}
+                    >
+                      {flow.protocol}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#6e6e73' }}>
+                    {flow.connCount}
+                  </td>
+                  <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#0071e3' }}>
+                    {formatBytes(flow.uploadTotal)}
+                  </td>
+                  <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#34c759' }}>
+                    {formatBytes(flow.downloadTotal)}
+                  </td>
+                  <td className="px-4 py-3 text-right text-[13px] font-mono font-semibold" style={{ color: '#ff9500' }}>
+                    {formatBytes(flow.bytesTotal)}
+                  </td>
+                  <td className="px-4 py-3 text-[12px] truncate" style={{ color: '#6e6e73' }}>
+                    {flow.rule}
+                  </td>
+                  <td className="px-4 py-3 text-[12px] truncate" style={{ color: '#8e8e93' }}>
+                    {flow.chains?.join(' → ')}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Sortable table header ──────────────────────────────────────────────────────
+
+function SortHeader({
+  field, label, current, dir, onClick, width,
+}: {
+  field: SortField;
+  label: string;
+  current: SortField;
+  dir: SortDir;
+  onClick: (f: SortField) => void;
+  width: string;
+}) {
+  return (
+    <th
+      className={`text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] cursor-pointer select-none ${width}`}
+      style={{ color: field === current ? '#0071e3' : '#6e6e73' }}
+      onClick={() => onClick(field)}
+    >
+      <div className="flex items-center justify-end gap-1">
+        {label}
+        <SortIcon field={field} active={current} dir={dir} />
+      </div>
+    </th>
+  );
+}

--- a/clash-dashboard/src/pages/Flows.tsx
+++ b/clash-dashboard/src/pages/Flows.tsx
@@ -76,18 +76,19 @@ function buildSankeyData(flows: FlowRecord[]): SankeyData {
       const srcId = groupSrcs ? 'src:Local Network' : `src:${ip}`;
       if (!linkAgg.has(srcId)) linkAgg.set(srcId, new Map());
       const dstMap = linkAgg.get(srcId)!;
-      const existing = dstMap.get(dstId);
+      const linkKey = `${dstId}|${flow.protocol.toUpperCase()}|${flow.dstPort}`;
+      const existing = dstMap.get(linkKey);
       if (existing) {
         existing.bytes += flow.bytesTotal * perIp;
         existing.upload += flow.uploadTotal * perIp;
         existing.download += flow.downloadTotal * perIp;
-        existing.connCount += flow.connCount;
+        existing.connCount += flow.connCount * perIp;
       } else {
-        dstMap.set(dstId, {
+        dstMap.set(linkKey, {
           bytes: flow.bytesTotal * perIp,
           upload: flow.uploadTotal * perIp,
           download: flow.downloadTotal * perIp,
-          connCount: flow.connCount,
+          connCount: flow.connCount * perIp,
           protocol: flow.protocol,
           rule: flow.rule,
         });
@@ -100,7 +101,8 @@ function buildSankeyData(flows: FlowRecord[]): SankeyData {
 
   for (const [srcId, dstMap] of linkAgg) {
     nodeIds.add(srcId);
-    for (const [dstId, agg] of dstMap) {
+    for (const [linkKey, agg] of dstMap) {
+      const dstId = linkKey.split('|')[0];
       nodeIds.add(dstId);
       const color = protocolColor(agg.protocol);
       links.push({
@@ -186,7 +188,7 @@ export function Flows() {
   const totalBytes = useMemo(() => flows.reduce((s, f) => s + f.bytesTotal, 0), [flows]);
   const topDst = useMemo(
     () => flows.length > 0
-      ? [...flows].sort((a, b) => b.bytesTotal - a.bytesTotal)[0].dstHost
+      ? [...flows].sort((a, b) => b.bytesTotal - a.bytesTotal)[0].dstHost || '—'
       : '—',
     [flows],
   );
@@ -434,14 +436,18 @@ function SortHeader({
 }) {
   return (
     <th
-      className={`text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] cursor-pointer select-none ${width}`}
+      aria-sort={field === current ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+      className={`text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] select-none ${width}`}
       style={{ color: field === current ? '#0071e3' : '#6e6e73' }}
-      onClick={() => onClick(field)}
     >
-      <div className="flex items-center justify-end gap-1">
+      <button
+        type="button"
+        className="w-full flex items-center justify-end gap-1 cursor-pointer"
+        onClick={() => onClick(field)}
+      >
         {label}
         <SortIcon field={field} active={current} dir={dir} />
-      </div>
+      </button>
     </th>
   );
 }

--- a/clash-lib/src/app/api/handlers/flows.rs
+++ b/clash-lib/src/app/api/handlers/flows.rs
@@ -1,0 +1,280 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use axum::{
+    Json, Router,
+    extract::{Query, State, WebSocketUpgrade, ws::Message},
+    response::IntoResponse,
+    routing::get,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::{
+    app::{api::AppState, dispatcher::StatisticsManager},
+    session::Network,
+};
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub(crate) struct FlowState {
+    pub statistics_manager: Arc<StatisticsManager>,
+}
+
+pub fn routes(statistics_manager: Arc<StatisticsManager>) -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/", get(handle))
+        .with_state(FlowState { statistics_manager })
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct FlowQuery {
+    /// Maximum number of flow records to return (default 20).
+    pub top: Option<usize>,
+    /// Field to group by (currently only "dst_host" is supported, kept for
+    /// forward compatibility).
+    #[allow(dead_code)]
+    pub group_by: Option<String>,
+    /// Whether to include recently-closed connections (default true).
+    pub include_closed: Option<bool>,
+    /// WebSocket polling interval in seconds (default 5, min 1).
+    #[allow(dead_code)]
+    pub interval: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FlowRecord {
+    pub dst_host: String,
+    pub dst_port: u16,
+    pub protocol: String,
+    pub src_ips: Vec<String>,
+    pub conn_count: usize,
+    pub upload_total: u64,
+    pub download_total: u64,
+    pub bytes_total: u64,
+    pub rule: String,
+    pub chains: Vec<String>,
+    pub last_seen: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation key
+// ---------------------------------------------------------------------------
+
+#[derive(Hash, PartialEq, Eq)]
+struct FlowKey {
+    dst_host: String,
+    dst_port: u16,
+    protocol: String,
+}
+
+// ---------------------------------------------------------------------------
+// Per-key accumulator
+// ---------------------------------------------------------------------------
+
+struct Acc {
+    src_ips: Vec<String>,
+    conn_count: usize,
+    upload_total: u64,
+    download_total: u64,
+    rule: String,
+    chains: Vec<String>,
+    last_seen: DateTime<Utc>,
+}
+
+impl Acc {
+    fn merge(
+        &mut self,
+        src_ip: String,
+        upload: u64,
+        download: u64,
+        rule: &str,
+        chains: Vec<String>,
+        start_time: DateTime<Utc>,
+    ) {
+        if !src_ip.is_empty() && !self.src_ips.contains(&src_ip) {
+            self.src_ips.push(src_ip);
+        }
+        self.conn_count += 1;
+        self.upload_total += upload;
+        self.download_total += download;
+        if self.rule.is_empty() && !rule.is_empty() {
+            self.rule = rule.to_owned();
+        }
+        if self.chains.is_empty() && !chains.is_empty() {
+            self.chains = chains;
+        }
+        if start_time > self.last_seen {
+            self.last_seen = start_time;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core aggregation logic
+// ---------------------------------------------------------------------------
+
+async fn build_flow_records(
+    mgr: &StatisticsManager,
+    top: usize,
+    include_closed: bool,
+) -> Vec<FlowRecord> {
+    use std::sync::atomic::Ordering;
+
+    let mut map: HashMap<FlowKey, Acc> = HashMap::new();
+
+    // Helper to insert/merge one TrackerInfo into the map.
+    macro_rules! merge_info {
+        ($info:expr, $chains:expr) => {{
+            let info = $info;
+            let dst_host = info.session_holder.destination.host();
+            let dst_port = info.session_holder.destination.port();
+            let protocol = match info.session_holder.network {
+                Network::Tcp => "tcp".to_string(),
+                Network::Udp => "udp".to_string(),
+            };
+            let src_ip = info.session_holder.source.ip().to_string();
+            let upload = info.upload_total.load(Ordering::Relaxed);
+            let download = info.download_total.load(Ordering::Relaxed);
+            let key = FlowKey {
+                dst_host,
+                dst_port,
+                protocol,
+            };
+            let acc = map.entry(key).or_insert_with(|| Acc {
+                src_ips: Vec::new(),
+                conn_count: 0,
+                upload_total: 0,
+                download_total: 0,
+                rule: String::new(),
+                chains: Vec::new(),
+                last_seen: DateTime::<Utc>::MIN_UTC,
+            });
+            acc.merge(
+                src_ip,
+                upload,
+                download,
+                &info.rule,
+                $chains,
+                info.start_time,
+            );
+        }};
+    }
+
+    // Active connections — use active_connections_snapshot so session_holder
+    // is preserved (snapshot() materialises a reduced view that drops it).
+    let active = mgr.active_connections_snapshot().await;
+    for info in &active {
+        let chains = info.proxy_chain_holder.snapshot().await;
+        merge_info!(info, chains);
+    }
+
+    // Closed connections (ring buffer).
+    if include_closed {
+        let closed = mgr.closed_flows_snapshot().await;
+        for info in &closed {
+            let chains = info.proxy_chain_holder.snapshot().await;
+            merge_info!(info, chains);
+        }
+    }
+
+    // Convert accumulator map → sorted FlowRecord list.
+    let mut records: Vec<FlowRecord> = map
+        .into_iter()
+        .map(|(key, acc)| {
+            let bytes_total = acc.upload_total + acc.download_total;
+            FlowRecord {
+                dst_host: key.dst_host,
+                dst_port: key.dst_port,
+                protocol: key.protocol,
+                src_ips: acc.src_ips,
+                conn_count: acc.conn_count,
+                upload_total: acc.upload_total,
+                download_total: acc.download_total,
+                bytes_total,
+                rule: acc.rule,
+                chains: acc.chains,
+                last_seen: acc.last_seen,
+            }
+        })
+        .collect();
+
+    records.sort_by(|a, b| b.bytes_total.cmp(&a.bytes_total));
+    records.truncate(top);
+    records
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler
+// ---------------------------------------------------------------------------
+
+pub async fn handle(
+    State(state): State<FlowState>,
+    Query(q): Query<FlowQuery>,
+) -> impl IntoResponse {
+    let top = q.top.unwrap_or(20).max(1);
+    let include_closed = q.include_closed.unwrap_or(true);
+
+    let records =
+        build_flow_records(&state.statistics_manager, top, include_closed).await;
+    Json(records).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket handler (used from websocket.rs via AppState)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct WsFlowQuery {
+    pub interval: Option<u64>,
+    pub top: Option<usize>,
+    pub include_closed: Option<bool>,
+}
+
+pub async fn ws_handle(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<WsFlowQuery>,
+) -> impl IntoResponse {
+    let top = q.top.unwrap_or(20).max(1);
+    let include_closed = q.include_closed.unwrap_or(true);
+    let interval_secs = q.interval.unwrap_or(5).max(1);
+
+    let callback = async move |mut socket: axum::extract::ws::WebSocket| {
+        let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
+        loop {
+            ticker.tick().await;
+            let records =
+                build_flow_records(&state.statistics_manager, top, include_closed)
+                    .await;
+            let body = match serde_json::to_string(&records) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("failed to serialize flow records: {}", e);
+                    break;
+                }
+            };
+            if let Err(e) = socket.send(Message::Text(body.into())).await {
+                debug!("ws/flows send error: {}", e);
+                break;
+            }
+        }
+    };
+
+    ws.on_failed_upgrade(|e| warn!("ws/flows upgrade error: {}", e))
+        .on_upgrade(async move |socket| {
+            callback(socket).await;
+        })
+}

--- a/clash-lib/src/app/api/handlers/flows.rs
+++ b/clash-lib/src/app/api/handlers/flows.rs
@@ -211,7 +211,7 @@ async fn build_flow_records(
         })
         .collect();
 
-    records.sort_by(|a, b| b.bytes_total.cmp(&a.bytes_total));
+    records.sort_by_key(|r| std::cmp::Reverse(r.bytes_total));
     records.truncate(top);
     records
 }
@@ -224,7 +224,7 @@ pub async fn handle(
     State(state): State<FlowState>,
     Query(q): Query<FlowQuery>,
 ) -> impl IntoResponse {
-    let top = q.top.unwrap_or(20).max(1);
+    let top = q.top.unwrap_or(20).clamp(1, 500);
     let include_closed = q.include_closed.unwrap_or(true);
 
     let records =
@@ -248,7 +248,7 @@ pub async fn ws_handle(
     State(state): State<Arc<AppState>>,
     Query(q): Query<WsFlowQuery>,
 ) -> impl IntoResponse {
-    let top = q.top.unwrap_or(20).max(1);
+    let top = q.top.unwrap_or(20).clamp(1, 500);
     let include_closed = q.include_closed.unwrap_or(true);
     let interval_secs = q.interval.unwrap_or(5).max(1);
 

--- a/clash-lib/src/app/api/handlers/mod.rs
+++ b/clash-lib/src/app/api/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod connection;
 pub mod dns;
+pub mod flows;
 pub mod group;
 pub mod hello;
 pub mod log;

--- a/clash-lib/src/app/api/runner.rs
+++ b/clash-lib/src/app/api/runner.rs
@@ -170,8 +170,9 @@ impl Runner for ApiRunner {
                 )
                 .nest(
                     "/connections",
-                    handlers::connection::routes(statistics_manager),
+                    handlers::connection::routes(statistics_manager.clone()),
                 )
+                .nest("/flows", handlers::flows::routes(statistics_manager))
                 .nest("/dns", handlers::dns::routes(dns_resolver))
                 .layer(middleware::from_fn(
                     middlewares::fix_json_content_type::fix_content_type,

--- a/clash-lib/src/app/api/websocket.rs
+++ b/clash-lib/src/app/api/websocket.rs
@@ -16,6 +16,7 @@ use crate::app::api::{
     AppState,
     handlers::{
         connection::GetConnectionsQuery,
+        flows::ws_handle as flows_ws_handle,
         memory::{GetMemoryQuery, GetMemoryResponse},
     },
 };
@@ -26,6 +27,7 @@ pub fn routes(state: Arc<AppState>) -> Router<Arc<AppState>> {
         .route("/traffic", get(traffic))
         .route("/memory", get(memory))
         .route("/logs", get(log))
+        .route("/flows", get(flows_ws_handle))
         .with_state(state)
 }
 

--- a/clash-lib/src/app/dispatcher/statistics_manager.rs
+++ b/clash-lib/src/app/dispatcher/statistics_manager.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     sync::{Arc, atomic::Ordering},
 };
 
@@ -28,6 +28,10 @@ impl ProxyChain {
     pub async fn push(&self, s: String) {
         let mut chain = self.0.write().await;
         chain.push(s);
+    }
+
+    pub async fn snapshot(&self) -> Vec<String> {
+        self.0.read().await.clone()
     }
 }
 
@@ -77,6 +81,7 @@ type ConnectionMap = HashMap<uuid::Uuid, (Tracked, Sender<()>)>;
 
 pub struct Manager {
     connections: Arc<Mutex<ConnectionMap>>,
+    closed_flows: Arc<Mutex<VecDeque<Arc<TrackerInfo>>>>,
     upload_temp: AtomicU64,
     download_temp: AtomicU64,
     upload_blip: AtomicU64,
@@ -92,6 +97,7 @@ impl Manager {
     pub fn new() -> Arc<Self> {
         let v = Arc::new(Self {
             connections: Arc::new(Mutex::new(HashMap::new())),
+            closed_flows: Arc::new(Mutex::new(VecDeque::new())),
             upload_temp: AtomicU64::new(0),
             download_temp: AtomicU64::new(0),
             upload_blip: AtomicU64::new(0),
@@ -120,6 +126,7 @@ impl Manager {
     pub fn untrack(&self, id: uuid::Uuid) {
         let connections = self.connections.clone();
         let user_period_stats = self.user_period_stats.clone();
+        let closed_flows = self.closed_flows.clone();
 
         tokio::spawn(async move {
             let mut connections = connections.lock().await;
@@ -139,8 +146,32 @@ impl Manager {
                     entry.upload += upload;
                     entry.download += download;
                 }
+
+                // Push to the closed_flows ring buffer (cap 1000).
+                let mut ring = closed_flows.lock().await;
+                ring.push_back(info);
+                if ring.len() > 1000 {
+                    ring.pop_front();
+                }
             }
         });
+    }
+
+    /// Return `Arc<TrackerInfo>` for every currently-active connection.
+    /// Unlike `snapshot()`, this preserves the full `session_holder` so
+    /// callers can access destination, source, and network fields directly.
+    pub async fn active_connections_snapshot(&self) -> Vec<Arc<TrackerInfo>> {
+        let conns = self.connections.lock().await;
+        conns
+            .values()
+            .map(|(tracked, _)| tracked.tracker_info())
+            .collect()
+    }
+
+    /// Return a snapshot of recently closed connections (up to 1000 entries).
+    pub async fn closed_flows_snapshot(&self) -> Vec<Arc<TrackerInfo>> {
+        let ring = self.closed_flows.lock().await;
+        ring.iter().cloned().collect()
     }
 
     /// Return per-user traffic accumulated since the last call (for both closed


### PR DESCRIPTION
## Overview

Adds a **Flows** page to the dashboard that shows a Sankey diagram of network flows — similar to a netflow visualization — showing traffic from source IPs to destination hosts in real time.

## Backend changes

- **Ring buffer** in `StatisticsManager`: last 1000 closed connections stored in a `VecDeque<Arc<TrackerInfo>>`, exposed via `closed_flows_snapshot()`
- **`active_connections_snapshot()`**: returns live `Arc<TrackerInfo>` objects with full session metadata intact
- **`ProxyChain::snapshot()`**: exposes inner proxy chain as `Vec<String>`
- **`GET /flows`**: aggregates active + closed connections into flow records grouped by `(dst_host, dst_port, protocol)`, sorted by total bytes. Query params: `top` (default 20), `include_closed` (default true)
- **`GET /ws/flows`**: WebSocket stream of the same data, configurable `interval` (default 5s, min 1s)

## Frontend changes

- **`useFlows`** hook: connects to `/ws/flows`
- **Flows page**: summary cards + Sankey diagram (`@nivo/sankey`) with source IPs on the left, destination hosts on the right, link width proportional to bytes, TCP=blue / UDP=orange; plus a sortable flow table below
- **Nav entry**: added between Connections and Rules in the sidebar

## Data available per flow record

`dstHost`, `dstPort`, `protocol`, `srcIps`, `connCount`, `uploadTotal`, `downloadTotal`, `bytesTotal`, `rule`, `chains`, `lastSeen`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Flows" page with Sankey visualization and protocol legend.
  * Interactive, sortable flow table with top flows, formatted metrics, and summary cards.
  * Real-time updates via a new WebSocket stream including recently closed connections and top-N aggregation.

* **Chores**
  * Added visualization library dependencies to enable Sankey/chart rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->