### PR TITLE
chore: reduce release binary size with line-tables-only debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ homepage = "https://github.com/watfaq/clash-rs"
 opt-level = "s"
 codegen-units = 1
 lto = "thin"
-strip = false
-debug = 2
+strip = "debuginfo"
+debug = 1
 panic = "abort"
 
 [profile.detailed-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ homepage = "https://github.com/watfaq/clash-rs"
 opt-level = "s"
 codegen-units = 1
 lto = "thin"
-strip = "debuginfo"
-debug = 1
+strip = "symbols"
+debug = 0
 panic = "abort"
 
 [profile.detailed-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ authors = ["https://github.com/Watfaq/clash-rs/graphs/contributors"]
 homepage = "https://github.com/watfaq/clash-rs"
 
 [profile.release]
-opt-level = "s"
+opt-level = "z"
 codegen-units = 1
-lto = "thin"
+lto = "fat"
 strip = "symbols"
 debug = 0
 panic = "abort"


### PR DESCRIPTION
## Problem
The release binary is ~300MB because of `debug = 2` (full DWARF) + `strip = false`.

## Change
- `debug = 2` → `debug = 1` (line tables only — keeps file+line in panic backtraces)
- `strip = false` → `strip = "debuginfo"` (strips the DWARF bulk, keeps symbol names for backtraces)

This preserves useful panic output like:
```
thread 'main' panicked at 'oh no', src/proxy/mod.rs:42
```

...while cutting binary size significantly. Full debug info (types, locals, inlined frames) can still be obtained via the `detailed-release` profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the release build to produce smaller, leaner binaries by increasing optimization, enabling more aggressive linking, and reducing included debug information.
  * Result: reduced artifact size and unchanged public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->