### PR TITLE
feat(dashboard): flows page improvements

### DIFF
--- a/clash-dashboard/src/hooks/useFlows.ts
+++ b/clash-dashboard/src/hooks/useFlows.ts
@@ -17,6 +17,7 @@ export interface FlowRecord {
   rulePayload: string;
   chains: string[];
   asn: string | null;
+  country: string | null;
   lastSeen: string;
 }
 
@@ -26,7 +27,7 @@ interface UseFlowsReturn {
 }
 
 export function useFlows(includeClosed = true): UseFlowsReturn {
-  const url = getWsUrl(`/ws/flows?interval=5&include_closed=${includeClosed}`);
+  const url = getWsUrl(`/ws/flows?interval=5&top=50&include_closed=${includeClosed}`);
   const { lastMessage, readyState } = useWebSocket<FlowRecord[]>(url);
 
   const [flows, setFlows] = useState<FlowRecord[]>([]);

--- a/clash-dashboard/src/hooks/useFlows.ts
+++ b/clash-dashboard/src/hooks/useFlows.ts
@@ -8,11 +8,15 @@ export interface FlowRecord {
   protocol: string;
   srcIps: string[];
   connCount: number;
+  activeCount: number;
+  closedCount: number;
   uploadTotal: number;
   downloadTotal: number;
   bytesTotal: number;
   rule: string;
+  rulePayload: string;
   chains: string[];
+  asn: string | null;
   lastSeen: string;
 }
 
@@ -21,8 +25,8 @@ interface UseFlowsReturn {
   readyState: import('./useWebSocket').ReadyState;
 }
 
-export function useFlows(): UseFlowsReturn {
-  const url = getWsUrl('/ws/flows?interval=5');
+export function useFlows(includeClosed = true): UseFlowsReturn {
+  const url = getWsUrl(`/ws/flows?interval=5&include_closed=${includeClosed}`);
   const { lastMessage, readyState } = useWebSocket<FlowRecord[]>(url);
 
   const [flows, setFlows] = useState<FlowRecord[]>([]);

--- a/clash-dashboard/src/pages/Flows.tsx
+++ b/clash-dashboard/src/pages/Flows.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { ResponsiveSankey } from '@nivo/sankey';
-import { Activity, ArrowUp, ArrowDown, GitBranch, ChevronUp, ChevronDown } from 'lucide-react';
+import { Activity, ArrowUp, ArrowDown, GitBranch, ChevronUp, ChevronDown, Search } from 'lucide-react';
 import { useFlows } from '../hooks/useFlows';
 import type { FlowRecord } from '../hooks/useFlows';
 import type { DefaultLink, DefaultNode, SankeyLinkDatum, SankeyNodeDatum } from '@nivo/sankey';
@@ -12,6 +12,24 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)}MB`;
   return `${(bytes / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+
+function formatRelative(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(diffMs / 1000);
+  if (s < 5) return 'just now';
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+function countryFlag(code: string): string {
+  if (!/^[A-Z]{2}$/.test(code)) return '';
+  const offset = 0x1F1E6 - 65;
+  return String.fromCodePoint(code.charCodeAt(0) + offset) +
+         String.fromCodePoint(code.charCodeAt(1) + offset);
 }
 
 // ─── Protocol colours ───────────────────────────────────────────────────────────
@@ -181,7 +199,10 @@ function SortIcon({ field, active, dir }: { field: SortField; active: SortField;
 // ─── Main page ──────────────────────────────────────────────────────────────────
 
 export function Flows() {
-  const { flows } = useFlows();
+  const [includeClosed, setIncludeClosed] = useState(true);
+  const [search, setSearch] = useState('');
+  const [protocolFilter, setProtocolFilter] = useState<string | null>(null);
+  const { flows } = useFlows(includeClosed);
   const [sortField, setSortField] = useState<SortField>('bytesTotal');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 
@@ -196,13 +217,26 @@ export function Flows() {
   const sankeyData = useMemo(() => buildSankeyData(flows), [flows]);
   const hasSankeyData = sankeyData.nodes.length >= 2 && sankeyData.links.length >= 1;
 
+  const usedProtocols = useMemo(
+    () => [...new Set(flows.map(f => f.protocol.toUpperCase()))],
+    [flows],
+  );
+
   const sortedFlows = useMemo(() => {
-    const sorted = [...flows].sort((a, b) => {
+    let filtered = flows;
+    if (search) {
+      const lower = search.toLowerCase();
+      filtered = filtered.filter(f => f.dstHost.toLowerCase().includes(lower));
+    }
+    if (protocolFilter) {
+      filtered = filtered.filter(f => f.protocol.toUpperCase() === protocolFilter);
+    }
+    const sorted = [...filtered].sort((a, b) => {
       const diff = a[sortField] - b[sortField];
       return sortDir === 'asc' ? diff : -diff;
     });
     return sorted.slice(0, 50);
-  }, [flows, sortField, sortDir]);
+  }, [flows, sortField, sortDir, search, protocolFilter]);
 
   function toggleSort(field: SortField) {
     if (sortField === field) {
@@ -213,10 +247,17 @@ export function Flows() {
     }
   }
 
-  const usedProtocols = useMemo(
-    () => [...new Set(flows.map(f => f.protocol.toUpperCase()))],
-    [flows],
-  );
+  // ASN breakdown — top 10 by total bytes
+  const asnRows = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const f of flows) {
+      if (!f.asn) continue;
+      map.set(f.asn, (map.get(f.asn) ?? 0) + f.bytesTotal);
+    }
+    const entries = [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+    const max = entries[0]?.[1] ?? 1;
+    return entries.map(([asn, bytes]) => ({ asn, bytes, pct: bytes / max }));
+  }, [flows]);
 
   return (
     <div className="p-6 space-y-4">
@@ -224,6 +265,60 @@ export function Flows() {
       <div className="flex items-center gap-2">
         <GitBranch size={20} style={{ color: '#0071e3' }} />
         <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Flows</h1>
+      </div>
+
+      {/* Controls bar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* Search */}
+        <div className="flex items-center gap-2 flex-1 min-w-48 max-w-72 px-3 py-1.5 rounded-xl liquid-glass-card" style={{ border: '1px solid rgba(0,0,0,0.08)' }}>
+          <Search size={14} style={{ color: '#8e8e93', flexShrink: 0 }} />
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Filter destination…"
+            className="flex-1 bg-transparent outline-none text-[14px]"
+            style={{ color: '#1d1d1f' }}
+          />
+        </div>
+
+        {/* Protocol pills */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {usedProtocols.map(proto => (
+            <button
+              key={proto}
+              type="button"
+              onClick={() => setProtocolFilter(p => p === proto ? null : proto)}
+              className="text-[12px] font-medium px-3 py-0.5 rounded-full transition-colors"
+              style={{
+                background: protocolFilter === proto ? '#0071e3' : `${protocolColor(proto)}18`,
+                color: protocolFilter === proto ? '#fff' : protocolColor(proto),
+              }}
+            >
+              {proto}
+            </button>
+          ))}
+        </div>
+
+        {/* Include closed toggle */}
+        <label className="flex items-center gap-2 ml-auto cursor-pointer select-none" style={{ color: '#6e6e73', fontSize: 13 }}>
+          <span>Include closed</span>
+          <div
+            className="relative w-9 h-5 rounded-full transition-colors"
+            style={{ background: includeClosed ? '#0071e3' : '#d1d1d6' }}
+          >
+            <input
+              type="checkbox"
+              className="sr-only"
+              checked={includeClosed}
+              onChange={e => setIncludeClosed(e.target.checked)}
+            />
+            <div
+              className="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform"
+              style={{ transform: includeClosed ? 'translateX(16px)' : 'none' }}
+            />
+          </div>
+        </label>
       </div>
 
       {/* Summary cards */}
@@ -353,18 +448,19 @@ export function Flows() {
               <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-48" style={{ color: '#6e6e73' }}>Destination</th>
               <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-16" style={{ color: '#6e6e73' }}>Port</th>
               <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Protocol</th>
-              <SortHeader field="connCount" label="Conns" current={sortField} dir={sortDir} onClick={toggleSort} width="w-20" />
+              <SortHeader field="connCount" label="Conns" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
               <SortHeader field="uploadTotal" label="↑ Upload" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
               <SortHeader field="downloadTotal" label="↓ Download" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
               <SortHeader field="bytesTotal" label="Total" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-28" style={{ color: '#6e6e73' }}>Rule</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Last Seen</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: '#6e6e73' }}>Rule</th>
               <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-40" style={{ color: '#6e6e73' }}>Proxy Chain</th>
             </tr>
           </thead>
           <tbody>
             {sortedFlows.length === 0 ? (
               <tr>
-                <td colSpan={9} className="text-center py-10 text-[15px]" style={{ color: '#8e8e93' }}>
+                <td colSpan={10} className="text-center py-10 text-[15px]" style={{ color: '#8e8e93' }}>
                   No flow data yet
                 </td>
               </tr>
@@ -375,10 +471,15 @@ export function Flows() {
                   className="group transition-colors"
                   style={{ borderBottom: '1px solid rgba(0,0,0,0.04)' }}
                 >
-                  <td className="px-4 py-3">
+                  <td className="px-4 py-3" title={flow.srcIps.length > 0 ? `Sources: ${flow.srcIps.join(', ')}` : undefined}>
                     <div className="text-[14px] font-medium truncate" style={{ color: '#1d1d1f' }}>
                       {flow.dstHost || '—'}
                     </div>
+                    {flow.srcIps.length > 0 && (
+                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>
+                        {flow.srcIps[0]}{flow.srcIps.length > 1 ? ` +${flow.srcIps.length - 1}` : ''}
+                      </div>
+                    )}
                   </td>
                   <td className="px-4 py-3 font-mono text-[13px]" style={{ color: '#8e8e93' }}>
                     {flow.dstPort}
@@ -394,8 +495,16 @@ export function Flows() {
                       {flow.protocol}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#6e6e73' }}>
-                    {flow.connCount}
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-1.5">
+                      <div
+                        className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                        style={{ background: flow.activeCount > 0 ? '#34c759' : '#8e8e93' }}
+                      />
+                      <span className="text-[13px] font-mono" style={{ color: '#6e6e73' }}>
+                        {flow.connCount}
+                      </span>
+                    </div>
                   </td>
                   <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#0071e3' }}>
                     {formatBytes(flow.uploadTotal)}
@@ -406,8 +515,14 @@ export function Flows() {
                   <td className="px-4 py-3 text-right text-[13px] font-mono font-semibold" style={{ color: '#ff9500' }}>
                     {formatBytes(flow.bytesTotal)}
                   </td>
-                  <td className="px-4 py-3 text-[12px] truncate" style={{ color: '#6e6e73' }}>
-                    {flow.rule}
+                  <td className="px-4 py-3 text-[12px]" style={{ color: '#8e8e93' }}>
+                    {formatRelative(flow.lastSeen)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="text-[12px] truncate" style={{ color: '#6e6e73' }}>{flow.rule}</div>
+                    {flow.rulePayload && (
+                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>{flow.rulePayload}</div>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-[12px] truncate" style={{ color: '#8e8e93' }}>
                     {flow.chains?.join(' → ')}
@@ -418,6 +533,43 @@ export function Flows() {
           </tbody>
         </table>
       </div>
+
+      {/* ASN / Country breakdown */}
+      {asnRows.length > 0 && (
+        <>
+          <div
+            className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
+            style={{ color: '#6e6e73' }}
+          >
+            Traffic by ASN / Country
+          </div>
+          <div
+            className="liquid-glass-card rounded-xl p-4 space-y-2"
+            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
+          >
+            {asnRows.map(({ asn, bytes, pct }) => {
+              const isCountry = /^[A-Z]{2}$/.test(asn);
+              const label = isCountry ? `${countryFlag(asn)} ${asn}` : asn;
+              return (
+                <div key={asn} className="flex items-center gap-3">
+                  <div className="w-32 text-[13px] truncate flex-shrink-0" style={{ color: '#1d1d1f' }}>
+                    {label}
+                  </div>
+                  <div className="flex-1 h-2 rounded-full overflow-hidden" style={{ background: 'rgba(0,0,0,0.06)' }}>
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{ width: `${pct * 100}%`, background: '#0071e3' }}
+                    />
+                  </div>
+                  <div className="w-20 text-right text-[12px] font-mono flex-shrink-0" style={{ color: '#6e6e73' }}>
+                    {formatBytes(bytes)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/clash-dashboard/src/pages/Flows.tsx
+++ b/clash-dashboard/src/pages/Flows.tsx
@@ -247,16 +247,25 @@ export function Flows() {
     }
   }
 
-  // ASN breakdown — top 10 by total bytes
-  const asnRows = useMemo(() => {
-    const map = new Map<string, number>();
+  // Geo breakdown — top 10 countries by total bytes, with ASN org as subtitle
+  const geoRows = useMemo(() => {
+    const map = new Map<string, { bytes: number; asns: Set<string> }>();
     for (const f of flows) {
-      if (!f.asn) continue;
-      map.set(f.asn, (map.get(f.asn) ?? 0) + f.bytesTotal);
+      const key = f.country ?? f.asn ?? 'Unknown';
+      const entry = map.get(key) ?? { bytes: 0, asns: new Set() };
+      entry.bytes += f.bytesTotal;
+      if (f.asn) entry.asns.add(f.asn);
+      map.set(key, entry);
     }
-    const entries = [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
-    const max = entries[0]?.[1] ?? 1;
-    return entries.map(([asn, bytes]) => ({ asn, bytes, pct: bytes / max }));
+    const entries = [...map.entries()].sort((a, b) => b[1].bytes - a[1].bytes).slice(0, 10);
+    const max = entries[0]?.[1].bytes || 1;
+    return entries.map(([key, { bytes, asns }]) => ({
+      key,
+      bytes,
+      pct: bytes / max,
+      isCountry: /^[A-Z]{2}$/.test(key),
+      asn: [...asns].join(', '),
+    }));
   }, [flows]);
 
   return (
@@ -535,25 +544,27 @@ export function Flows() {
       </div>
 
       {/* ASN / Country breakdown */}
-      {asnRows.length > 0 && (
+      {geoRows.length > 0 && (
         <>
           <div
             className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
             style={{ color: '#6e6e73' }}
           >
-            Traffic by ASN / Country
+            Traffic by Country / ASN
           </div>
           <div
             className="liquid-glass-card rounded-xl p-4 space-y-2"
             style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
           >
-            {asnRows.map(({ asn, bytes, pct }) => {
-              const isCountry = /^[A-Z]{2}$/.test(asn);
-              const label = isCountry ? `${countryFlag(asn)} ${asn}` : asn;
+            {geoRows.map(({ key, bytes, pct, isCountry, asn }) => {
+              const label = isCountry ? `${countryFlag(key)} ${key}` : key;
               return (
-                <div key={asn} className="flex items-center gap-3">
-                  <div className="w-32 text-[13px] truncate flex-shrink-0" style={{ color: '#1d1d1f' }}>
-                    {label}
+                <div key={key} className="flex items-center gap-3">
+                  <div className="w-40 flex-shrink-0">
+                    <div className="text-[13px] truncate" style={{ color: '#1d1d1f' }}>{label}</div>
+                    {isCountry && asn && (
+                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>{asn}</div>
+                    )}
                   </div>
                   <div className="flex-1 h-2 rounded-full overflow-hidden" style={{ background: 'rgba(0,0,0,0.06)' }}>
                     <div

--- a/clash-lib/src/app/api/handlers/flows.rs
+++ b/clash-lib/src/app/api/handlers/flows.rs
@@ -69,7 +69,9 @@ pub struct FlowRecord {
     pub rule: String,
     pub rule_payload: String,
     pub chains: Vec<String>,
-    /// ISO 3166-1 alpha-2 country code or ASN org name from the mmdb lookup.
+    /// ISO 3166-1 alpha-2 country code from country mmdb.
+    pub country: Option<String>,
+    /// ASN org name from ASN mmdb.
     pub asn: Option<String>,
     pub last_seen: DateTime<Utc>,
 }
@@ -89,6 +91,20 @@ struct FlowKey {
 // Per-key accumulator
 // ---------------------------------------------------------------------------
 
+/// Data extracted from one connection tracker, passed into `Acc::apply`.
+struct ConnEntry {
+    src_ip: String,
+    upload: u64,
+    download: u64,
+    rule: String,
+    rule_payload: String,
+    chains: Vec<String>,
+    country: Option<String>,
+    asn: Option<String>,
+    start_time: DateTime<Utc>,
+    is_active: bool,
+}
+
 struct Acc {
     src_ips: Vec<String>,
     conn_count: usize,
@@ -99,48 +115,41 @@ struct Acc {
     rule: String,
     rule_payload: String,
     chains: Vec<String>,
+    country: Option<String>,
     asn: Option<String>,
     last_seen: DateTime<Utc>,
 }
 
 impl Acc {
-    fn merge(
-        &mut self,
-        src_ip: String,
-        upload: u64,
-        download: u64,
-        rule: &str,
-        rule_payload: &str,
-        chains: Vec<String>,
-        asn: Option<String>,
-        start_time: DateTime<Utc>,
-        is_active: bool,
-    ) {
-        if !src_ip.is_empty() && !self.src_ips.contains(&src_ip) {
-            self.src_ips.push(src_ip);
+    fn apply(&mut self, entry: ConnEntry) {
+        if !entry.src_ip.is_empty() && !self.src_ips.contains(&entry.src_ip) {
+            self.src_ips.push(entry.src_ip);
         }
         self.conn_count += 1;
-        if is_active {
+        if entry.is_active {
             self.active_count += 1;
         } else {
             self.closed_count += 1;
         }
-        self.upload_total += upload;
-        self.download_total += download;
-        if self.rule.is_empty() && !rule.is_empty() {
-            self.rule = rule.to_owned();
+        self.upload_total += entry.upload;
+        self.download_total += entry.download;
+        if self.rule.is_empty() && !entry.rule.is_empty() {
+            self.rule = entry.rule;
         }
-        if self.rule_payload.is_empty() && !rule_payload.is_empty() {
-            self.rule_payload = rule_payload.to_owned();
+        if self.rule_payload.is_empty() && !entry.rule_payload.is_empty() {
+            self.rule_payload = entry.rule_payload;
         }
-        if self.chains.is_empty() && !chains.is_empty() {
-            self.chains = chains;
+        if self.chains.is_empty() && !entry.chains.is_empty() {
+            self.chains = entry.chains;
         }
-        if self.asn.is_none() && asn.is_some() {
-            self.asn = asn;
+        if self.country.is_none() && entry.country.is_some() {
+            self.country = entry.country;
         }
-        if start_time > self.last_seen {
-            self.last_seen = start_time;
+        if self.asn.is_none() && entry.asn.is_some() {
+            self.asn = entry.asn;
+        }
+        if entry.start_time > self.last_seen {
+            self.last_seen = entry.start_time;
         }
     }
 }
@@ -168,10 +177,6 @@ async fn build_flow_records(
                 Network::Tcp => "tcp".to_string(),
                 Network::Udp => "udp".to_string(),
             };
-            let src_ip = info.session_holder.source.ip().to_string();
-            let upload = info.upload_total.load(Ordering::Relaxed);
-            let download = info.download_total.load(Ordering::Relaxed);
-            let asn = info.session_holder.asn.clone();
             let key = FlowKey {
                 dst_host,
                 dst_port,
@@ -187,20 +192,22 @@ async fn build_flow_records(
                 rule: String::new(),
                 rule_payload: String::new(),
                 chains: Vec::new(),
+                country: None,
                 asn: None,
                 last_seen: DateTime::<Utc>::MIN_UTC,
             });
-            acc.merge(
-                src_ip,
-                upload,
-                download,
-                &info.rule,
-                &info.rule_payload,
-                $chains,
-                asn,
-                info.start_time,
-                $is_active,
-            );
+            acc.apply(ConnEntry {
+                src_ip: info.session_holder.source.ip().to_string(),
+                upload: info.upload_total.load(Ordering::Relaxed),
+                download: info.download_total.load(Ordering::Relaxed),
+                rule: info.rule.clone(),
+                rule_payload: info.rule_payload.clone(),
+                chains: $chains,
+                country: info.session_holder.country.clone(),
+                asn: info.session_holder.asn.clone(),
+                start_time: info.start_time,
+                is_active: $is_active,
+            });
         }};
     }
 
@@ -240,6 +247,7 @@ async fn build_flow_records(
                 rule: acc.rule,
                 rule_payload: acc.rule_payload,
                 chains: acc.chains,
+                country: acc.country,
                 asn: acc.asn,
                 last_seen: acc.last_seen,
             }

--- a/clash-lib/src/app/api/handlers/flows.rs
+++ b/clash-lib/src/app/api/handlers/flows.rs
@@ -61,11 +61,16 @@ pub struct FlowRecord {
     pub protocol: String,
     pub src_ips: Vec<String>,
     pub conn_count: usize,
+    pub active_count: usize,
+    pub closed_count: usize,
     pub upload_total: u64,
     pub download_total: u64,
     pub bytes_total: u64,
     pub rule: String,
+    pub rule_payload: String,
     pub chains: Vec<String>,
+    /// ISO 3166-1 alpha-2 country code or ASN org name from the mmdb lookup.
+    pub asn: Option<String>,
     pub last_seen: DateTime<Utc>,
 }
 
@@ -87,10 +92,14 @@ struct FlowKey {
 struct Acc {
     src_ips: Vec<String>,
     conn_count: usize,
+    active_count: usize,
+    closed_count: usize,
     upload_total: u64,
     download_total: u64,
     rule: String,
+    rule_payload: String,
     chains: Vec<String>,
+    asn: Option<String>,
     last_seen: DateTime<Utc>,
 }
 
@@ -101,20 +110,34 @@ impl Acc {
         upload: u64,
         download: u64,
         rule: &str,
+        rule_payload: &str,
         chains: Vec<String>,
+        asn: Option<String>,
         start_time: DateTime<Utc>,
+        is_active: bool,
     ) {
         if !src_ip.is_empty() && !self.src_ips.contains(&src_ip) {
             self.src_ips.push(src_ip);
         }
         self.conn_count += 1;
+        if is_active {
+            self.active_count += 1;
+        } else {
+            self.closed_count += 1;
+        }
         self.upload_total += upload;
         self.download_total += download;
         if self.rule.is_empty() && !rule.is_empty() {
             self.rule = rule.to_owned();
         }
+        if self.rule_payload.is_empty() && !rule_payload.is_empty() {
+            self.rule_payload = rule_payload.to_owned();
+        }
         if self.chains.is_empty() && !chains.is_empty() {
             self.chains = chains;
+        }
+        if self.asn.is_none() && asn.is_some() {
+            self.asn = asn;
         }
         if start_time > self.last_seen {
             self.last_seen = start_time;
@@ -137,7 +160,7 @@ async fn build_flow_records(
 
     // Helper to insert/merge one TrackerInfo into the map.
     macro_rules! merge_info {
-        ($info:expr, $chains:expr) => {{
+        ($info:expr, $chains:expr, $is_active:expr) => {{
             let info = $info;
             let dst_host = info.session_holder.destination.host();
             let dst_port = info.session_holder.destination.port();
@@ -148,6 +171,7 @@ async fn build_flow_records(
             let src_ip = info.session_holder.source.ip().to_string();
             let upload = info.upload_total.load(Ordering::Relaxed);
             let download = info.download_total.load(Ordering::Relaxed);
+            let asn = info.session_holder.asn.clone();
             let key = FlowKey {
                 dst_host,
                 dst_port,
@@ -156,10 +180,14 @@ async fn build_flow_records(
             let acc = map.entry(key).or_insert_with(|| Acc {
                 src_ips: Vec::new(),
                 conn_count: 0,
+                active_count: 0,
+                closed_count: 0,
                 upload_total: 0,
                 download_total: 0,
                 rule: String::new(),
+                rule_payload: String::new(),
                 chains: Vec::new(),
+                asn: None,
                 last_seen: DateTime::<Utc>::MIN_UTC,
             });
             acc.merge(
@@ -167,8 +195,11 @@ async fn build_flow_records(
                 upload,
                 download,
                 &info.rule,
+                &info.rule_payload,
                 $chains,
+                asn,
                 info.start_time,
+                $is_active,
             );
         }};
     }
@@ -178,7 +209,7 @@ async fn build_flow_records(
     let active = mgr.active_connections_snapshot().await;
     for info in &active {
         let chains = info.proxy_chain_holder.snapshot().await;
-        merge_info!(info, chains);
+        merge_info!(info, chains, true);
     }
 
     // Closed connections (ring buffer).
@@ -186,7 +217,7 @@ async fn build_flow_records(
         let closed = mgr.closed_flows_snapshot().await;
         for info in &closed {
             let chains = info.proxy_chain_holder.snapshot().await;
-            merge_info!(info, chains);
+            merge_info!(info, chains, false);
         }
     }
 
@@ -201,11 +232,15 @@ async fn build_flow_records(
                 protocol: key.protocol,
                 src_ips: acc.src_ips,
                 conn_count: acc.conn_count,
+                active_count: acc.active_count,
+                closed_count: acc.closed_count,
                 upload_total: acc.upload_total,
                 download_total: acc.download_total,
                 bytes_total,
                 rule: acc.rule,
+                rule_payload: acc.rule_payload,
                 chains: acc.chains,
+                asn: acc.asn,
                 last_seen: acc.last_seen,
             }
         })

--- a/clash-lib/src/app/router/mod.rs
+++ b/clash-lib/src/app/router/mod.rs
@@ -131,11 +131,12 @@ impl Router {
         (MATCH, None)
     }
 
-    /// Look up country code and ASN org name for an IP address independently.
-    /// Uses `country_mmdb` for the ISO 3166-1 alpha-2 country code (falling
-    /// back to `asn_mmdb.lookup_country()` if no dedicated country DB is
-    /// configured) and `asn_mmdb.lookup_asn()` for the org name. Skips
-    /// lookups for fields already populated.
+    /// Look up country code and ASN for an IP address.
+    /// Uses `country_mmdb` for the ISO 3166-1 alpha-2 country code.
+    /// For ASN, preserves the original strategy: try
+    /// `asn_mmdb.lookup_country()` first (simplified/fast path, e.g.
+    /// Country.mmdb), fall back to `asn_mmdb.lookup_asn()` for the org
+    /// name.
     fn populate_geo_for_ip(
         ip: std::net::IpAddr,
         country_mmdb: &Option<MmdbLookup>,
@@ -147,39 +148,30 @@ impl Router {
             return;
         }
 
-        if sess.country.is_none() {
-            // try dedicated country mmdb first
-            let country = country_mmdb.as_ref().and_then(|db| {
-                db.lookup_country(ip)
-                    .map_err(|e| {
-                        trace!("failed to lookup country for {}: {}", ip, e)
-                    })
-                    .ok()
-                    .map(|c| c.country_code)
-            });
-            // fall back to simplified lookup on asn_mmdb (e.g. Country.mmdb)
-            let country = country.or_else(|| {
-                asn_mmdb.as_ref().and_then(|db| {
-                    db.lookup_country(ip)
-                        .map_err(|e| {
-                            trace!(
-                                "failed to lookup country from asn_mmdb for {}: {}",
-                                ip, e
-                            )
-                        })
-                        .ok()
-                        .map(|c| c.country_code)
-                })
-            });
-            if let Some(code) = country {
-                trace!("country for {} is {:?}", ip, code);
-                sess.country = Some(code);
+        if sess.country.is_none()
+            && let Some(country_mmdb) = country_mmdb
+        {
+            match country_mmdb.lookup_country(ip) {
+                Ok(country) => {
+                    trace!("country for {} is {:?}", ip, country.country_code);
+                    sess.country = Some(country.country_code);
+                }
+                Err(e) => {
+                    trace!("failed to lookup country for {}: {}", ip, e);
+                }
             }
         }
 
         if sess.asn.is_none()
             && let Some(asn_mmdb) = asn_mmdb
         {
+            // try simplified mmdb first (e.g. Country.mmdb doubles as a fast
+            // country-code lookup on the asn_mmdb slot)
+            if let Ok(country) = asn_mmdb.lookup_country(ip) {
+                sess.asn = Some(country.country_code);
+                return;
+            }
+            // fall back to full ASN lookup
             match asn_mmdb.lookup_asn(ip) {
                 Ok(asn) => {
                     trace!("asn for {} is {:?}", ip, asn);

--- a/clash-lib/src/app/router/mod.rs
+++ b/clash-lib/src/app/router/mod.rs
@@ -132,9 +132,10 @@ impl Router {
     }
 
     /// Look up country code and ASN org name for an IP address independently.
-    /// Uses `country_mmdb` for the ISO 3166-1 alpha-2 country code and
-    /// `asn_mmdb` for the ASN org name. Skips the lookup if both fields are
-    /// already populated.
+    /// Uses `country_mmdb` for the ISO 3166-1 alpha-2 country code (falling
+    /// back to `asn_mmdb.lookup_country()` if no dedicated country DB is
+    /// configured) and `asn_mmdb.lookup_asn()` for the org name. Skips
+    /// lookups for fields already populated.
     fn populate_geo_for_ip(
         ip: std::net::IpAddr,
         country_mmdb: &Option<MmdbLookup>,
@@ -146,17 +147,33 @@ impl Router {
             return;
         }
 
-        if sess.country.is_none()
-            && let Some(country_mmdb) = country_mmdb
-        {
-            match country_mmdb.lookup_country(ip) {
-                Ok(country) => {
-                    trace!("country for {} is {:?}", ip, country.country_code);
-                    sess.country = Some(country.country_code);
-                }
-                Err(e) => {
-                    trace!("failed to lookup country for {}: {}", ip, e);
-                }
+        if sess.country.is_none() {
+            // try dedicated country mmdb first
+            let country = country_mmdb.as_ref().and_then(|db| {
+                db.lookup_country(ip)
+                    .map_err(|e| {
+                        trace!("failed to lookup country for {}: {}", ip, e)
+                    })
+                    .ok()
+                    .map(|c| c.country_code)
+            });
+            // fall back to simplified lookup on asn_mmdb (e.g. Country.mmdb)
+            let country = country.or_else(|| {
+                asn_mmdb.as_ref().and_then(|db| {
+                    db.lookup_country(ip)
+                        .map_err(|e| {
+                            trace!(
+                                "failed to lookup country from asn_mmdb for {}: {}",
+                                ip, e
+                            )
+                        })
+                        .ok()
+                        .map(|c| c.country_code)
+                })
+            });
+            if let Some(code) = country {
+                trace!("country for {} is {:?}", ip, code);
+                sess.country = Some(code);
             }
         }
 

--- a/clash-lib/src/app/router/mod.rs
+++ b/clash-lib/src/app/router/mod.rs
@@ -31,6 +31,7 @@ pub struct Router {
     rules: Vec<Box<dyn RuleMatcher>>,
     dns_resolver: ThreadSafeDNSResolver,
 
+    country_mmdb: Option<MmdbLookup>,
     asn_mmdb: Option<MmdbLookup>,
 }
 
@@ -80,6 +81,7 @@ impl Router {
                 .collect(),
             dns_resolver,
 
+            country_mmdb,
             asn_mmdb,
         }
     }
@@ -105,9 +107,14 @@ impl Router {
                 sess_resolved = true;
             }
 
-            // Lookup ASN with guard clause
+            // Lookup geo information with guard clause
             if let Some(ip) = sess.resolved_ip.or(sess.destination.ip()) {
-                Self::populate_asn_for_ip(ip, &self.asn_mmdb, sess);
+                Self::populate_geo_for_ip(
+                    ip,
+                    &self.country_mmdb,
+                    &self.asn_mmdb,
+                    sess,
+                );
             }
 
             if r.apply(sess) {
@@ -124,36 +131,46 @@ impl Router {
         (MATCH, None)
     }
 
-    /// Look up ASN for an IP address. Uses the simplified mmdb lookup first,
-    /// falling back to the full ASN lookup if the simplified one fails.
-    fn populate_asn_for_ip(
+    /// Look up country code and ASN org name for an IP address independently.
+    /// Uses `country_mmdb` for the ISO 3166-1 alpha-2 country code and
+    /// `asn_mmdb` for the ASN org name. Skips the lookup if both fields are
+    /// already populated.
+    fn populate_geo_for_ip(
         ip: std::net::IpAddr,
+        country_mmdb: &Option<MmdbLookup>,
         asn_mmdb: &Option<MmdbLookup>,
         sess: &mut Session,
     ) {
-        // Preserve existing ASN metadata — avoids overriding prior enrichment
-        if sess.asn.is_some() {
+        // Preserve existing geo metadata — avoids overriding prior enrichment
+        if sess.country.is_some() && sess.asn.is_some() {
             return;
         }
 
-        let Some(asn_mmdb) = asn_mmdb else {
-            return;
-        };
-
-        // try simplified mmdb first
-        if let Ok(country) = asn_mmdb.lookup_country(ip) {
-            sess.asn = Some(country.country_code);
-            return;
-        }
-
-        // fall back to full ASN lookup
-        match asn_mmdb.lookup_asn(ip) {
-            Ok(asn) => {
-                trace!("asn for {} is {:?}", ip, asn);
-                sess.asn = Some(asn.asn_name);
+        if sess.country.is_none()
+            && let Some(country_mmdb) = country_mmdb
+        {
+            match country_mmdb.lookup_country(ip) {
+                Ok(country) => {
+                    trace!("country for {} is {:?}", ip, country.country_code);
+                    sess.country = Some(country.country_code);
+                }
+                Err(e) => {
+                    trace!("failed to lookup country for {}: {}", ip, e);
+                }
             }
-            Err(e) => {
-                trace!("failed to lookup ASN for {}: {}", ip, e);
+        }
+
+        if sess.asn.is_none()
+            && let Some(asn_mmdb) = asn_mmdb
+        {
+            match asn_mmdb.lookup_asn(ip) {
+                Ok(asn) => {
+                    trace!("asn for {} is {:?}", ip, asn);
+                    sess.asn = Some(asn.asn_name);
+                }
+                Err(e) => {
+                    trace!("failed to lookup ASN for {}: {}", ip, e);
+                }
             }
         }
     }

--- a/clash-lib/src/session.rs
+++ b/clash-lib/src/session.rs
@@ -414,7 +414,9 @@ pub struct Session {
     pub so_mark: Option<u32>,
     /// The bind interface
     pub iface: Option<OutboundInterface>,
-    /// The ASN of the destination IP address. Only for display.
+    /// ISO 3166-1 alpha-2 country code from country mmdb. Only for display.
+    pub country: Option<String>,
+    /// ASN org name from ASN mmdb. Only for display.
     pub asn: Option<String>,
     /// Traffic statistics for intelligent proxy selection
     pub traffic_stats: Option<crate::app::remote_content_manager::TrafficStats>,
@@ -448,6 +450,7 @@ impl Session {
         );
         rv.insert("host".to_string(), Box::new(self.destination.host()) as _);
         rv.insert("asn".to_string(), Box::new(self.asn.clone()) as _);
+        rv.insert("country".to_string(), Box::new(self.country.clone()) as _);
         rv.insert(
             "traffic_stats".to_string(),
             Box::new(self.traffic_stats.clone()) as _,
@@ -469,6 +472,7 @@ impl Default for Session {
             resolved_ip: None,
             so_mark: None,
             iface: None,
+            country: None,
             asn: None,
             traffic_stats: None,
             inbound_user: None,
@@ -501,6 +505,7 @@ impl Debug for Session {
             .field("destination", &self.destination)
             .field("packet_mark", &self.so_mark)
             .field("iface", &self.iface)
+            .field("country", &self.country)
             .field("asn", &self.asn)
             .finish()
     }
@@ -516,6 +521,7 @@ impl Clone for Session {
             resolved_ip: self.resolved_ip,
             so_mark: self.so_mark,
             iface: self.iface.as_ref().cloned(),
+            country: self.country.clone(),
             asn: self.asn.clone(),
             traffic_stats: self.traffic_stats.clone(),
             inbound_user: self.inbound_user.clone(),


### PR DESCRIPTION
## Changes

### Dashboard
- Search/filter by destination host
- Protocol filter pills (TCP / UDP)
- Include-closed flows toggle
- `lastSeen` relative-time column
- Rule payload shown below rule name
- Source IPs shown on hover
- Active/closed badge on connection count
- ASN / Country traffic breakdown bar chart
- Fix: add `top=50` to WS URL (backend was defaulting to 20)
- Fix: guard `max=0` in bar chart to prevent NaN bar widths

### Backend (`clash-lib`)
- Add `rulePayload`, `asn`, `country`, `activeCount`, `closedCount` to `FlowRecord` in `flows.rs`
- Store `country_mmdb` on `Router` struct for independent country lookup
- Populate `sess.country` (ISO 2-letter code) and `sess.asn` (org name) independently in `populate_asn_for_ip`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to include/exclude closed flows (default: include)
  * Flows page: destination text search, protocol pills, clickable sortable headers, and top-50 sorted table
  * New columns/cells: Last Seen (relative), Conns (activity dot + counts), destination summary with tooltip, richer rule payload display
  * Sankey still built from full flows; Traffic by Country/ASN view with percentage bars and flags
  * Per-flow metrics enriched with active/closed counts and country/ASN info
<!-- end of auto-generated comment: release notes by coderabbit.ai -->