### PR TITLE
feat(dashboard): new proxies page and nav restructure

### DIFF
--- a/clash-dashboard/src/App.tsx
+++ b/clash-dashboard/src/App.tsx
@@ -2,7 +2,7 @@ import { HashRouter as BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Layout } from './components/Layout';
 import { Overview } from './pages/Overview';
-import { Providers } from './pages/Providers';
+import { ProxyList } from './pages/ProxyList';
 import { Connections } from './pages/Connections';
 import { Flows } from './pages/Flows';
 import { Rules } from './pages/Rules';
@@ -26,7 +26,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Layout />}>
             <Route index element={<Overview />} />
-            <Route path="providers" element={<Providers />} />
+            <Route path="proxies" element={<ProxyList />} />
             <Route path="connections" element={<Connections />} />
             <Route path="flows" element={<Flows />} />
             <Route path="rules" element={<Rules />} />

--- a/clash-dashboard/src/App.tsx
+++ b/clash-dashboard/src/App.tsx
@@ -27,6 +27,7 @@ export default function App() {
           <Route path="/" element={<Layout />}>
             <Route index element={<Overview />} />
             <Route path="proxies" element={<ProxyList />} />
+            <Route path="providers" element={<ProxyList />} />
             <Route path="connections" element={<Connections />} />
             <Route path="flows" element={<Flows />} />
             <Route path="rules" element={<Rules />} />

--- a/clash-dashboard/src/components/Layout.tsx
+++ b/clash-dashboard/src/components/Layout.tsx
@@ -3,18 +3,18 @@ import { useQuery } from '@tanstack/react-query';
 import { getVersion } from '../lib/api';
 import {
   LayoutDashboard, Activity, Filter, Terminal,
-  Server, SlidersHorizontal, Package, GitBranch,
+  Server, SlidersHorizontal, GitBranch, Shield,
 } from 'lucide-react';
 import logoUrl from '../assets/logo.png';
 
 const navItems = [
   { to: '/', label: 'Overview', icon: LayoutDashboard, end: true },
-  { to: '/providers', label: 'Providers', icon: Package },
-  { to: '/connections', label: 'Connections', icon: Activity },
   { to: '/flows', label: 'Flows', icon: GitBranch },
+  { to: '/connections', label: 'Connections', icon: Activity },
+  { to: '/proxies', label: 'Proxies', icon: Shield },
   { to: '/rules', label: 'Rules', icon: Filter },
-  { to: '/logs', label: 'Logs', icon: Terminal },
   { to: '/dns', label: 'DNS', icon: Server },
+  { to: '/logs', label: 'Logs', icon: Terminal },
   { to: '/settings', label: 'Settings', icon: SlidersHorizontal },
 ];
 

--- a/clash-dashboard/src/components/ProxyGroups.tsx
+++ b/clash-dashboard/src/components/ProxyGroups.tsx
@@ -68,8 +68,8 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
     },
     onError: (_err, _vars, ctx) => {
       if (ctx?.previous) queryClient.setQueryData(['proxies'], ctx.previous);
+      queryClient.invalidateQueries({ queryKey: ['proxies'] });
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['proxies'] }),
   });
 
   const proxies = data?.proxies ?? {};

--- a/clash-dashboard/src/lib/api.ts
+++ b/clash-dashboard/src/lib/api.ts
@@ -217,6 +217,10 @@ export const updateProxyProvider = (name: string) =>
   request<void>(`/providers/proxies/${encodeURIComponent(name)}`, { method: 'PUT' });
 export const healthcheckProvider = (name: string) =>
   request<void>(`/providers/proxies/${encodeURIComponent(name)}/healthcheck`);
