### PR TITLE
fix(api): exempt /ui from secret authentication

### DIFF
--- a/clash-lib/src/app/api/middlewares/auth.rs
+++ b/clash-lib/src/app/api/middlewares/auth.rs
@@ -68,6 +68,11 @@ where
             return Box::pin(self.inner.call(req));
         }
 
+        // /ui is a public endpoint — no auth required regardless of transport
+        if req.uri().path().starts_with("/ui") {
+            return Box::pin(self.inner.call(req));
+        }
+
         let unauthorised = Response::builder()
             .status(http::StatusCode::UNAUTHORIZED)
             .body("unauthorized".to_string().into())

--- a/clash-lib/src/app/api/middlewares/auth.rs
+++ b/clash-lib/src/app/api/middlewares/auth.rs
@@ -69,7 +69,8 @@ where
         }
 
         // /ui is a public endpoint — no auth required regardless of transport
-        if req.uri().path().starts_with("/ui") {
+        let path = req.uri().path();
+        if path == "/ui" || path.starts_with("/ui/") {
             return Box::pin(self.inner.call(req));
         }
 


### PR DESCRIPTION
The `/ui` endpoint serves the web dashboard and should be publicly accessible regardless of transport (TCP or IPC).

Currently the TCP listener applies `AuthMiddlewareLayer` to all routes via `route_layer()`, blocking `/ui` behind the secret token.

**Fix:** add an early-return in `AuthMiddleware::call()` for any path starting with `/ui`, bypassing token validation. IPC already has no auth applied so no change needed there.

All other API endpoints remain protected as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests to the UI endpoints (/ui and /ui/*) now bypass authentication and are served directly.

* **Bug Fixes**
  * Empty authentication token is treated as bypassed, avoiding unnecessary auth checks.
  * Existing WebSocket and header-based authorization behavior remains unchanged; unauthorized requests still return 401.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->