### PR TITLE
fix(dashboard): group latency, provider healthcheck, rule provider API

### DIFF
--- a/clash-dashboard/src/lib/api.ts
+++ b/clash-dashboard/src/lib/api.ts
@@ -219,7 +219,7 @@ export const healthcheckProvider = (name: string) =>
   request<void>(`/providers/proxies/${encodeURIComponent(name)}/healthcheck`);
 export const getProviderProxyDelay = (providerName: string, proxyName: string, url: string, timeout: number) =>
   request<{ delay: number }>(
-    `/providers/proxies/${encodeURIComponent(providerName)}/proxies/${encodeURIComponent(proxyName)}/delay?url=${encodeURIComponent(url)}&timeout=${timeout}`
+    `/providers/proxies/${encodeURIComponent(providerName)}/${encodeURIComponent(proxyName)}/healthcheck?url=${encodeURIComponent(url)}&timeout=${timeout}`
   );
 
 // Rule Providers

--- a/clash-dashboard/src/pages/Proxies.tsx
+++ b/clash-dashboard/src/pages/Proxies.tsx
@@ -149,6 +149,7 @@ export function Proxies() {
     try {
       await getGroupDelay(group.name, TEST_URL, TEST_TIMEOUT);
       await queryClient.invalidateQueries({ queryKey: ['proxies'] });
+      await queryClient.invalidateQueries({ queryKey: ['providers'] });
     } catch {
       // leave existing latency values unchanged on error
     } finally {
@@ -229,6 +230,8 @@ export function Proxies() {
               const isSelector = group.type === 'Selector';
               const accentColor = getGroupAccentColor(group.type);
               const typeBadge = getTypeBadgeStyle(group.type);
+              const groupLatency = getLastDelay(group.history ?? []);
+              const groupLatencyColor = getLatencyColor(groupLatency);
 
           return (
             <div
@@ -267,6 +270,14 @@ export function Proxies() {
                       {group.now && (
                         <span className="text-[13px] truncate" style={{ color: '#6e6e73' }}>
                           {group.now}
+                        </span>
+                      )}
+                      {groupLatency !== undefined && (
+                        <span
+                          className="text-[11px] font-mono flex-shrink-0"
+                          style={{ color: groupLatencyColor }}
+                        >
+                          {groupLatency === 0 ? 'Timeout' : `${groupLatency}ms`}
                         </span>
                       )}
                     </div>

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -234,6 +234,15 @@ export function ProxyList() {
     try {
       await healthcheckProvider(provider.name);
       await queryClient.invalidateQueries({ queryKey: ['providers'] });
+      // Clear stale per-proxy overrides so cards fall back to freshly fetched history
+      setLatencyMap((prev) => {
+        const next = { ...prev };
+        const prefix = `${provider.name}::`;
+        for (const key of Object.keys(next)) {
+          if (key.startsWith(prefix)) delete next[key];
+        }
+        return next;
+      });
     } catch {
       // leave existing latency values unchanged on error
     } finally {

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   getProxies, getProxyProviders, getProxyDelay, getProviderProxyDelay,
-  updateProxyProvider,
+  updateProxyProvider, healthcheckProvider,
 } from '../lib/api';
 import { Activity, RefreshCw } from 'lucide-react';
 import type { Proxy, ProxyProvider } from '../lib/api';
@@ -232,14 +232,10 @@ export function ProxyList() {
   async function testAllInProvider(provider: ProxyProvider) {
     setTestingProviders((s) => new Set(s).add(provider.name));
     try {
-      const proxies = provider.proxies ?? [];
-      const BATCH = 5;
-      for (let i = 0; i < proxies.length; i += BATCH) {
-        await Promise.allSettled(
-          proxies.slice(i, i + BATCH).map((proxy) => testProviderProxy(provider.name, proxy))
-        );
-      }
+      await healthcheckProvider(provider.name);
       await queryClient.invalidateQueries({ queryKey: ['providers'] });
+    } catch {
+      // leave existing latency values unchanged on error
     } finally {
       setTestingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
     }
@@ -273,10 +269,10 @@ export function ProxyList() {
         <div className="text-[15px]" style={{ color: '#ff3b30' }}>Failed to load proxies. Check your API connection.</div>
       ) : (
         <>
-          {/* Config Proxies */}
+          {/* Proxies */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
-              <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Config Proxies</h2>
+              <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Proxies</h2>
               <span className="text-[11px]" style={{ color: '#8e8e93' }}>
                 {configProxies.length} {configProxies.length === 1 ? 'proxy' : 'proxies'}
               </span>
@@ -321,6 +317,12 @@ export function ProxyList() {
           ) : (
             <>
               <div className="w-full h-px" style={{ background: 'rgba(0,0,0,0.06)' }} />
+              <div className="flex items-center gap-2">
+                <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Proxy Providers</h2>
+                <span className="text-[11px]" style={{ color: '#8e8e93' }}>
+                  {providers.length} {providers.length === 1 ? 'provider' : 'providers'}
+                </span>
+              </div>
               <div className="space-y-8">
                 {providers.map((provider) => (
                   <ProviderSection

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{
     Extension, Router,
@@ -8,14 +14,16 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     app::{
         api::AppState, outbound::manager::ThreadSafeOutboundManager,
         remote_content_manager::providers::proxy_provider::ThreadSafeProxyProvider,
+        router::ArcRouter,
     },
     proxy::AnyOutboundHandler,
+    session::{Network, Session, SocksAddr, Type},
 };
 #[derive(Clone)]
 struct ProviderState {
@@ -197,4 +205,147 @@ async fn get_proxy_delay(
         )
             .into_response(),
     }
+}
+
+// ── Rule provider routes ────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct RuleProviderState {
+    router: ArcRouter,
+}
+
+pub fn rule_routes(router: ArcRouter) -> Router<Arc<AppState>> {
+    let state = RuleProviderState { router };
+    Router::new()
+        .route("/", get(get_rule_providers))
+        .route(
+            "/{provider_name}",
+            get(get_rule_provider).put(update_rule_provider),
+        )
+        .route("/{provider_name}/rules", get(get_rule_provider_rules))
+        .route("/{provider_name}/match", get(match_rule_provider))
+        .with_state(state)
+}
+
+async fn get_rule_providers(
+    State(state): State<RuleProviderState>,
+) -> impl IntoResponse {
+    let mut providers = HashMap::new();
+    for (name, p) in state.router.get_rule_providers() {
+        providers.insert(name.clone(), p.as_map().await);
+    }
+    let mut res = HashMap::new();
+    res.insert("providers", providers);
+    axum::response::Json(res)
+}
+
+#[derive(Deserialize)]
+struct RuleProviderNamePath {
+    provider_name: String,
+}
+
+async fn get_rule_provider(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+) -> impl IntoResponse {
+    match state.router.get_rule_providers().get(&provider_name) {
+        Some(p) => axum::response::Json(p.as_map().await).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response(),
+    }
+}
+
+async fn update_rule_provider(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+) -> impl IntoResponse {
+    match state.router.get_rule_providers().get(&provider_name) {
+        Some(p) => match p.update().await {
+            Ok(_) => (StatusCode::ACCEPTED, "rule provider update started")
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("update rule provider {provider_name} failed: {err}"),
+            )
+                .into_response(),
+        },
+        None => (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_rule_provider_rules(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+) -> impl IntoResponse {
+    match state.router.get_rule_providers().get(&provider_name) {
+        Some(p) => {
+            let rules = p.list_rules(500).await;
+            let mut res = HashMap::new();
+            res.insert("rules", rules);
+            axum::response::Json(res).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct MatchQuery {
+    target: String,
+}
+
+#[derive(Serialize)]
+struct MatchResponse {
+    #[serde(rename = "match")]
+    matched: bool,
+}
+
+async fn match_rule_provider(
+    State(state): State<RuleProviderState>,
+    Path(RuleProviderNamePath { provider_name }): Path<RuleProviderNamePath>,
+    Query(q): Query<MatchQuery>,
+) -> impl IntoResponse {
+    let Some(p) = state.router.get_rule_providers().get(&provider_name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("rule provider {provider_name} not found"),
+        )
+            .into_response();
+    };
+
+    let destination = match SocksAddr::from_str(&q.target) {
+        Ok(addr) => addr,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, "invalid target").into_response();
+        }
+    };
+
+    let sess = Session {
+        network: Network::Tcp,
+        typ: Type::Http,
+        source: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        destination,
+        resolved_ip: None,
+        so_mark: None,
+        iface: None,
+        asn: None,
+        country: None,
+        traffic_stats: None,
+        inbound_user: None,
+    };
+
+    axum::response::Json(MatchResponse {
+        matched: p.search(&sess),
+    })
+    .into_response()
 }

--- a/clash-lib/src/app/api/runner.rs
+++ b/clash-lib/src/app/api/runner.rs
@@ -158,7 +158,7 @@ impl Runner for ApiRunner {
                         dns_enabled,
                     ),
                 )
-                .nest("/rules", handlers::rule::routes(router))
+                .nest("/rules", handlers::rule::routes(router.clone()))
                 .nest("/group", handlers::group::routes(outbound_manager.clone()))
                 .nest(
                     "/proxies",
@@ -168,6 +168,7 @@ impl Runner for ApiRunner {
                     "/providers/proxies",
                     handlers::provider::routes(outbound_manager),
                 )
+                .nest("/providers/rules", handlers::provider::rule_routes(router))
                 .nest(
                     "/connections",
                     handlers::connection::routes(statistics_manager.clone()),

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -86,10 +86,18 @@ struct Inner {
     content: RuleContent,
 }
 
+#[async_trait]
 pub trait RuleProvider: Provider {
     fn search(&self, sess: &Session) -> bool;
     fn behavior(&self) -> RuleSetBehavior;
     fn format(&self) -> RuleSetFormat;
+    /// Returns up to `limit` rules as strings. Only Classical providers return
+    /// non-empty results; Domain/IPCIDR data structures don't support
+    /// enumeration.
+    async fn list_rules(&self, limit: usize) -> Vec<String> {
+        let _ = limit;
+        vec![]
+    }
 }
 
 pub type ThreadSafeRuleProvider = Arc<dyn RuleProvider + Send + Sync>;
@@ -294,6 +302,18 @@ impl RuleProvider for RuleProviderImpl {
 
     fn format(&self) -> RuleSetFormat {
         self.format
+    }
+
+    async fn list_rules(&self, limit: usize) -> Vec<String> {
+        let inner = self.inner.read().await;
+        match &inner.content {
+            RuleContent::Classical(rules) => rules
+                .iter()
+                .take(limit)
+                .map(|r| format!("{},{}", r.type_name(), r.payload()))
+                .collect(),
+            _ => vec![],
+        }
     }
 }
 

--- a/clash-lib/src/app/router/mod.rs
+++ b/clash-lib/src/app/router/mod.rs
@@ -33,6 +33,7 @@ pub struct Router {
 
     country_mmdb: Option<MmdbLookup>,
     asn_mmdb: Option<MmdbLookup>,
+    rule_providers: HashMap<String, ThreadSafeRuleProvider>,
 }
 
 pub type ArcRouter = Arc<Router>;
@@ -83,7 +84,12 @@ impl Router {
 
             country_mmdb,
             asn_mmdb,
+            rule_providers: rule_provider_registry,
         }
+    }
+
+    pub fn get_rule_providers(&self) -> &HashMap<String, ThreadSafeRuleProvider> {
+        &self.rule_providers
     }
 
     /// this mutates the session, attaching resolved IP and ASN


### PR DESCRIPTION
## Summary

Fixes several regressions introduced by PRs #1360 and #1362, and restores rule provider API dropped by #1342.

## Changes

### Frontend
- **api.ts**: Fix `getProviderProxyDelay` endpoint — removed extra `/proxies/` path segment and changed `/delay` → `/healthcheck`
- **ProxyList.tsx**: Replace N individual per-proxy latency calls (all 404ing) with single `healthcheckProvider()` bulk call; rename "Config Proxies" → "Proxies"; add "Proxy Providers" section header
- **Proxies.tsx**: Show group latency in header via `getLastDelay(group.history)` after test completes; also invalidate `['providers']` query after group delay test so provider-sourced proxies refresh

### Backend
- **provider.rs**: Restore full `rule_routes()` — `GET /providers/rules`, `GET /providers/rules/{name}`, `PUT /providers/rules/{name}`, `GET /providers/rules/{name}/rules`, `GET /providers/rules/{name}/match` — all were dropped by #1342
- **rule_provider/provider.rs**: Restore `list_rules(limit)` async default method on `RuleProvider` trait (Classical providers enumerate rules; Domain/IPCIDR return empty)
- **router/mod.rs**: Store `rule_providers` as a field on `Router` struct and expose via `get_rule_providers()` so the registry isn't dropped after construction
- **runner.rs**: Re-register `/providers/rules` nest; fix `router` → `router.clone()` for `/rules` route

## Root Cause
PR #1342 (built-in dashboard) accidentally overwrote `runner.rs` and `provider.rs`, dropping the `/providers/rules` routes that #1343 had added. The dashboard's `Providers.tsx` already had full rule provider UI (list, update, expand rules, match tester) wired up and waiting for those endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule provider API added for listing, querying and matching rules.
  * Provider-level healthcheck endpoint used for provider "Test All" actions.

* **UI/UX Improvements**
  * Group latency shown as a color-coded monospaced badge; shows "Timeout" for timed-out checks.
  * Renamed proxy section header to "Proxies" and added a "Proxy Providers" area with provider counts.

* **Bug Fixes**
  * "Test All" now refreshes provider data and falls back to fetched history on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->