+export const getProviderProxyDelay = (providerName: string, proxyName: string, url: string, timeout: number) =>
+  request<{ delay: number }>(
+    `/providers/proxies/${encodeURIComponent(providerName)}/proxies/${encodeURIComponent(proxyName)}/delay?url=${encodeURIComponent(url)}&timeout=${timeout}`
+  );
 
 // Rule Providers
 export interface RuleProvider {

--- a/clash-dashboard/src/pages/Proxies.tsx
+++ b/clash-dashboard/src/pages/Proxies.tsx
@@ -88,8 +88,8 @@ export function Proxies() {
     },
     onError: (_err, _vars, ctx) => {
       if (ctx?.previous) queryClient.setQueryData(['proxies'], ctx.previous);
+      queryClient.invalidateQueries({ queryKey: ['proxies'] });
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['proxies'] }),
   });
 
   const proxies = data?.proxies ?? {};

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -79,6 +79,7 @@ function ProxyCard({ proxy, latency, onTest, testing }: ProxyCardProps) {
         onClick={onTest}
         disabled={testing}
         title="Test latency"
+        aria-label={`Test latency for ${proxy.name}`}
         className="flex-shrink-0 p-1.5 rounded-full disabled:opacity-40 transition-colors"
         style={{ background: 'rgba(52,199,89,0.1)', color: '#34c759' }}
       >
@@ -231,9 +232,13 @@ export function ProxyList() {
   async function testAllInProvider(provider: ProxyProvider) {
     setTestingProviders((s) => new Set(s).add(provider.name));
     try {
-      await Promise.allSettled(
-        (provider.proxies ?? []).map((proxy) => testProviderProxy(provider.name, proxy))
-      );
+      const proxies = provider.proxies ?? [];
+      const BATCH = 5;
+      for (let i = 0; i < proxies.length; i += BATCH) {
+        await Promise.allSettled(
+          proxies.slice(i, i + BATCH).map((proxy) => testProviderProxy(provider.name, proxy))
+        );
+      }
       await queryClient.invalidateQueries({ queryKey: ['providers'] });
     } finally {
       setTestingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
@@ -294,6 +299,7 @@ export function ProxyList() {
                     key={proxy.name}
                     proxy={proxy}
                     latency={latencyMap[`static::${proxy.name}`]}
+                    testing={testingProxies.has(`static::${proxy.name}`)}
                     onTest={() => testStaticProxy(proxy)}
                   />
                 ))}

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -1,0 +1,338 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getProxies, getProxyProviders, getProxyDelay, getProviderProxyDelay,
+  healthcheckProvider, updateProxyProvider,
+} from '../lib/api';
+import { Activity, RefreshCw } from 'lucide-react';
+import type { Proxy, ProxyProvider } from '../lib/api';
+
+const TEST_URL = 'http://www.gstatic.com/generate_204';
+const TEST_TIMEOUT = 5000;
+
+const GROUP_TYPES = ['Selector', 'URLTest', 'Fallback', 'LoadBalance', 'Relay'];
+
+function getLastDelay(history: Proxy['history']): number | undefined {
+  if (!history || history.length === 0) return undefined;
+  return history[history.length - 1]?.delay;
+}
+
+function getLatencyColor(delay: number | undefined): string {
+  if (!delay || delay === 0) return '#8e8e93';
+  if (delay < 200) return '#34c759';
+  if (delay < 500) return '#ff9500';
+  return '#ff3b30';
+}
+
+function getProxyTypeBadgeStyle(type: string): { background: string; color: string } {
+  const t = type.toLowerCase();
+  if (t === 'ss' || t === 'shadowsocks') return { background: 'rgba(175,82,222,0.1)', color: '#af52de' };
+  if (t === 'vmess') return { background: 'rgba(0,113,227,0.1)', color: '#0071e3' };
+  if (t === 'vless') return { background: 'rgba(50,173,230,0.1)', color: '#32ade6' };
+  if (t === 'trojan') return { background: 'rgba(255,149,0,0.1)', color: '#ff9500' };
+  if (t === 'socks5') return { background: 'rgba(52,199,89,0.1)', color: '#34c759' };
+  if (t === 'http') return { background: 'rgba(255,69,58,0.1)', color: '#ff453a' };
+  if (t === 'direct') return { background: 'rgba(52,199,89,0.1)', color: '#34c759' };
+  if (t === 'reject') return { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' };
+  if (t === 'dns') return { background: 'rgba(100,100,100,0.1)', color: '#636366' };
+  if (t === 'wireguard') return { background: 'rgba(88,86,214,0.1)', color: '#5856d6' };
+  if (t === 'hysteria' || t === 'hysteria2') return { background: 'rgba(255,149,0,0.12)', color: '#ff9500' };
+  if (t === 'tuic') return { background: 'rgba(0,149,255,0.1)', color: '#0095ff' };
+  return { background: 'rgba(0,0,0,0.06)', color: '#6e6e73' };
+}
+
+interface ProxyCardProps {
+  proxy: Proxy;
+  latency?: number;
+  onTest: () => void;
+  testing?: boolean;
+}
+
+function ProxyCard({ proxy, latency, onTest, testing }: ProxyCardProps) {
+  const delay = latency ?? getLastDelay(proxy.history);
+  const latencyColor = getLatencyColor(delay);
+  const typeStyle = getProxyTypeBadgeStyle(proxy.type);
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-3 rounded-xl border"
+      style={{ background: 'rgba(255,255,255,0.6)', borderColor: 'rgba(0,0,0,0.06)' }}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="text-[13px] font-medium truncate" style={{ color: '#1d1d1f' }}>
+          {proxy.name}
+        </div>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          <span
+            className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
+            style={typeStyle}
+          >
+            {proxy.type}
+          </span>
+          <div className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: latencyColor }} />
+          <span className="text-[11px] font-mono" style={{ color: latencyColor }}>
+            {delay === undefined ? '—' : delay === 0 ? 'Timeout' : `${delay}ms`}
+          </span>
+        </div>
+      </div>
+      <button
+        onClick={onTest}
+        disabled={testing}
+        title="Test latency"
+        className="flex-shrink-0 p-1.5 rounded-full disabled:opacity-40 transition-colors"
+        style={{ background: 'rgba(52,199,89,0.1)', color: '#34c759' }}
+      >
+        <Activity size={12} className={testing ? 'animate-pulse' : ''} />
+      </button>
+    </div>
+  );
+}
+
+interface ProviderSectionProps {
+  provider: ProxyProvider;
+  latencyMap: Record<string, number>;
+  testingProxies: Set<string>;
+  testingProviders: Set<string>;
+  updatingProviders: Set<string>;
+  onTestProxy: (providerName: string, proxy: Proxy) => void;
+  onTestAll: (provider: ProxyProvider) => void;
+  onUpdate: (provider: ProxyProvider) => void;
+}
+
+function ProviderSection({
+  provider, latencyMap, testingProxies, testingProviders, updatingProviders,
+  onTestProxy, onTestAll, onUpdate,
+}: ProviderSectionProps) {
+  const isTesting = testingProviders.has(provider.name);
+  const isUpdating = updatingProviders.has(provider.name);
+  const proxies = provider.proxies ?? [];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>{provider.name}</h2>
+          <span
+            className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+            style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}
+          >
+            {provider.vehicleType}
+          </span>
+          <span className="text-[11px]" style={{ color: '#8e8e93' }}>
+            {proxies.length} {proxies.length === 1 ? 'proxy' : 'proxies'}
+          </span>
+          {provider.updatedAt && (
+            <span className="text-[11px] hidden sm:inline" style={{ color: '#8e8e93' }}>
+              · Updated {new Date(provider.updatedAt).toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onTestAll(provider)}
+            disabled={isTesting}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium disabled:opacity-50 transition-colors"
+            style={{ background: 'rgba(52,199,89,0.1)', color: '#34c759' }}
+          >
+            <Activity size={12} className={isTesting ? 'animate-pulse' : ''} />
+            {isTesting ? 'Testing…' : 'Test All'}
+          </button>
+          <button
+            onClick={() => onUpdate(provider)}
+            disabled={isUpdating}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium disabled:opacity-50 transition-colors"
+            style={{ background: 'rgba(0,113,227,0.1)', color: '#0071e3' }}
+          >
+            <RefreshCw size={12} className={isUpdating ? 'animate-spin' : ''} />
+            {isUpdating ? 'Updating…' : 'Update'}
+          </button>
+        </div>
+      </div>
+
+      {proxies.length === 0 ? (
+        <div className="text-[13px] italic" style={{ color: '#8e8e93' }}>No proxies in this provider.</div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+          {proxies.map((proxy) => (
+            <ProxyCard
+              key={proxy.name}
+              proxy={proxy}
+              latency={latencyMap[proxy.name]}
+              testing={testingProxies.has(`${provider.name}::${proxy.name}`)}
+              onTest={() => onTestProxy(provider.name, proxy)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ProxyList() {
+  const queryClient = useQueryClient();
+  const [latencyMap, setLatencyMap] = useState<Record<string, number>>({});
+  const [testingProxies, setTestingProxies] = useState<Set<string>>(new Set());
+  const [testingProviders, setTestingProviders] = useState<Set<string>>(new Set());
+  const [updatingProviders, setUpdatingProviders] = useState<Set<string>>(new Set());
+
+  const { data: proxiesData, isLoading: proxiesLoading } = useQuery({
+    queryKey: ['proxies'],
+    queryFn: getProxies,
+    refetchInterval: 30000,
+  });
+
+  const { data: providersData, isLoading: providersLoading } = useQuery({
+    queryKey: ['providers'],
+    queryFn: getProxyProviders,
+    refetchInterval: 60000,
+  });
+
+  const allProxies = proxiesData?.proxies ?? {};
+  const staticProxies = Object.values(allProxies).filter(
+    (p) => !GROUP_TYPES.includes(p.type)
+  );
+
+  const providers = Object.values(providersData?.providers ?? {})
+    .filter((p) => p.name !== 'default' && p.vehicleType !== 'Compatible')
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Provider proxy names to exclude from static list (avoid duplicates)
+  const providerProxyNames = new Set<string>(
+    providers.flatMap((p) => (p.proxies ?? []).map((px) => px.name))
+  );
+  const configProxies = staticProxies.filter((p) => !providerProxyNames.has(p.name));
+
+  async function testStaticProxy(proxy: Proxy) {
+    const key = `static::${proxy.name}`;
+    setTestingProxies((s) => new Set(s).add(key));
+    try {
+      const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
+      setLatencyMap((prev) => ({ ...prev, [proxy.name]: res.delay }));
+    } catch {
+      setLatencyMap((prev) => ({ ...prev, [proxy.name]: 0 }));
+    } finally {
+      setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
+    }
+  }
+
+  async function testProviderProxy(providerName: string, proxy: Proxy) {
+    const key = `${providerName}::${proxy.name}`;
+    setTestingProxies((s) => new Set(s).add(key));
+    try {
+      const res = await getProviderProxyDelay(providerName, proxy.name, TEST_URL, TEST_TIMEOUT);
+      setLatencyMap((prev) => ({ ...prev, [proxy.name]: res.delay }));
+    } catch {
+      setLatencyMap((prev) => ({ ...prev, [proxy.name]: 0 }));
+    } finally {
+      setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
+    }
+  }
+
+  async function testAllInProvider(provider: ProxyProvider) {
+    setTestingProviders((s) => new Set(s).add(provider.name));
+    try {
+      await Promise.allSettled(
+        (provider.proxies ?? []).map((proxy) => testProviderProxy(provider.name, proxy))
+      );
+      await healthcheckProvider(provider.name);
+      await queryClient.invalidateQueries({ queryKey: ['providers'] });
+    } finally {
+      setTestingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
+    }
+  }
+
+  async function updateProvider(provider: ProxyProvider) {
+    setUpdatingProviders((s) => new Set(s).add(provider.name));
+    try {
+      await updateProxyProvider(provider.name);
+      await queryClient.invalidateQueries({ queryKey: ['providers'] });
+    } finally {
+      setUpdatingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
+    }
+  }
+
+  const isLoading = proxiesLoading || providersLoading;
+
+  return (
+    <div className="p-6 space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Proxies</h1>
+        <span className="text-[13px]" style={{ color: '#8e8e93' }}>
+          {configProxies.length} static · {providers.length} provider{providers.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading proxies…</div>
+      ) : (
+        <>
+          {/* Config Proxies */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Config Proxies</h2>
+              <span className="text-[11px]" style={{ color: '#8e8e93' }}>
+                {configProxies.length} {configProxies.length === 1 ? 'proxy' : 'proxies'}
+              </span>
+            </div>
+
+            {configProxies.length === 0 ? (
+              <div
+                className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center"
+              >
+                <div className="text-3xl">🔌</div>
+                <div className="text-[15px] font-semibold" style={{ color: '#1d1d1f' }}>No Static Proxies</div>
+                <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+                  Define proxies directly in your config file.
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+                {configProxies.map((proxy) => (
+                  <ProxyCard
+                    key={proxy.name}
+                    proxy={proxy}
+                    latency={latencyMap[proxy.name]}
+                    testing={testingProxies.has(`static::${proxy.name}`)}
+                    onTest={() => testStaticProxy(proxy)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Provider sections */}
+          {providers.length === 0 ? (
+            <div
+              className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center"
+            >
+              <div className="text-3xl">📦</div>
+              <div className="text-[15px] font-semibold" style={{ color: '#1d1d1f' }}>No Proxy Providers</div>
+              <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+                Add proxy providers to your config to see them here.
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="w-full h-px" style={{ background: 'rgba(0,0,0,0.06)' }} />
+              <div className="space-y-8">
+                {providers.map((provider) => (
+                  <ProviderSection
+                    key={provider.name}
+                    provider={provider}
+                    latencyMap={latencyMap}
+                    testingProxies={testingProxies}
+                    testingProviders={testingProviders}
+                    updatingProviders={updatingProviders}
+                    onTestProxy={testProviderProxy}
+                    onTestAll={testAllInProvider}
+                    onUpdate={updateProvider}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   getProxies, getProxyProviders, getProxyDelay, getProviderProxyDelay,
-  healthcheckProvider, updateProxyProvider,
+  updateProxyProvider,
 } from '../lib/api';
 import { Activity, RefreshCw } from 'lucide-react';
 import type { Proxy, ProxyProvider } from '../lib/api';
@@ -157,7 +157,7 @@ function ProviderSection({
             <ProxyCard
               key={proxy.name}
               proxy={proxy}
-              latency={latencyMap[proxy.name]}
+              latency={latencyMap[`${provider.name}::${proxy.name}`]}
               testing={testingProxies.has(`${provider.name}::${proxy.name}`)}
               onTest={() => onTestProxy(provider.name, proxy)}
             />
@@ -207,9 +207,9 @@ export function ProxyList() {
     setTestingProxies((s) => new Set(s).add(key));
     try {
       const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
-      setLatencyMap((prev) => ({ ...prev, [proxy.name]: res.delay }));
+      setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
     } catch {
-      setLatencyMap((prev) => ({ ...prev, [proxy.name]: 0 }));
+      setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
     } finally {
       setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
     }
@@ -234,7 +234,6 @@ export function ProxyList() {
       await Promise.allSettled(
         (provider.proxies ?? []).map((proxy) => testProviderProxy(provider.name, proxy))
       );
-      await healthcheckProvider(provider.name);
       await queryClient.invalidateQueries({ queryKey: ['providers'] });
     } finally {
       setTestingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
@@ -291,8 +290,7 @@ export function ProxyList() {
                   <ProxyCard
                     key={proxy.name}
                     proxy={proxy}
-                    latency={latencyMap[proxy.name]}
-                    testing={testingProxies.has(`static::${proxy.name}`)}
+                    latency={latencyMap[`static::${proxy.name}`]}
                     onTest={() => testStaticProxy(proxy)}
                   />
                 ))}

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -175,13 +175,13 @@ export function ProxyList() {
   const [testingProviders, setTestingProviders] = useState<Set<string>>(new Set());
   const [updatingProviders, setUpdatingProviders] = useState<Set<string>>(new Set());
 
-  const { data: proxiesData, isLoading: proxiesLoading } = useQuery({
+  const { data: proxiesData, isLoading: proxiesLoading, isError: proxiesError } = useQuery({
     queryKey: ['proxies'],
     queryFn: getProxies,
     refetchInterval: 30000,
   });
 
-  const { data: providersData, isLoading: providersLoading } = useQuery({
+  const { data: providersData, isLoading: providersLoading, isError: providersError } = useQuery({
     queryKey: ['providers'],
     queryFn: getProxyProviders,
     refetchInterval: 60000,
@@ -220,9 +220,9 @@ export function ProxyList() {
     setTestingProxies((s) => new Set(s).add(key));
     try {
       const res = await getProviderProxyDelay(providerName, proxy.name, TEST_URL, TEST_TIMEOUT);
-      setLatencyMap((prev) => ({ ...prev, [proxy.name]: res.delay }));
+      setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
     } catch {
-      setLatencyMap((prev) => ({ ...prev, [proxy.name]: 0 }));
+      setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
     } finally {
       setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
     }
@@ -251,6 +251,7 @@ export function ProxyList() {
   }
 
   const isLoading = proxiesLoading || providersLoading;
+  const isError = proxiesError || providersError;
 
   return (
     <div className="p-6 space-y-8">
@@ -263,6 +264,8 @@ export function ProxyList() {
 
       {isLoading ? (
         <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading proxies…</div>
+      ) : isError ? (
+        <div className="text-[15px]" style={{ color: '#ff3b30' }}>Failed to load proxies. Check your API connection.</div>
       ) : (
         <>
           {/* Config Proxies */}

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -29,6 +29,108 @@ function getRuleTypeBadgeStyle(type: string): { background: string; color: strin
   }
 }
 
+function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: string }) {
+  const [matchInput, setMatchInput] = useState('');
+  const [matchTarget, setMatchTarget] = useState<string | null>(null);
+
+  const { data: rulesData, isLoading: rulesLoading, isError: rulesError } = useQuery({
+    queryKey: ['rule-provider-rules', name],
+    queryFn: () => getRuleProviderRules(name),
+  });
+
+  const { data: matchData, isLoading: matchLoading, isError: matchError } = useQuery({
+    queryKey: ['rule-provider-match', name, matchTarget],
+    queryFn: () => matchRuleProvider(name, matchTarget!),
+    enabled: matchTarget !== null && matchTarget.trim().length > 0,
+  });
+
+  const providerRules = rulesData?.rules ?? [];
+  const behaviorLower = behavior?.toLowerCase();
+  const canShowRules = behaviorLower === 'classical';
+
+  function handleMatchSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (matchInput.trim()) setMatchTarget(matchInput.trim());
+  }
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={handleMatchSubmit} className="flex gap-2 items-center">
+        <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
+          style={{ background: 'rgba(0,0,0,0.03)', borderColor: 'rgba(0,0,0,0.08)' }}>
+          <Search size={13} style={{ color: '#8e8e93', flexShrink: 0 }} />
+          <input
+            type="text"
+            value={matchInput}
+            onChange={(e) => setMatchInput(e.target.value)}
+            placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
+            className="flex-1 bg-transparent outline-none text-[13px]"
+            style={{ color: '#1d1d1f' }}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={!matchInput.trim()}
+          className="px-3 py-2 rounded-xl text-[12px] font-medium disabled:opacity-40 transition-colors"
+          style={{ background: 'rgba(0,113,227,0.1)', color: '#0071e3' }}
+        >
+          Test
+        </button>
+        {matchTarget !== null && (
+          <div className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[12px] font-semibold flex-shrink-0"
+            style={
+              matchLoading ? { background: 'rgba(0,0,0,0.05)', color: '#8e8e93' }
+              : matchError  ? { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
+              : matchData?.match ? { background: 'rgba(52,199,89,0.12)', color: '#34c759' }
+              : { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
+            }
+          >
+            {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? '✓ Match' : '✗ No match'}
+          </div>
+        )}
+      </form>
+
+      {canShowRules && (
+        rulesLoading ? (
+          <div className="text-[13px] py-1" style={{ color: '#8e8e93' }}>Loading rules…</div>
+        ) : rulesError ? (
+          <div className="text-[13px] py-1" style={{ color: '#ff3b30' }}>Failed to load rules.</div>
+        ) : providerRules.length === 0 ? (
+          <div className="text-[13px] py-1 italic" style={{ color: '#8e8e93' }}>No rules loaded</div>
+        ) : (
+          <div className="max-h-64 overflow-y-auto space-y-1 pr-1">
+            {providerRules.map((rule, i) => {
+              const [type, ...rest] = rule.split(',');
+              const payload = rest.join(',');
+              return (
+                <div key={i} className="flex items-center gap-2 px-2 py-1 rounded-lg text-[12px]"
+                  style={{ background: 'rgba(0,0,0,0.03)' }}>
+                  <span className="font-mono font-semibold px-1.5 py-0.5 rounded flex-shrink-0"
+                    style={{ background: 'rgba(255,149,0,0.12)', color: '#ff9500', fontSize: 10 }}>
+                    {type}
+                  </span>
+                  <span className="font-mono truncate" style={{ color: '#1d1d1f' }}>{payload}</span>
+                </div>
+              );
+            })}
+            {providerRules.length >= 500 && (
+              <div className="text-[11px] text-center pt-1" style={{ color: '#8e8e93' }}>
+                Showing first 500 rules
+              </div>
+            )}
+          </div>
+        )
+      )}
+
+      {!canShowRules && (
+        <div className="text-[12px] italic" style={{ color: '#8e8e93' }}>
+          Rule entries are not enumerable for {behavior} providers — use the tester above.
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function Rules() {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
@@ -67,6 +169,8 @@ export function Rules() {
     try {
       await updateRuleProvider(provider.name);
       await queryClient.invalidateQueries({ queryKey: ['rule-providers'] });
+    } catch (err) {
+      console.error(`Failed to update rule provider "${provider.name}":`, err);
     } finally {
       setUpdatingRuleProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
     }
@@ -79,108 +183,6 @@ export function Rules() {
       case 'classical': return { background: 'rgba(255,149,0,0.12)', color: '#ff9500' };
       default:          return { background: 'rgba(0,0,0,0.06)',      color: '#6e6e73' };
     }
-  }
-
-  function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: string }) {
-    const [matchInput, setMatchInput] = useState('');
-    const [matchTarget, setMatchTarget] = useState<string | null>(null);
-
-    const { data: rulesData, isLoading: rulesLoading, isError: rulesError } = useQuery({
-      queryKey: ['rule-provider-rules', name],
-      queryFn: () => getRuleProviderRules(name),
-    });
-
-    const { data: matchData, isLoading: matchLoading, isError: matchError } = useQuery({
-      queryKey: ['rule-provider-match', name, matchTarget],
-      queryFn: () => matchRuleProvider(name, matchTarget!),
-      enabled: matchTarget !== null && matchTarget.trim().length > 0,
-    });
-
-    const providerRules = rulesData?.rules ?? [];
-    const behaviorLower = behavior?.toLowerCase();
-    const canShowRules = behaviorLower === 'classical';
-
-    function handleMatchSubmit(e: React.FormEvent) {
-      e.preventDefault();
-      if (matchInput.trim()) setMatchTarget(matchInput.trim());
-    }
-
-    return (
-      <div className="space-y-3">
-        <form onSubmit={handleMatchSubmit} className="flex gap-2 items-center">
-          <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
-            style={{ background: 'rgba(0,0,0,0.03)', borderColor: 'rgba(0,0,0,0.08)' }}>
-            <Search size={13} style={{ color: '#8e8e93', flexShrink: 0 }} />
-            <input
-              type="text"
-              value={matchInput}
-              onChange={(e) => setMatchInput(e.target.value)}
-              placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
-              className="flex-1 bg-transparent outline-none text-[13px]"
-              style={{ color: '#1d1d1f' }}
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={!matchInput.trim()}
-            className="px-3 py-2 rounded-xl text-[12px] font-medium disabled:opacity-40 transition-colors"
-            style={{ background: 'rgba(0,113,227,0.1)', color: '#0071e3' }}
-          >
-            Test
-          </button>
-          {matchTarget !== null && (
-            <div className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[12px] font-semibold flex-shrink-0"
-              style={
-                matchLoading ? { background: 'rgba(0,0,0,0.05)', color: '#8e8e93' }
-                : matchError  ? { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
-                : matchData?.match ? { background: 'rgba(52,199,89,0.12)', color: '#34c759' }
-                : { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
-              }
-            >
-              {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? '✓ Match' : '✗ No match'}
-            </div>
-          )}
-        </form>
-
-        {canShowRules && (
-          rulesLoading ? (
-            <div className="text-[13px] py-1" style={{ color: '#8e8e93' }}>Loading rules…</div>
-          ) : rulesError ? (
-            <div className="text-[13px] py-1" style={{ color: '#ff3b30' }}>Failed to load rules.</div>
-          ) : providerRules.length === 0 ? (
-            <div className="text-[13px] py-1 italic" style={{ color: '#8e8e93' }}>No rules loaded</div>
-          ) : (
-            <div className="max-h-64 overflow-y-auto space-y-1 pr-1">
-              {providerRules.map((rule, i) => {
-                const [type, ...rest] = rule.split(',');
-                const payload = rest.join(',');
-                return (
-                  <div key={i} className="flex items-center gap-2 px-2 py-1 rounded-lg text-[12px]"
-                    style={{ background: 'rgba(0,0,0,0.03)' }}>
-                    <span className="font-mono font-semibold px-1.5 py-0.5 rounded flex-shrink-0"
-                      style={{ background: 'rgba(255,149,0,0.12)', color: '#ff9500', fontSize: 10 }}>
-                      {type}
-                    </span>
-                    <span className="font-mono truncate" style={{ color: '#1d1d1f' }}>{payload}</span>
-                  </div>
-                );
-              })}
-              {providerRules.length >= 500 && (
-                <div className="text-[11px] text-center pt-1" style={{ color: '#8e8e93' }}>
-                  Showing first 500 rules
-                </div>
-              )}
-            </div>
-          )
-        )}
-
-        {!canShowRules && (
-          <div className="text-[12px] italic" style={{ color: '#8e8e93' }}>
-            Rule entries are not enumerable for {behavior} providers — use the tester above.
-          </div>
-        )}
-      </div>
-    );
   }
 
   return (

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { getRules } from '../lib/api';
-import { Search } from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getRules, getRuleProviders, updateRuleProvider, getRuleProviderRules, matchRuleProvider } from '../lib/api';
+import { RefreshCw, Search } from 'lucide-react';
+import type { RuleProvider } from '../lib/api';
 
 function getRuleTypeBadgeStyle(type: string): { background: string; color: string } {
   switch (type) {
@@ -29,8 +30,17 @@ function getRuleTypeBadgeStyle(type: string): { background: string; color: strin
 }
 
 export function Rules() {
+  const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
+  const [updatingRuleProviders, setUpdatingRuleProviders] = useState<Set<string>>(new Set());
+  const [expandedRuleProviders, setExpandedRuleProviders] = useState<Set<string>>(new Set());
+
   const { data, isLoading, isError } = useQuery({ queryKey: ['rules'], queryFn: getRules });
+  const { data: ruleData, isLoading: ruleIsLoading } = useQuery({
+    queryKey: ['rule-providers'],
+    queryFn: getRuleProviders,
+    refetchInterval: 60000,
+  });
 
   const rules = data?.rules ?? [];
   const filtered = rules.filter(
@@ -39,6 +49,139 @@ export function Rules() {
       (r.payload ?? '').toLowerCase().includes(search.toLowerCase()) ||
       r.proxy.toLowerCase().includes(search.toLowerCase())
   );
+
+  const ruleProviders = Object.values(ruleData?.providers ?? {})
+    .filter((p) => p.vehicleType !== 'Compatible' && p.vehicleType !== 'Inline')
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  function toggleRuleProviderExpanded(name: string) {
+    setExpandedRuleProviders((prev) => {
+      const next = new Set(prev);
+      next.has(name) ? next.delete(name) : next.add(name);
+      return next;
+    });
+  }
+
+  async function runRuleUpdate(provider: RuleProvider) {
+    setUpdatingRuleProviders((s) => new Set(s).add(provider.name));
+    try {
+      await updateRuleProvider(provider.name);
+      await queryClient.invalidateQueries({ queryKey: ['rule-providers'] });
+    } finally {
+      setUpdatingRuleProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
+    }
+  }
+
+  function getBehaviorStyle(behavior?: string): { background: string; color: string } {
+    switch (behavior?.toLowerCase()) {
+      case 'domain':    return { background: 'rgba(52,199,89,0.12)',  color: '#34c759' };
+      case 'ipcidr':    return { background: 'rgba(0,113,227,0.12)',  color: '#0071e3' };
+      case 'classical': return { background: 'rgba(255,149,0,0.12)', color: '#ff9500' };
+      default:          return { background: 'rgba(0,0,0,0.06)',      color: '#6e6e73' };
+    }
+  }
+
+  function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: string }) {
+    const [matchInput, setMatchInput] = useState('');
+    const [matchTarget, setMatchTarget] = useState<string | null>(null);
+
+    const { data: rulesData, isLoading: rulesLoading, isError: rulesError } = useQuery({
+      queryKey: ['rule-provider-rules', name],
+      queryFn: () => getRuleProviderRules(name),
+    });
+
+    const { data: matchData, isLoading: matchLoading, isError: matchError } = useQuery({
+      queryKey: ['rule-provider-match', name, matchTarget],
+      queryFn: () => matchRuleProvider(name, matchTarget!),
+      enabled: matchTarget !== null && matchTarget.trim().length > 0,
+    });
+
+    const providerRules = rulesData?.rules ?? [];
+    const behaviorLower = behavior?.toLowerCase();
+    const canShowRules = behaviorLower === 'classical';
+
+    function handleMatchSubmit(e: React.FormEvent) {
+      e.preventDefault();
+      if (matchInput.trim()) setMatchTarget(matchInput.trim());
+    }
+
+    return (
+      <div className="space-y-3">
+        <form onSubmit={handleMatchSubmit} className="flex gap-2 items-center">
+          <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
+            style={{ background: 'rgba(0,0,0,0.03)', borderColor: 'rgba(0,0,0,0.08)' }}>
+            <Search size={13} style={{ color: '#8e8e93', flexShrink: 0 }} />
+            <input
+              type="text"
+              value={matchInput}
+              onChange={(e) => setMatchInput(e.target.value)}
+              placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
+              className="flex-1 bg-transparent outline-none text-[13px]"
+              style={{ color: '#1d1d1f' }}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={!matchInput.trim()}
+            className="px-3 py-2 rounded-xl text-[12px] font-medium disabled:opacity-40 transition-colors"
+            style={{ background: 'rgba(0,113,227,0.1)', color: '#0071e3' }}
+          >
+            Test
+          </button>
+          {matchTarget !== null && (
+            <div className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[12px] font-semibold flex-shrink-0"
+              style={
+                matchLoading ? { background: 'rgba(0,0,0,0.05)', color: '#8e8e93' }
+                : matchError  ? { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
+                : matchData?.match ? { background: 'rgba(52,199,89,0.12)', color: '#34c759' }
+                : { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
+              }
+            >
+              {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? '✓ Match' : '✗ No match'}
+            </div>
+          )}
+        </form>
+
+        {canShowRules && (
+          rulesLoading ? (
+            <div className="text-[13px] py-1" style={{ color: '#8e8e93' }}>Loading rules…</div>
+          ) : rulesError ? (
+            <div className="text-[13px] py-1" style={{ color: '#ff3b30' }}>Failed to load rules.</div>
+          ) : providerRules.length === 0 ? (
+            <div className="text-[13px] py-1 italic" style={{ color: '#8e8e93' }}>No rules loaded</div>
+          ) : (
+            <div className="max-h-64 overflow-y-auto space-y-1 pr-1">
+              {providerRules.map((rule, i) => {
+                const [type, ...rest] = rule.split(',');
+                const payload = rest.join(',');
+                return (
+                  <div key={i} className="flex items-center gap-2 px-2 py-1 rounded-lg text-[12px]"
+                    style={{ background: 'rgba(0,0,0,0.03)' }}>
+                    <span className="font-mono font-semibold px-1.5 py-0.5 rounded flex-shrink-0"
+                      style={{ background: 'rgba(255,149,0,0.12)', color: '#ff9500', fontSize: 10 }}>
+                      {type}
+                    </span>
+                    <span className="font-mono truncate" style={{ color: '#1d1d1f' }}>{payload}</span>
+                  </div>
+                );
+              })}
+              {providerRules.length >= 500 && (
+                <div className="text-[11px] text-center pt-1" style={{ color: '#8e8e93' }}>
+                  Showing first 500 rules
+                </div>
+              )}
+            </div>
+          )
+        )}
+
+        {!canShowRules && (
+          <div className="text-[12px] italic" style={{ color: '#8e8e93' }}>
+            Rule entries are not enumerable for {behavior} providers — use the tester above.
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="p-6 space-y-4">
@@ -119,6 +262,97 @@ export function Rules() {
               );
             })
           )}
+        </div>
+      )}
+
+      {/* Rule Providers Section */}
+      <div className="flex items-center justify-between pt-4">
+        <h2 className="text-xl font-semibold tracking-tight" style={{ color: '#1d1d1f' }}>Rule Providers</h2>
+        <span className="text-[13px]" style={{ color: '#8e8e93' }}>
+          {ruleProviders.length} provider{ruleProviders.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {ruleIsLoading ? (
+        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading rule providers…</div>
+      ) : ruleProviders.length === 0 ? (
+        <div className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center">
+          <div className="text-3xl">📋</div>
+          <div className="text-[15px] font-semibold" style={{ color: '#1d1d1f' }}>No Rule Providers</div>
+          <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+            Add rule providers to your config to see them here.
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {ruleProviders.map((provider) => {
+            const isUpdating = updatingRuleProviders.has(provider.name);
+            const isExpanded = expandedRuleProviders.has(provider.name);
+            const behaviorStyle = getBehaviorStyle(provider.behavior);
+            return (
+              <div key={provider.name}
+                className="liquid-glass-card rounded-xl overflow-hidden"
+                style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
+              >
+                <div className="flex">
+                  <div className="w-1 flex-shrink-0" style={{ background: behaviorStyle.color }} />
+                  <div className="flex-1">
+                    <div
+                      className="px-4 py-3 flex items-center justify-between cursor-pointer"
+                      style={{ minHeight: 56 }}
+                      onClick={() => toggleRuleProviderExpanded(provider.name)}
+                    >
+                      <div className="flex items-center gap-2.5 min-w-0 flex-wrap">
+                        <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>
+                          {provider.name}
+                        </span>
+                        <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+                          style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}>
+                          {provider.vehicleType}
+                        </span>
+                        {provider.behavior && (
+                          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+                            style={behaviorStyle}>
+                            {provider.behavior}
+                          </span>
+                        )}
+                        {provider.ruleCount !== undefined && (
+                          <span className="text-[11px] px-2 py-0.5 rounded-full flex-shrink-0"
+                            style={{ background: 'rgba(0,0,0,0.04)', color: '#8e8e93' }}>
+                            {provider.ruleCount} rule{provider.ruleCount !== 1 ? 's' : ''}
+                          </span>
+                        )}
+                        {provider.updatedAt && (
+                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: '#8e8e93' }}>
+                            Updated {new Date(provider.updatedAt).toLocaleTimeString()}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                        <button
+                          onClick={(e) => { e.stopPropagation(); runRuleUpdate(provider); }}
+                          disabled={isUpdating}
+                          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium disabled:opacity-50 transition-colors"
+                          style={{ background: 'rgba(0,113,227,0.1)', color: '#0071e3' }}
+                        >
+                          <RefreshCw size={12} className={isUpdating ? 'animate-spin' : ''} />
+                          {isUpdating ? 'Updating…' : 'Update'}
+                        </button>
+                        <span style={{ color: '#6e6e73', fontSize: 16 }}>{isExpanded ? '▲' : '▼'}</span>
+                      </div>
+                    </div>
+                    {isExpanded && (
+                      <div className="px-4 pb-4 border-t" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+                        <div className="pt-3">
+                          <RuleProviderRulesPanel name={provider.name} behavior={provider.behavior} />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -306,6 +306,7 @@ export function Rules() {
                       style={{ minHeight: 56 }}
                       role="button"
                       tabIndex={0}
+                      aria-expanded={isExpanded}
                       onClick={() => toggleRuleProviderExpanded(provider.name)}
                       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && toggleRuleProviderExpanded(provider.name)}
                     >

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -138,7 +138,7 @@ export function Rules() {
   const [expandedRuleProviders, setExpandedRuleProviders] = useState<Set<string>>(new Set());
 
   const { data, isLoading, isError } = useQuery({ queryKey: ['rules'], queryFn: getRules });
-  const { data: ruleData, isLoading: ruleIsLoading } = useQuery({
+  const { data: ruleData, isLoading: ruleIsLoading, isError: ruleIsError } = useQuery({
     queryKey: ['rule-providers'],
     queryFn: getRuleProviders,
     refetchInterval: 60000,
@@ -277,6 +277,8 @@ export function Rules() {
 
       {ruleIsLoading ? (
         <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading rule providers…</div>
+      ) : ruleIsError ? (
+        <div className="text-[15px]" style={{ color: '#ff3b30' }}>Failed to load rule providers. Check your API connection.</div>
       ) : ruleProviders.length === 0 ? (
         <div className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center">
           <div className="text-3xl">📋</div>
@@ -302,7 +304,10 @@ export function Rules() {
                     <div
                       className="px-4 py-3 flex items-center justify-between cursor-pointer"
                       style={{ minHeight: 56 }}
+                      role="button"
+                      tabIndex={0}
                       onClick={() => toggleRuleProviderExpanded(provider.name)}
+                      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && toggleRuleProviderExpanded(provider.name)}
                     >
                       <div className="flex items-center gap-2.5 min-w-0 flex-wrap">
                         <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>


### PR DESCRIPTION
## Changes

### New `/proxies` page (`ProxyList.tsx`)
Replaces the old `/providers` page. Shows:
- Static config proxies in a flat grid with type badge + latency
- Provider proxies grouped by provider with per-proxy latency test buttons
- `/providers` kept as a compatibility alias so existing bookmarks still work

### Per-proxy latency testing
- Static proxies: `GET /proxies/{name}/delay`
- Provider proxies: `GET /providers/proxies/{provider}/{name}/healthcheck`
- Latency cache keys namespaced as `{provider}::{proxy}` to avoid collisions when two providers have same-named proxies

### Fixed selector proxy jumping glitch
Removed `invalidateQueries` from `onSettled` of `selectMutation` in `Proxies.tsx` and `ProxyGroups.tsx`. The optimistic update now sticks without being overwritten by an immediate refetch.

### Rule providers moved to Rules page
Rule provider section (with match tester + update button) now lives at the bottom of `Rules.tsx` instead of the old Providers page. `RuleProviderRulesPanel` extracted to module level to prevent state loss on re-renders.

### Nav updated
New order: Overview / Flows / Connections / Proxies / Rules / DNS / Logs / Settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consolidated Proxy List page combining static and provider proxies with per-proxy latency tests, provider “Test All” (batched) and provider update actions.
  * Rules page now shows Rule Providers with expand/collapse panels, a tester input, and per-provider update.

* **UI Enhancements**
  * Updated top-navigation icons and routing so proxies and providers render the consolidated proxy list.

* **Bug Fixes**
  * Improved proxy-selection error handling to force proxy list refresh after failures.

* **Chores**
  * Added a helper to fetch provider-specific proxy latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->