### PR TITLE
feat(dashboard): dark mode, theme toggle, test refresh fixes, group latency, batch test, rule match

### DIFF
--- a/clash-dashboard/src/components/Layout.tsx
+++ b/clash-dashboard/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Server, SlidersHorizontal, GitBranch, Shield,
 } from 'lucide-react';
 import logoUrl from '../assets/logo.png';
+import { ThemeToggle } from './ThemeToggle';
 
 const navItems = [
   { to: '/', label: 'Overview', icon: LayoutDashboard, end: true },
@@ -36,7 +37,7 @@ export function Layout() {
           {/* Logo — real clash-rs icon from public/favicon.svg */}
           <div className="flex items-center gap-2 flex-shrink-0">
             <img src={logoUrl} alt="clash-rs" className="w-7 h-7 rounded-lg" />
-            <span className="font-semibold text-[15px] hidden sm:inline" style={{ color: '#1d1d1f' }}>
+            <span className="font-semibold text-[15px] hidden sm:inline" style={{ color: 'var(--color-text-primary)' }}>
               clash-rs
             </span>
           </div>
@@ -54,7 +55,7 @@ export function Layout() {
                   `flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all flex-shrink-0 ${
                     isActive
                       ? 'nav-pill-glass text-[#0071e3]'
-                      : 'text-[#6e6e73] hover:text-[#1d1d1f] hover:bg-black/[0.05]'
+                      : 'nav-inactive'
                   }`
                 }
               >
@@ -63,6 +64,8 @@ export function Layout() {
               </NavLink>
             ))}
           </nav>
+
+          <ThemeToggle />
 
           {/* Connection status */}
           <div className="flex items-center gap-2 flex-shrink-0">
@@ -75,7 +78,7 @@ export function Layout() {
                 />
               )}
             </div>
-            <span className="text-[13px] font-medium hidden sm:inline" style={{ color: '#6e6e73' }}>
+            <span className="text-[13px] font-medium hidden sm:inline" style={{ color: 'var(--color-text-secondary)' }}>
               {isConnected ? `v${version?.version}` : 'Offline'}
             </span>
           </div>

--- a/clash-dashboard/src/components/ProxyGroups.tsx
+++ b/clash-dashboard/src/components/ProxyGroups.tsx
@@ -28,7 +28,7 @@ function getTypeBadgeStyle(type: string): { background: string; color: string } 
   if (type === 'URLTest') return { background: 'rgba(52,199,89,0.1)', color: '#34c759' };
   if (type === 'Fallback') return { background: 'rgba(255,149,0,0.1)', color: '#ff9500' };
   if (type === 'LoadBalance') return { background: 'rgba(175,82,222,0.1)', color: '#af52de' };
-  return { background: 'rgba(0,0,0,0.06)', color: '#6e6e73' };
+  return { background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' };
 }
 
 function getLastDelay(history: Proxy['history']): number | undefined {
@@ -120,14 +120,14 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
   }
 
   if (isLoading) {
-    return <div className="text-[13px]" style={{ color: '#6e6e73' }}>Loading proxies…</div>;
+    return <div className="text-[13px]" style={{ color: 'var(--color-text-secondary)' }}>Loading proxies…</div>;
   }
 
   if (mode === 'direct' || groups.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 py-4 text-center">
         <div className="text-2xl">⚡️</div>
-        <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+        <div className="text-[13px]" style={{ color: 'var(--color-text-secondary)' }}>
           {mode === 'direct' ? 'Direct mode — no proxy groups' : 'No groups for this mode'}
         </div>
       </div>
@@ -147,7 +147,7 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
           <div
             key={group.name}
             className="rounded-xl overflow-hidden border"
-            style={{ borderColor: 'rgba(0,0,0,0.06)', background: 'rgba(255,255,255,0.6)' }}
+            style={{ borderColor: 'var(--color-separator)', background: 'var(--color-proxy-card-bg)' }}
           >
             <div className="flex">
               <div className="w-1 flex-shrink-0" style={{ background: accentColor }} />
@@ -158,7 +158,7 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                   onClick={() => toggleExpanded(group.name)}
                 >
                   <div className="flex items-center gap-2.5 min-w-0">
-                    <span className="font-semibold text-[14px] truncate" style={{ color: '#1d1d1f' }}>
+                    <span className="font-semibold text-[14px] truncate" style={{ color: 'var(--color-text-primary)' }}>
                       {group.name}
                     </span>
                     <span
@@ -168,7 +168,7 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                       {group.type}
                     </span>
                     {group.now && (
-                      <span className="text-[13px] truncate" style={{ color: '#6e6e73' }}>
+                      <span className="text-[13px] truncate" style={{ color: 'var(--color-text-secondary)' }}>
                         {group.now}
                       </span>
                     )}
@@ -178,22 +178,22 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                       onClick={(e) => { e.stopPropagation(); testGroupDelay(group); }}
                       disabled={isTesting}
                       className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium disabled:opacity-50"
-                      style={{ background: 'rgba(0,0,0,0.05)', color: '#6e6e73' }}
+                      style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
                     >
                       <RefreshCw size={11} className={isTesting ? 'animate-spin' : ''} />
                       {isTesting ? 'Testing…' : 'Test'}
                     </button>
                     {isExpanded
-                      ? <ChevronUp size={15} style={{ color: '#6e6e73' }} />
-                      : <ChevronDown size={15} style={{ color: '#6e6e73' }} />
+                      ? <ChevronUp size={15} style={{ color: 'var(--color-text-secondary)' }} />
+                      : <ChevronDown size={15} style={{ color: 'var(--color-text-secondary)' }} />
                     }
                   </div>
                 </div>
 
                 {isExpanded && (
-                  <div className="px-4 pb-4 border-t pt-3" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+                  <div className="px-4 pb-4 border-t pt-3" style={{ borderColor: 'var(--color-separator)' }}>
                     {!isSelector && (
-                      <p className="text-[11px] mb-2.5" style={{ color: '#8e8e93' }}>
+                      <p className="text-[11px] mb-2.5" style={{ color: 'var(--color-text-tertiary)' }}>
                         Auto-selected — click to force override
                       </p>
                     )}
@@ -210,7 +210,7 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                               {isSelected && <Check size={11} className="text-white flex-shrink-0" />}
                               <div
                                 className="text-[12px] font-medium truncate"
-                                style={{ color: isSelected ? 'white' : '#1d1d1f' }}
+                                style={{ color: isSelected ? 'white' : 'var(--color-text-primary)' }}
                               >
                                 {proxyName}
                               </div>
@@ -233,7 +233,7 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                         const chipStyle = {
                           ...(isSelected
                             ? { background: '#0071e3', borderColor: '#0071e3' }
-                            : { background: 'white', borderColor: 'rgba(0,0,0,0.06)' }),
+                            : { background: 'var(--color-input-focus-bg)', borderColor: 'var(--color-separator)' }),
                         };
 
                         return isSelector ? (

--- a/clash-dashboard/src/components/ProxyGroups.tsx
+++ b/clash-dashboard/src/components/ProxyGroups.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getProxies, selectProxy, getGroupDelay } from '../lib/api';
+import { getProxies, getProxyProviders, selectProxy, getGroupDelay } from '../lib/api';
 import { RefreshCw, ChevronDown, ChevronUp, Check } from 'lucide-react';
 import type { Proxy } from '../lib/api';
 
@@ -44,11 +44,18 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
   const queryClient = useQueryClient();
   const [testingGroups, setTestingGroups] = useState<Set<string>>(new Set());
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [groupLatencyMap, setGroupLatencyMap] = useState<Record<string, number>>({});
 
   const { data, isLoading } = useQuery({
     queryKey: ['proxies'],
     queryFn: getProxies,
     refetchInterval: 30000,
+  });
+
+  const { data: providersData } = useQuery({
+    queryKey: ['providers'],
+    queryFn: getProxyProviders,
+    refetchInterval: 60000,
   });
 
   const selectMutation = useMutation({
@@ -73,6 +80,14 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
   });
 
   const proxies = data?.proxies ?? {};
+
+  // Merge provider proxies so group chips show latency for provider-sourced members
+  const mergedProxies: Record<string, Proxy> = {};
+  for (const p of Object.values(providersData?.providers ?? {})) {
+    for (const px of p.proxies ?? []) mergedProxies[px.name] = px;
+  }
+  Object.assign(mergedProxies, proxies); // registry entries take precedence
+
   const globalGroup = proxies['GLOBAL'];
   const sortIndex: string[] = globalGroup?.all ?? [];
 
@@ -110,8 +125,16 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
     setTestingGroups((s) => new Set(s).add(group.name));
     setExpanded((prev) => new Set(prev).add(group.name));
     try {
-      await getGroupDelay(group.name, TEST_URL, TEST_TIMEOUT);
-      await queryClient.invalidateQueries({ queryKey: ['proxies'] });
+      const result = await getGroupDelay(group.name, TEST_URL, TEST_TIMEOUT);
+      // result is { [groupName]: latencyMs } — store the group's own latency
+      const ms = result[group.name];
+      if (ms !== undefined) {
+        setGroupLatencyMap((prev) => ({ ...prev, [group.name]: ms }));
+      }
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: ['proxies'] }),
+        queryClient.refetchQueries({ queryKey: ['providers'] }),
+      ]);
     } catch {
       // leave existing latency values unchanged on error
     } finally {
@@ -142,6 +165,11 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
         const isSelector = group.type === 'Selector';
         const accentColor = getGroupAccentColor(group.type);
         const typeBadge = getTypeBadgeStyle(group.type);
+        // Group's own latency: from last test result, falling back to group history
+        const groupProxy = proxies[group.name];
+        const historyLatency = getLastDelay(groupProxy?.history);
+        const headerLatency = groupLatencyMap[group.name] ?? historyLatency;
+        const headerLatencyColor = getLatencyColor(headerLatency);
 
         return (
           <div
@@ -172,6 +200,11 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                         {group.now}
                       </span>
                     )}
+                    {headerLatency !== undefined && (
+                      <span className="text-[11px] font-mono flex-shrink-0" style={{ color: headerLatencyColor }}>
+                        {headerLatency === 0 ? 'Timeout' : `${headerLatency}ms`}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 flex-shrink-0 ml-2">
                     <button
@@ -199,7 +232,7 @@ export function ProxyGroups({ mode }: ProxyGroupsProps) {
                     )}
                     <div className="grid grid-cols-3 sm:grid-cols-4 gap-1.5">
                       {group.all?.map((proxyName) => {
-                        const proxy = proxies[proxyName];
+                        const proxy = mergedProxies[proxyName];
                         const history = proxy?.history ?? [];
                         const latency = getLastDelay(history);
                         const isSelected = group.now === proxyName;

--- a/clash-dashboard/src/components/ThemeToggle.tsx
+++ b/clash-dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+import { Monitor, Sun, Moon } from 'lucide-react';
+import { useTheme, type Theme } from '../hooks/useTheme';
+
+const OPTIONS: { value: Theme; icon: React.ReactNode; label: string }[] = [
+  { value: 'system', icon: <Monitor size={13} />, label: 'System' },
+  { value: 'light',  icon: <Sun size={13} />,     label: 'Light'  },
+  { value: 'dark',   icon: <Moon size={13} />,    label: 'Dark'   },
+];
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div
+      className="flex items-center rounded-full p-0.5 flex-shrink-0"
+      style={{ background: 'var(--color-fill-medium)' }}
+      title="Toggle theme"
+    >
+      {OPTIONS.map(({ value, icon, label }) => {
+        const active = theme === value;
+        return (
+          <button
+            key={value}
+            onClick={() => setTheme(value)}
+            title={label}
+            aria-label={label}
+            className="w-7 h-6 rounded-full flex items-center justify-center transition-all"
+            style={{
+              background: active ? 'var(--color-input-focus-bg)' : 'transparent',
+              color: active ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+              boxShadow: active ? '0 1px 3px rgba(0,0,0,0.12)' : 'none',
+            }}
+          >
+            {icon}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/clash-dashboard/src/components/ThemeToggle.tsx
+++ b/clash-dashboard/src/components/ThemeToggle.tsx
@@ -12,6 +12,8 @@ export function ThemeToggle() {
 
   return (
     <div
+      role="group"
+      aria-label="Theme"
       className="flex items-center rounded-full p-0.5 flex-shrink-0"
       style={{ background: 'var(--color-fill-medium)' }}
       title="Toggle theme"
@@ -24,6 +26,7 @@ export function ThemeToggle() {
             onClick={() => setTheme(value)}
             title={label}
             aria-label={label}
+            aria-pressed={active}
             className="w-7 h-6 rounded-full flex items-center justify-center transition-all"
             style={{
               background: active ? 'var(--color-input-focus-bg)' : 'transparent',

--- a/clash-dashboard/src/components/ui/card.tsx
+++ b/clash-dashboard/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn("text-[13px]", className)}
-      style={{ color: '#6e6e73' }}
+      style={{ color: 'var(--color-text-secondary)' }}
       {...props}
     />
   )
@@ -60,7 +60,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn("flex items-center rounded-b-xl border-t px-4 py-3", className)}
-      style={{ borderColor: 'rgba(0,0,0,0.06)', background: 'rgba(0,0,0,0.02)' }}
+      style={{ borderColor: 'var(--color-separator)', background: 'var(--color-fill-subtle)' }}
       {...props}
     />
   )

--- a/clash-dashboard/src/hooks/useTheme.ts
+++ b/clash-dashboard/src/hooks/useTheme.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+export type Theme = 'system' | 'light' | 'dark';
+
+const STORAGE_KEY = 'clash-rs-theme';
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  if (theme === 'system') {
+    root.removeAttribute('data-theme');
+  } else {
+    root.setAttribute('data-theme', theme);
+  }
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    return stored ?? 'system';
+  });
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // Apply on mount (before first render flicker)
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored) applyTheme(stored);
+  }, []);
+
+  function setTheme(t: Theme) {
+    localStorage.setItem(STORAGE_KEY, t);
+    setThemeState(t);
+    applyTheme(t);
+  }
+
+  return { theme, setTheme };
+}

--- a/clash-dashboard/src/hooks/useTheme.ts
+++ b/clash-dashboard/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 export type Theme = 'system' | 'light' | 'dark';
 
@@ -19,20 +19,14 @@ export function useTheme() {
     return stored ?? 'system';
   });
 
-  useEffect(() => {
+  // useLayoutEffect applies data-theme before paint, preventing flash on load
+  useLayoutEffect(() => {
     applyTheme(theme);
   }, [theme]);
-
-  // Apply on mount (before first render flicker)
-  useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    if (stored) applyTheme(stored);
-  }, []);
 
   function setTheme(t: Theme) {
     localStorage.setItem(STORAGE_KEY, t);
     setThemeState(t);
-    applyTheme(t);
   }
 
   return { theme, setTheme };

--- a/clash-dashboard/src/hooks/useTheme.ts
+++ b/clash-dashboard/src/hooks/useTheme.ts
@@ -15,8 +15,10 @@ function applyTheme(theme: Theme) {
 
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    return stored ?? 'system';
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'system' || stored === 'light' || stored === 'dark'
+      ? stored
+      : 'system';
   });
 
   // useLayoutEffect applies data-theme before paint, preventing flash on load

--- a/clash-dashboard/src/index.css
+++ b/clash-dashboard/src/index.css
@@ -301,9 +301,11 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); }
+  :root:not([data-theme="light"]) ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.25); }
 }
 
 :root[data-theme="dark"] ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); }
+:root[data-theme="dark"] ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.25); }
 
 .uplot canvas { border-radius: 8px; }
 

--- a/clash-dashboard/src/index.css
+++ b/clash-dashboard/src/index.css
@@ -5,6 +5,65 @@
 
 * { box-sizing: border-box; }
 
+/* ─── Theme tokens ────────────────────────────────────────────────────────── */
+:root {
+  --color-text-primary:    #1d1d1f;
+  --color-text-secondary:  #6e6e73;
+  --color-text-tertiary:   #8e8e93;
+  --color-separator:       rgba(0, 0, 0, 0.06);
+  --color-separator-subtle: rgba(0, 0, 0, 0.04);
+  --color-border:          rgba(0, 0, 0, 0.08);
+  --color-fill-subtle:     rgba(0, 0, 0, 0.04);
+  --color-fill-medium:     rgba(0, 0, 0, 0.06);
+  --color-fill-strong:     rgba(0, 0, 0, 0.10);
+  --color-input-bg:        rgba(255, 255, 255, 0.8);
+  --color-input-focus-bg:  #ffffff;
+  --color-proxy-card-bg:   rgba(255, 255, 255, 0.6);
+  --color-surface-float:   rgba(255, 255, 255, 0.97);
+  --color-toggle-off:      rgba(0, 0, 0, 0.15);
+  --color-bar-track:       rgba(0, 0, 0, 0.06);
+}
+
+/* System dark mode (only when no manual override) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-text-primary:    #f5f5f7;
+    --color-text-secondary:  #98989d;
+    --color-text-tertiary:   #6e6e73;
+    --color-separator:       rgba(255, 255, 255, 0.08);
+    --color-separator-subtle: rgba(255, 255, 255, 0.05);
+    --color-border:          rgba(255, 255, 255, 0.12);
+    --color-fill-subtle:     rgba(255, 255, 255, 0.06);
+    --color-fill-medium:     rgba(255, 255, 255, 0.10);
+    --color-fill-strong:     rgba(255, 255, 255, 0.14);
+    --color-input-bg:        rgba(255, 255, 255, 0.08);
+    --color-input-focus-bg:  rgba(255, 255, 255, 0.13);
+    --color-proxy-card-bg:   rgba(58, 58, 60, 0.85);
+    --color-surface-float:   rgba(36, 36, 38, 0.97);
+    --color-toggle-off:      rgba(255, 255, 255, 0.18);
+    --color-bar-track:       rgba(255, 255, 255, 0.10);
+  }
+}
+
+/* Manual dark override */
+:root[data-theme="dark"] {
+  --color-text-primary:    #f5f5f7;
+  --color-text-secondary:  #98989d;
+  --color-text-tertiary:   #6e6e73;
+  --color-separator:       rgba(255, 255, 255, 0.08);
+  --color-separator-subtle: rgba(255, 255, 255, 0.05);
+  --color-border:          rgba(255, 255, 255, 0.12);
+  --color-fill-subtle:     rgba(255, 255, 255, 0.06);
+  --color-fill-medium:     rgba(255, 255, 255, 0.10);
+  --color-fill-strong:     rgba(255, 255, 255, 0.14);
+  --color-input-bg:        rgba(255, 255, 255, 0.08);
+  --color-input-focus-bg:  rgba(255, 255, 255, 0.13);
+  --color-proxy-card-bg:   rgba(58, 58, 60, 0.85);
+  --color-surface-float:   rgba(36, 36, 38, 0.97);
+  --color-toggle-off:      rgba(255, 255, 255, 0.18);
+  --color-bar-track:       rgba(255, 255, 255, 0.10);
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif;
@@ -18,12 +77,19 @@ body {
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
+  :root:not([data-theme="light"]) body {
     background: radial-gradient(ellipse at 20% 50%, rgba(0,113,227,0.08) 0%, transparent 50%),
                 radial-gradient(ellipse at 80% 20%, rgba(52,199,89,0.08) 0%, transparent 50%),
                 #1c1c1e;
     color: #f5f5f7;
   }
+}
+
+:root[data-theme="dark"] body {
+  background: radial-gradient(ellipse at 20% 50%, rgba(0,113,227,0.08) 0%, transparent 50%),
+              radial-gradient(ellipse at 80% 20%, rgba(52,199,89,0.08) 0%, transparent 50%),
+              #1c1c1e;
+  color: #f5f5f7;
 }
 
 /* ─── Liquid Glass ────────────────────────────────────────────────────────── */
@@ -63,7 +129,7 @@ body {
 .liquid-glass > * { position: relative; z-index: 1; }
 
 @media (prefers-color-scheme: dark) {
-  .liquid-glass {
+  :root:not([data-theme="light"]) .liquid-glass {
     background: rgba(28, 28, 30, 0.78);
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     box-shadow:
@@ -71,7 +137,7 @@ body {
       0 1px 0 rgba(0, 0, 0, 0.4),
       0 8px 32px rgba(0, 0, 0, 0.45);
   }
-  .liquid-glass::before {
+  :root:not([data-theme="light"]) .liquid-glass::before {
     background: linear-gradient(
       118deg,
       rgba(255, 255, 255, 0.1) 0%,
@@ -80,6 +146,25 @@ body {
       rgba(255, 255, 255, 0.04) 100%
     );
   }
+}
+
+:root[data-theme="dark"] .liquid-glass {
+  background: rgba(28, 28, 30, 0.78);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    inset 0 1.5px 0 rgba(255, 255, 255, 0.14),
+    0 1px 0 rgba(0, 0, 0, 0.4),
+    0 8px 32px rgba(0, 0, 0, 0.45);
+}
+
+:root[data-theme="dark"] .liquid-glass::before {
+  background: linear-gradient(
+    118deg,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.02) 30%,
+    rgba(255, 255, 255, 0.0) 55%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
 }
 
 /* Card: content cards (subtler, frosted white) */
@@ -114,20 +199,36 @@ body {
 .liquid-glass-card > * { position: relative; z-index: 1; }
 
 @media (prefers-color-scheme: dark) {
-  .liquid-glass-card {
+  :root:not([data-theme="light"]) .liquid-glass-card {
     background: rgba(44, 44, 46, 0.82);
     border: 1px solid rgba(255, 255, 255, 0.08);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.1),
       0 4px 20px rgba(0, 0, 0, 0.35);
   }
-  .liquid-glass-card::before {
+  :root:not([data-theme="light"]) .liquid-glass-card::before {
     background: linear-gradient(
       150deg,
       rgba(255, 255, 255, 0.07) 0%,
       rgba(255, 255, 255, 0.0) 40%
     );
   }
+}
+
+:root[data-theme="dark"] .liquid-glass-card {
+  background: rgba(44, 44, 46, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 4px 20px rgba(0, 0, 0, 0.35);
+}
+
+:root[data-theme="dark"] .liquid-glass-card::before {
+  background: linear-gradient(
+    150deg,
+    rgba(255, 255, 255, 0.07) 0%,
+    rgba(255, 255, 255, 0.0) 40%
+  );
 }
 
 /* Vivid card shimmer sweep (animated light streak across gradient cards) */
@@ -170,14 +271,39 @@ body {
     0 2px 8px rgba(0, 113, 227, 0.15);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .nav-pill-glass {
+    background: rgba(0, 113, 227, 0.2);
+    border-color: rgba(0, 113, 227, 0.35);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 2px 8px rgba(0,113,227,0.25);
+  }
+}
+
+:root[data-theme="dark"] .nav-pill-glass {
+  background: rgba(0, 113, 227, 0.2);
+  border-color: rgba(0, 113, 227, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 2px 8px rgba(0,113,227,0.25);
+}
+
+/* ─── Nav inactive link ───────────────────────────────────────────────────── */
+.nav-inactive { color: var(--color-text-secondary); }
+.nav-inactive:hover { color: var(--color-text-primary); background: var(--color-fill-medium); }
+
+/* ─── Config input ────────────────────────────────────────────────────────── */
+.config-input { background: var(--color-fill-subtle); }
+.config-input:focus { background: var(--color-input-focus-bg); }
+
 /* ─── Scrollbars ──────────────────────────────────────────────────────────── */
 ::-webkit-scrollbar { width: 4px; height: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.15); border-radius: 4px; }
 ::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,0.25); }
+
 @media (prefers-color-scheme: dark) {
-  ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); }
+  :root:not([data-theme="light"]) ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); }
 }
+
+:root[data-theme="dark"] ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); }
 
 .uplot canvas { border-radius: 8px; }
 

--- a/clash-dashboard/src/lib/api.ts
+++ b/clash-dashboard/src/lib/api.ts
@@ -176,7 +176,12 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   if (!raw.trim()) {
     return undefined as T;
   }
-  return JSON.parse(raw) as T;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    // Plain-text 2xx response (e.g. "provider healthcheck") — treat as void
+    return undefined as T;
+  }
 }
 
 // Version

--- a/clash-dashboard/src/lib/api.ts
+++ b/clash-dashboard/src/lib/api.ts
@@ -177,7 +177,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   if (!raw.trim() || !contentType.includes('application/json')) {
     return undefined as T;
   }
-  return JSON.parse(raw) as T;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new Error(`Invalid JSON response from ${path}`);
+  }
 }
 
 // Version

--- a/clash-dashboard/src/lib/api.ts
+++ b/clash-dashboard/src/lib/api.ts
@@ -241,7 +241,7 @@ export const updateRuleProvider = (name: string) =>
 export const getRuleProviderRules = (name: string) =>
   request<{ rules: string[] }>(`/providers/rules/${encodeURIComponent(name)}/rules`);
 export const matchRuleProvider = (name: string, target: string) =>
-  request<{ match: boolean }>(`/providers/rules/${encodeURIComponent(name)}/match?target=${encodeURIComponent(target)}`);
+  request<{ match: boolean; rule?: string }>(`/providers/rules/${encodeURIComponent(name)}/match?target=${encodeURIComponent(target)}`);
 
 // Rules
 export const getRules = () => request<{ rules: Rule[] }>('/rules');

--- a/clash-dashboard/src/lib/api.ts
+++ b/clash-dashboard/src/lib/api.ts
@@ -172,16 +172,12 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     return undefined as T;
   }
 
+  const contentType = response.headers.get('content-type') ?? '';
   const raw = await response.text();
-  if (!raw.trim()) {
+  if (!raw.trim() || !contentType.includes('application/json')) {
     return undefined as T;
   }
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    // Plain-text 2xx response (e.g. "provider healthcheck") — treat as void
-    return undefined as T;
-  }
+  return JSON.parse(raw) as T;
 }
 
 // Version

--- a/clash-dashboard/src/pages/Connections.tsx
+++ b/clash-dashboard/src/pages/Connections.tsx
@@ -56,7 +56,7 @@ export function Connections() {
     <div className="p-6 space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Connections</h1>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Connections</h1>
         <button
           onClick={() => closeAllMutation.mutate()}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors"
@@ -70,7 +70,7 @@ export function Connections() {
       {/* Summary InsetGroup card */}
       <div
         className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
-        style={{ color: '#6e6e73' }}
+        style={{ color: 'var(--color-text-secondary)' }}
       >
         Summary
       </div>
@@ -100,19 +100,19 @@ export function Connections() {
             className="flex items-center gap-3 px-4"
             style={{
               minHeight: 52,
-              borderBottom: idx < arr.length - 1 ? '1px solid rgba(0,0,0,0.06)' : 'none',
+              borderBottom: idx < arr.length - 1 ? '1px solid var(--color-separator)' : 'none',
             }}
           >
             <IconBadge bg={row.bg}>{row.icon}</IconBadge>
-            <span className="text-[15px] flex-1" style={{ color: '#1d1d1f' }}>{row.label}</span>
-            <span className="text-[15px] font-mono" style={{ color: '#6e6e73' }}>{row.value}</span>
+            <span className="text-[15px] flex-1" style={{ color: 'var(--color-text-primary)' }}>{row.label}</span>
+            <span className="text-[15px] font-mono" style={{ color: 'var(--color-text-secondary)' }}>{row.value}</span>
           </div>
         ))}
       </div>
 
       {/* Search */}
       <div className="relative">
-        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: '#8e8e93' }} />
+        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: 'var(--color-text-tertiary)' }} />
         <input
           type="text"
           aria-label="Filter connections by host, rule, or chain"
@@ -121,10 +121,10 @@ export function Connections() {
           onChange={(e) => setSearch(e.target.value)}
           className="w-full pl-10 pr-4 py-2.5 rounded-xl text-[15px] focus:outline-none transition-shadow"
           style={{
-            background: 'rgba(255,255,255,0.8)',
+            background: 'var(--color-input-bg)',
             backdropFilter: 'blur(8px)',
-            border: '1px solid rgba(0,0,0,0.08)',
-            color: '#1d1d1f',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-primary)',
           }}
         />
       </div>
@@ -133,22 +133,22 @@ export function Connections() {
       <div className="liquid-glass-card rounded-xl overflow-hidden overflow-x-auto" style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}>
         <table className="table-fixed w-full text-sm">
           <thead>
-            <tr style={{ borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-52" style={{ color: '#6e6e73' }}>Host</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: '#6e6e73' }}>ASN</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-24" style={{ color: '#6e6e73' }}>Network</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: '#6e6e73' }}>Rule</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-36" style={{ color: '#6e6e73' }}>Chain</th>
-              <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Upload</th>
-              <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Download</th>
-              <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-24" style={{ color: '#6e6e73' }}>Duration</th>
+            <tr style={{ borderBottom: '1px solid var(--color-separator)' }}>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-52" style={{ color: 'var(--color-text-secondary)' }}>Host</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: 'var(--color-text-secondary)' }}>ASN</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-24" style={{ color: 'var(--color-text-secondary)' }}>Network</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: 'var(--color-text-secondary)' }}>Rule</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-36" style={{ color: 'var(--color-text-secondary)' }}>Chain</th>
+              <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: 'var(--color-text-secondary)' }}>Upload</th>
+              <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: 'var(--color-text-secondary)' }}>Download</th>
+              <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-24" style={{ color: 'var(--color-text-secondary)' }}>Duration</th>
               <th className="px-4 py-3 w-10"></th>
             </tr>
           </thead>
           <tbody>
             {filtered.length === 0 ? (
               <tr>
-                <td colSpan={9} className="text-center py-10 text-[15px]" style={{ color: '#8e8e93' }}>
+                <td colSpan={9} className="text-center py-10 text-[15px]" style={{ color: 'var(--color-text-tertiary)' }}>
                   No active connections
                 </td>
               </tr>
@@ -157,32 +157,32 @@ export function Connections() {
                 <tr
                   key={conn.id}
                   className="group transition-colors"
-                  style={{ borderBottom: '1px solid rgba(0,0,0,0.04)' }}
+                  style={{ borderBottom: '1px solid var(--color-separator-subtle)' }}
                 >
                   <td className="px-4 py-3">
-                    <div className="text-[15px] font-medium truncate" style={{ color: '#1d1d1f' }}>
+                    <div className="text-[15px] font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
                       {conn.metadata.host || conn.metadata.destinationIP}
                       {conn.metadata.destinationPort && `:${conn.metadata.destinationPort}`}
                     </div>
                     {conn.metadata.process && (
-                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>{conn.metadata.process}</div>
+                      <div className="text-[11px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>{conn.metadata.process}</div>
                     )}
                   </td>
                   <td className="px-4 py-3 text-[12px] truncate" style={{ color: '#0071e3' }}>
                     {conn.metadata.asn || '—'}
                   </td>
-                  <td className="px-4 py-3 font-mono whitespace-nowrap text-[13px]" style={{ color: '#8e8e93' }}>
+                  <td className="px-4 py-3 font-mono whitespace-nowrap text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>
                     {conn.metadata.network}/{conn.metadata.type}
                   </td>
-                  <td className="px-4 py-3 text-[13px] truncate" style={{ color: '#6e6e73' }}>
+                  <td className="px-4 py-3 text-[13px] truncate" style={{ color: 'var(--color-text-secondary)' }}>
                     {conn.rule}{conn.rulePayload && ` (${conn.rulePayload})`}
                   </td>
-                  <td className="px-4 py-3 text-[13px] truncate" style={{ color: '#8e8e93' }}>
+                  <td className="px-4 py-3 text-[13px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>
                     {conn.chains?.join(' → ')}
                   </td>
                   <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#0071e3' }}>{formatBytes(conn.upload)}</td>
                   <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#34c759' }}>{formatBytes(conn.download)}</td>
-                  <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: '#8e8e93' }}>{formatDuration(conn.start)}</td>
+                  <td className="px-4 py-3 text-right text-[13px] font-mono" style={{ color: 'var(--color-text-tertiary)' }}>{formatDuration(conn.start)}</td>
                   <td className="px-4 py-3">
                     <button
                       onClick={() => closeOneMutation.mutate(conn.id)}

--- a/clash-dashboard/src/pages/DNS.tsx
+++ b/clash-dashboard/src/pages/DNS.tsx
@@ -14,7 +14,7 @@ function getTypeBadgeStyle(typeNum: number): { background: string; color: string
   if (type === 'A') return { background: 'rgba(52,199,89,0.1)', color: '#34c759' };
   if (type === 'AAAA') return { background: 'rgba(0,113,227,0.1)', color: '#0071e3' };
   if (type === 'CNAME') return { background: 'rgba(255,149,0,0.1)', color: '#ff9500' };
-  return { background: 'rgba(0,0,0,0.06)', color: '#6e6e73' };
+      return { background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' };
 }
 
 export function DNS() {
@@ -42,12 +42,12 @@ export function DNS() {
 
   return (
     <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>DNS Lookup</h1>
+      <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>DNS Lookup</h1>
 
       {/* Query form */}
       <div className="flex gap-2">
         <div className="flex-1 relative">
-          <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: '#8e8e93' }} />
+          <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: 'var(--color-text-tertiary)' }} />
           <input
             type="text"
             placeholder="Hostname (e.g. example.com)"
@@ -61,9 +61,9 @@ export function DNS() {
             }}
             className="w-full pl-10 pr-4 py-2.5 rounded-xl text-[15px] focus:outline-none transition-shadow"
             style={{
-              background: 'rgba(255,255,255,0.8)',
-              border: '1px solid rgba(0,0,0,0.08)',
-              color: '#1d1d1f',
+              background: 'var(--color-input-bg)',
+              border: '1px solid var(--color-border)',
+              color: 'var(--color-text-primary)',
             }}
           />
         </div>
@@ -72,9 +72,9 @@ export function DNS() {
           onChange={(e) => setType(e.target.value)}
           className="px-3 py-2.5 rounded-xl text-[15px] focus:outline-none"
           style={{
-            background: 'white',
-            border: '1px solid rgba(0,0,0,0.08)',
-            color: '#1d1d1f',
+            background: 'var(--color-input-focus-bg)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-primary)',
           }}
         >
           {DNS_TYPES.map((t) => (
@@ -109,7 +109,7 @@ export function DNS() {
             <div>
               <div
                 className="text-[11px] font-semibold uppercase tracking-[0.06em] mb-2 px-1"
-                style={{ color: '#6e6e73' }}
+                style={{ color: 'var(--color-text-secondary)' }}
               >
                 Answer
               </div>
@@ -123,12 +123,12 @@ export function DNS() {
                     className="flex items-center gap-3 px-4"
                     style={{
                       minHeight: 52,
-                      borderBottom: i < result.Answer!.length - 1 ? '1px solid rgba(0,0,0,0.06)' : 'none',
+                      borderBottom: i < result.Answer!.length - 1 ? '1px solid var(--color-separator)' : 'none',
                     }}
                   >
                     <div className="flex-1 min-w-0">
-                      <div className="font-mono text-[13px] truncate" style={{ color: '#1d1d1f' }}>{a.name}</div>
-                      <div className="font-mono text-[11px]" style={{ color: '#8e8e93' }}>{a.TTL}s TTL</div>
+                      <div className="font-mono text-[13px] truncate" style={{ color: 'var(--color-text-primary)' }}>{a.name}</div>
+                      <div className="font-mono text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>{a.TTL}s TTL</div>
                     </div>
                     <span
                       className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
@@ -157,9 +157,9 @@ export function DNS() {
           <div
             className="rounded-xl p-3 text-[11px] font-mono"
             style={{
-              background: 'white',
-              border: '1px solid rgba(0,0,0,0.06)',
-              color: '#8e8e93',
+              background: 'var(--color-input-focus-bg)',
+              border: '1px solid var(--color-separator)',
+              color: 'var(--color-text-tertiary)',
               boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
             }}
           >

--- a/clash-dashboard/src/pages/Flows.tsx
+++ b/clash-dashboard/src/pages/Flows.tsx
@@ -149,24 +149,24 @@ function LinkTooltip({ link }: { link: SankeyLinkDatum<FlowNode, FlowLink> }) {
     <div
       className="rounded-xl px-3 py-2 text-[13px] space-y-1"
       style={{
-        background: 'rgba(255,255,255,0.97)',
+        background: 'var(--color-surface-float)',
         backdropFilter: 'blur(8px)',
-        border: '1px solid rgba(0,0,0,0.08)',
+        border: '1px solid var(--color-border)',
         boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
       }}
     >
-      <div className="font-semibold text-[14px]" style={{ color: '#1d1d1f' }}>
+      <div className="font-semibold text-[14px]" style={{ color: 'var(--color-text-primary)' }}>
         {link.source.id.replace(/^src:/, '')} → {link.target.id.replace(/^dst:/, '')}
       </div>
-      <div className="flex gap-3" style={{ color: '#6e6e73' }}>
+      <div className="flex gap-3" style={{ color: 'var(--color-text-secondary)' }}>
         <span>↑ {formatBytes(link.uploadTotal)}</span>
         <span>↓ {formatBytes(link.downloadTotal)}</span>
       </div>
-      <div className="flex gap-3" style={{ color: '#6e6e73' }}>
+      <div className="flex gap-3" style={{ color: 'var(--color-text-secondary)' }}>
         <span>Conns: {link.connCount}</span>
         <span style={{ color: protocolColor(link.protocol) }}>{link.protocol}</span>
       </div>
-      <div className="text-[12px]" style={{ color: '#8e8e93' }}>Rule: {link.rule}</div>
+      <div className="text-[12px]" style={{ color: 'var(--color-text-tertiary)' }}>Rule: {link.rule}</div>
     </div>
   );
 }
@@ -273,21 +273,21 @@ export function Flows() {
       {/* Header */}
       <div className="flex items-center gap-2">
         <GitBranch size={20} style={{ color: '#0071e3' }} />
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Flows</h1>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Flows</h1>
       </div>
 
       {/* Controls bar */}
       <div className="flex items-center gap-3 flex-wrap">
         {/* Search */}
-        <div className="flex items-center gap-2 flex-1 min-w-48 max-w-72 px-3 py-1.5 rounded-xl liquid-glass-card" style={{ border: '1px solid rgba(0,0,0,0.08)' }}>
-          <Search size={14} style={{ color: '#8e8e93', flexShrink: 0 }} />
+        <div className="flex items-center gap-2 flex-1 min-w-48 max-w-72 px-3 py-1.5 rounded-xl liquid-glass-card" style={{ border: '1px solid var(--color-border)' }}>
+          <Search size={14} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
           <input
             type="text"
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Filter destination…"
             className="flex-1 bg-transparent outline-none text-[14px]"
-            style={{ color: '#1d1d1f' }}
+            style={{ color: 'var(--color-text-primary)' }}
           />
         </div>
 
@@ -310,7 +310,7 @@ export function Flows() {
         </div>
 
         {/* Include closed toggle */}
-        <label className="flex items-center gap-2 ml-auto cursor-pointer select-none" style={{ color: '#6e6e73', fontSize: 13 }}>
+        <label className="flex items-center gap-2 ml-auto cursor-pointer select-none" style={{ color: 'var(--color-text-secondary)', fontSize: 13 }}>
           <span>Include closed</span>
           <div
             className="relative w-9 h-5 rounded-full transition-colors"
@@ -333,7 +333,7 @@ export function Flows() {
       {/* Summary cards */}
       <div
         className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
-        style={{ color: '#6e6e73' }}
+        style={{ color: 'var(--color-text-secondary)' }}
       >
         Summary
       </div>
@@ -366,12 +366,12 @@ export function Flows() {
             className="flex items-center gap-3 px-4"
             style={{
               minHeight: 52,
-              borderBottom: idx < arr.length - 1 ? '1px solid rgba(0,0,0,0.06)' : 'none',
+              borderBottom: idx < arr.length - 1 ? '1px solid var(--color-separator)' : 'none',
             }}
           >
             <IconBadge bg={row.bg}>{row.icon}</IconBadge>
-            <span className="text-[15px] flex-1" style={{ color: '#1d1d1f' }}>{row.label}</span>
-            <span className="text-[15px] font-mono truncate max-w-48" style={{ color: '#6e6e73' }}>{row.value}</span>
+            <span className="text-[15px] flex-1" style={{ color: 'var(--color-text-primary)' }}>{row.label}</span>
+            <span className="text-[15px] font-mono truncate max-w-48" style={{ color: 'var(--color-text-secondary)' }}>{row.value}</span>
           </div>
         ))}
       </div>
@@ -379,7 +379,7 @@ export function Flows() {
       {/* Sankey diagram */}
       <div
         className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
-        style={{ color: '#6e6e73' }}
+        style={{ color: 'var(--color-text-secondary)' }}
       >
         Flow Map (top 15 destinations)
       </div>
@@ -393,7 +393,7 @@ export function Flows() {
                 className="w-2.5 h-2.5 rounded-sm"
                 style={{ background: protocolColor(proto) }}
               />
-              <span className="text-[12px]" style={{ color: '#6e6e73' }}>{proto}</span>
+              <span className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>{proto}</span>
             </div>
           ))}
         </div>
@@ -433,7 +433,7 @@ export function Flows() {
           />
         ) : (
           <div className="h-full flex items-center justify-center">
-            <span className="text-[15px]" style={{ color: '#8e8e93' }}>
+            <span className="text-[15px]" style={{ color: 'var(--color-text-tertiary)' }}>
               {flows.length === 0 ? 'Waiting for flow data…' : 'Not enough data to render diagram'}
             </span>
           </div>
@@ -443,7 +443,7 @@ export function Flows() {
       {/* Flow table */}
       <div
         className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
-        style={{ color: '#6e6e73' }}
+        style={{ color: 'var(--color-text-secondary)' }}
       >
         Flow Table (top 50)
       </div>
@@ -453,23 +453,23 @@ export function Flows() {
       >
         <table className="table-fixed w-full text-sm">
           <thead>
-            <tr style={{ borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-48" style={{ color: '#6e6e73' }}>Destination</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-16" style={{ color: '#6e6e73' }}>Port</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Protocol</th>
+            <tr style={{ borderBottom: '1px solid var(--color-separator)' }}>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-48" style={{ color: 'var(--color-text-secondary)' }}>Destination</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-16" style={{ color: 'var(--color-text-secondary)' }}>Port</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: 'var(--color-text-secondary)' }}>Protocol</th>
               <SortHeader field="connCount" label="Conns" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
               <SortHeader field="uploadTotal" label="↑ Upload" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
               <SortHeader field="downloadTotal" label="↓ Download" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
               <SortHeader field="bytesTotal" label="Total" current={sortField} dir={sortDir} onClick={toggleSort} width="w-24" />
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: '#6e6e73' }}>Last Seen</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: '#6e6e73' }}>Rule</th>
-              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-40" style={{ color: '#6e6e73' }}>Proxy Chain</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-20" style={{ color: 'var(--color-text-secondary)' }}>Last Seen</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-32" style={{ color: 'var(--color-text-secondary)' }}>Rule</th>
+              <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] w-40" style={{ color: 'var(--color-text-secondary)' }}>Proxy Chain</th>
             </tr>
           </thead>
           <tbody>
             {sortedFlows.length === 0 ? (
               <tr>
-                <td colSpan={10} className="text-center py-10 text-[15px]" style={{ color: '#8e8e93' }}>
+                <td colSpan={10} className="text-center py-10 text-[15px]" style={{ color: 'var(--color-text-tertiary)' }}>
                   No flow data yet
                 </td>
               </tr>
@@ -478,19 +478,19 @@ export function Flows() {
                 <tr
                   key={`${flow.dstHost}-${flow.dstPort}-${flow.protocol}-${idx}`}
                   className="group transition-colors"
-                  style={{ borderBottom: '1px solid rgba(0,0,0,0.04)' }}
+                  style={{ borderBottom: '1px solid var(--color-separator-subtle)' }}
                 >
                   <td className="px-4 py-3" title={flow.srcIps.length > 0 ? `Sources: ${flow.srcIps.join(', ')}` : undefined}>
-                    <div className="text-[14px] font-medium truncate" style={{ color: '#1d1d1f' }}>
+                    <div className="text-[14px] font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
                       {flow.dstHost || '—'}
                     </div>
                     {flow.srcIps.length > 0 && (
-                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>
+                      <div className="text-[11px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>
                         {flow.srcIps[0]}{flow.srcIps.length > 1 ? ` +${flow.srcIps.length - 1}` : ''}
                       </div>
                     )}
                   </td>
-                  <td className="px-4 py-3 font-mono text-[13px]" style={{ color: '#8e8e93' }}>
+                  <td className="px-4 py-3 font-mono text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>
                     {flow.dstPort}
                   </td>
                   <td className="px-4 py-3">
@@ -510,7 +510,7 @@ export function Flows() {
                         className="w-1.5 h-1.5 rounded-full flex-shrink-0"
                         style={{ background: flow.activeCount > 0 ? '#34c759' : '#8e8e93' }}
                       />
-                      <span className="text-[13px] font-mono" style={{ color: '#6e6e73' }}>
+                      <span className="text-[13px] font-mono" style={{ color: 'var(--color-text-secondary)' }}>
                         {flow.connCount}
                       </span>
                     </div>
@@ -524,16 +524,16 @@ export function Flows() {
                   <td className="px-4 py-3 text-right text-[13px] font-mono font-semibold" style={{ color: '#ff9500' }}>
                     {formatBytes(flow.bytesTotal)}
                   </td>
-                  <td className="px-4 py-3 text-[12px]" style={{ color: '#8e8e93' }}>
+                  <td className="px-4 py-3 text-[12px]" style={{ color: 'var(--color-text-tertiary)' }}>
                     {formatRelative(flow.lastSeen)}
                   </td>
                   <td className="px-4 py-3">
-                    <div className="text-[12px] truncate" style={{ color: '#6e6e73' }}>{flow.rule}</div>
+                    <div className="text-[12px] truncate" style={{ color: 'var(--color-text-secondary)' }}>{flow.rule}</div>
                     {flow.rulePayload && (
-                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>{flow.rulePayload}</div>
+                      <div className="text-[11px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>{flow.rulePayload}</div>
                     )}
                   </td>
-                  <td className="px-4 py-3 text-[12px] truncate" style={{ color: '#8e8e93' }}>
+                  <td className="px-4 py-3 text-[12px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>
                     {flow.chains?.join(' → ')}
                   </td>
                 </tr>
@@ -548,7 +548,7 @@ export function Flows() {
         <>
           <div
             className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
-            style={{ color: '#6e6e73' }}
+            style={{ color: 'var(--color-text-secondary)' }}
           >
             Traffic by Country / ASN
           </div>
@@ -561,18 +561,18 @@ export function Flows() {
               return (
                 <div key={key} className="flex items-center gap-3">
                   <div className="w-40 flex-shrink-0">
-                    <div className="text-[13px] truncate" style={{ color: '#1d1d1f' }}>{label}</div>
+                    <div className="text-[13px] truncate" style={{ color: 'var(--color-text-primary)' }}>{label}</div>
                     {isCountry && asn && (
-                      <div className="text-[11px] truncate" style={{ color: '#8e8e93' }}>{asn}</div>
+                      <div className="text-[11px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>{asn}</div>
                     )}
                   </div>
-                  <div className="flex-1 h-2 rounded-full overflow-hidden" style={{ background: 'rgba(0,0,0,0.06)' }}>
+                  <div className="flex-1 h-2 rounded-full overflow-hidden" style={{ background: 'var(--color-bar-track)' }}>
                     <div
                       className="h-full rounded-full transition-all"
                       style={{ width: `${pct * 100}%`, background: '#0071e3' }}
                     />
                   </div>
-                  <div className="w-20 text-right text-[12px] font-mono flex-shrink-0" style={{ color: '#6e6e73' }}>
+                  <div className="w-20 text-right text-[12px] font-mono flex-shrink-0" style={{ color: 'var(--color-text-secondary)' }}>
                     {formatBytes(bytes)}
                   </div>
                 </div>
@@ -601,7 +601,7 @@ function SortHeader({
     <th
       aria-sort={field === current ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
       className={`text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.06em] select-none ${width}`}
-      style={{ color: field === current ? '#0071e3' : '#6e6e73' }}
+      style={{ color: field === current ? '#0071e3' : 'var(--color-text-secondary)' }}
     >
       <button
         type="button"

--- a/clash-dashboard/src/pages/Logs.tsx
+++ b/clash-dashboard/src/pages/Logs.tsx
@@ -32,7 +32,7 @@ function WsStatus({ state }: { state: string }) {
   const isOpen = state === 'OPEN';
   const isConnecting = state === 'CONNECTING';
   return (
-    <span className="flex items-center gap-1.5 text-[11px]" style={{ color: '#6e6e73' }}>
+    <span className="flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--color-text-secondary)' }}>
       <span
         className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${isConnecting ? 'animate-pulse' : ''}`}
         style={{ background: isOpen ? '#34c759' : isConnecting ? '#ff9500' : '#ff3b30' }}
@@ -74,7 +74,7 @@ export function Logs() {
       {/* Toolbar */}
       <div className="flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-[#1d1d1f] dark:text-white">Logs</h1>
+          <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Logs</h1>
           <WsStatus state={readyState} />
         </div>
         <div className="flex items-center gap-2">
@@ -86,8 +86,8 @@ export function Logs() {
                 <button
                   key={l}
                   onClick={() => setLevel(l)}
-                  className={`px-3 py-1.5 rounded-full text-[12px] font-medium capitalize transition-all ${active ? '' : 'text-[#6e6e73] dark:text-white/60'}`}
-                  style={active ? LEVEL_ACTIVE_STYLE[l] : undefined}
+                  className={`px-3 py-1.5 rounded-full text-[12px] font-medium capitalize transition-all ${active ? '' : ''}`}
+                  style={active ? LEVEL_ACTIVE_STYLE[l] : { color: 'var(--color-text-secondary)' }}
                 >
                   {l}
                 </button>
@@ -102,14 +102,14 @@ export function Logs() {
             className="px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors"
             style={userPaused
               ? { background: 'rgba(255,149,0,0.1)', color: '#ff9500' }
-              : { background: 'rgba(0,0,0,0.05)', color: '#6e6e73' }}
+              : { background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
           >
             {userPaused ? 'Resume' : 'Pause'}
           </button>
           <button
             onClick={() => setLogs([])}
             className="px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors"
-            style={{ background: 'rgba(0,0,0,0.05)', color: '#6e6e73' }}
+            style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
           >
             Clear
           </button>
@@ -124,14 +124,14 @@ export function Logs() {
         onMouseLeave={() => setHoverPaused(false)}
       >
         {filtered.length === 0 ? (
-          <div className="text-[13px] text-center py-10" style={{ color: '#6e6e73' }}>
+          <div className="text-[13px] text-center py-10" style={{ color: 'var(--color-text-secondary)' }}>
             {readyState === 'OPEN' ? 'Waiting for logs…' : readyState === 'CONNECTING' ? 'Connecting…' : 'Disconnected — check API settings'}
           </div>
         ) : (
           <div className="space-y-0.5">
             {filtered.map((log) => (
               <div key={log.id} className="flex items-baseline gap-3 py-0.5">
-                <span className="font-mono text-[11px] flex-shrink-0 w-20" style={{ color: '#6e6e73' }}>
+                <span className="font-mono text-[11px] flex-shrink-0 w-20" style={{ color: 'var(--color-text-secondary)' }}>
                   {log.ts}
                 </span>
                 <div

--- a/clash-dashboard/src/pages/Overview.tsx
+++ b/clash-dashboard/src/pages/Overview.tsx
@@ -89,7 +89,7 @@ function ToggleSwitch({ value, onChange }: { value: boolean; onChange: (v: boole
     <button
       onClick={() => onChange(!value)}
       className="w-10 h-6 rounded-full transition-colors flex-shrink-0 relative"
-      style={{ background: value ? '#34c759' : 'rgba(0,0,0,0.15)' }}
+      style={{ background: value ? '#34c759' : 'var(--color-toggle-off)' }}
     >
       <span
         className="absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-all"
@@ -108,7 +108,7 @@ function PortInput({ value, onCommit }: { value: number | undefined; onCommit: (
       onChange={(e) => setLocal(e.target.value)}
       onBlur={() => { const n = parseInt(local, 10); onCommit(!local || isNaN(n) ? null : n); }}
       onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
-      className="form-input w-24 text-right text-[13px] font-mono rounded-lg border-0 bg-black/[0.04] focus:ring-2 focus:ring-[#0071e3]/30 focus:bg-white py-1 px-2 transition-all"
+      className="form-input config-input w-24 text-right text-[13px] font-mono rounded-lg border-0 focus:ring-2 focus:ring-[#0071e3]/30 py-1 px-2 transition-all"
       placeholder="disabled"
     />
   );
@@ -123,7 +123,7 @@ function TextInput({ value, onCommit }: { value: string | undefined; onCommit: (
       onChange={(e) => setLocal(e.target.value)}
       onBlur={() => onCommit(local)}
       onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
-      className="form-input w-40 text-right text-[13px] font-mono rounded-lg border-0 bg-black/[0.04] focus:ring-2 focus:ring-[#0071e3]/30 focus:bg-white py-1 px-2 transition-all"
+      className="form-input config-input w-40 text-right text-[13px] font-mono rounded-lg border-0 focus:ring-2 focus:ring-[#0071e3]/30 py-1 px-2 transition-all"
     />
   );
 }
@@ -133,7 +133,7 @@ function SelectInput({ value, options, onChange }: { value: string | undefined; 
     <select
       value={value ?? ''}
       onChange={(e) => onChange(e.target.value)}
-      className="form-select text-[13px] font-mono rounded-lg border-0 bg-black/[0.04] focus:ring-2 focus:ring-[#0071e3]/30 py-1 px-2 capitalize transition-all"
+      className="form-select config-input text-[13px] font-mono rounded-lg border-0 focus:ring-2 focus:ring-[#0071e3]/30 py-1 px-2 capitalize transition-all"
     >
       {options.map((o) => <option key={o} value={o} className="capitalize">{o}</option>)}
     </select>
@@ -142,9 +142,9 @@ function SelectInput({ value, options, onChange }: { value: string | undefined; 
 
 function EditRow({ label, icon, iconBg, children }: { label: string; icon: React.ReactNode; iconBg: string; children: React.ReactNode }) {
   return (
-    <div className="flex items-center gap-3 px-4" style={{ minHeight: 52, borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
+    <div className="flex items-center gap-3 px-4" style={{ minHeight: 52, borderBottom: '1px solid var(--color-separator)' }}>
       <IconBadge bg={iconBg}>{icon}</IconBadge>
-      <span className="text-[15px] flex-1" style={{ color: '#1d1d1f' }}>{label}</span>
+      <span className="text-[15px] flex-1" style={{ color: 'var(--color-text-primary)' }}>{label}</span>
       {children}
     </div>
   );
@@ -153,7 +153,7 @@ function EditRow({ label, icon, iconBg, children }: { label: string; icon: React
 function EditSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <div className="text-[11px] font-semibold uppercase tracking-[0.06em] mb-2 px-1" style={{ color: '#6e6e73' }}>{title}</div>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.06em] mb-2 px-1" style={{ color: 'var(--color-text-secondary)' }}>{title}</div>
       <div className="liquid-glass-card rounded-xl overflow-hidden">
         <div className="[&>*:last-child]:[border-bottom:none]">{children}</div>
       </div>
@@ -206,10 +206,10 @@ export function Overview() {
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Overview</h1>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Overview</h1>
         <div className="flex items-center gap-2">
           {patchMutation.isPending && (
-            <span className="text-[12px]" style={{ color: '#6e6e73' }}>Saving…</span>
+            <span className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>Saving…</span>
           )}
           <button
             onClick={() => reloadMutation.mutate()}
@@ -283,13 +283,13 @@ export function Overview() {
           {/* Header row */}
           <div className="p-5 flex items-center justify-between">
             <div>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.06em] mb-1" style={{ color: '#6e6e73' }}>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.06em] mb-1" style={{ color: 'var(--color-text-secondary)' }}>
                 Proxy Mode
               </div>
-              <div className="text-[13px]" style={{ color: '#6e6e73' }}>Controls how traffic is routed</div>
+              <div className="text-[13px]" style={{ color: 'var(--color-text-secondary)' }}>Controls how traffic is routed</div>
             </div>
             <div className="flex items-center gap-3">
-              <div className="flex items-center p-1 rounded-full" style={{ background: 'rgba(0,0,0,0.06)' }}>
+              <div className="flex items-center p-1 rounded-full" style={{ background: 'var(--color-fill-medium)' }}>
                 {MODES.map((m) => {
                   const active = currentMode === m;
                   return (
@@ -299,9 +299,10 @@ export function Overview() {
                       disabled={modeMutation.isPending}
                       className={`px-5 py-1.5 rounded-full text-[13px] font-medium capitalize transition-all disabled:opacity-50 ${
                         active
-                          ? (MODE_COLORS[m] ?? 'bg-white text-[#1d1d1f] shadow-sm')
-                          : 'text-[#6e6e73] hover:text-[#1d1d1f]'
+                          ? (MODE_COLORS[m] ?? 'bg-white shadow-sm')
+                          : ''
                       }`}
+                      style={{ color: active ? undefined : 'var(--color-text-secondary)' }}
                     >
                       {m.charAt(0).toUpperCase() + m.slice(1)}
                     </button>
@@ -312,7 +313,7 @@ export function Overview() {
                 <button
                   onClick={() => setProxyExpanded((v) => !v)}
                   className="p-1.5 rounded-lg transition-colors"
-                  style={{ background: 'rgba(0,0,0,0.05)', color: '#6e6e73' }}
+                  style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
                 >
                   {proxyExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
                 </button>
@@ -321,7 +322,7 @@ export function Overview() {
           </div>
           {/* Expandable proxy groups */}
           {proxyExpanded && currentMode !== 'direct' && (
-            <div className="border-t px-5 pb-5 pt-4 space-y-3" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+            <div className="border-t px-5 pb-5 pt-4 space-y-3" style={{ borderColor: 'var(--color-separator)' }}>
               <ProxyGroups mode={currentMode} />
             </div>
           )}
@@ -329,7 +330,7 @@ export function Overview() {
       )}
 
       {/* Config form — editable */}
-      {configsLoading && <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading config…</div>}
+      {configsLoading && <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading config…</div>}
       {cfg && (
         <div className="space-y-4">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
@@ -382,13 +383,13 @@ export function Overview() {
                   return a.name.localeCompare(b.name);
                 })
                 .map((l) => (
-                <div key={l.name} className="flex items-center gap-3 px-4" style={{ minHeight: 52, borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
+                <div key={l.name} className="flex items-center gap-3 px-4" style={{ minHeight: 52, borderBottom: '1px solid var(--color-separator)' }}>
                   <IconBadge bg={l.active ? '#34c759' : '#8e8e93'}>
                     <Server size={14} color="white" />
                   </IconBadge>
-                  <span className="text-[15px] flex-1" style={{ color: '#1d1d1f' }}>{l.name}</span>
+                  <span className="text-[15px] flex-1" style={{ color: 'var(--color-text-primary)' }}>{l.name}</span>
                   <span className="flex items-center gap-2">
-                    <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full" style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}>{l.type}</span>
+                    <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full" style={{ background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' }}>{l.type}</span>
                     <span className="font-mono text-[13px]">:{l.port}</span>
                     <span className="w-1.5 h-1.5 rounded-full" style={{ background: l.active ? '#34c759' : '#8e8e93' }} />
                   </span>
@@ -401,13 +402,13 @@ export function Overview() {
           <button
             onClick={() => setShowRaw((v) => !v)}
             className="flex items-center gap-2 text-[13px] transition-colors"
-            style={{ color: '#6e6e73' }}
+            style={{ color: 'var(--color-text-secondary)' }}
           >
             {showRaw ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
             {showRaw ? 'Hide' : 'Show'} Raw JSON
           </button>
           {showRaw && (
-            <pre className="liquid-glass-card rounded-xl p-5 text-[11px] overflow-auto max-h-96 font-mono" style={{ color: '#6e6e73' }}>
+            <pre className="liquid-glass-card rounded-xl p-5 text-[11px] overflow-auto max-h-96 font-mono" style={{ color: 'var(--color-text-secondary)' }}>
               {JSON.stringify(cfg, null, 2)}
             </pre>
           )}

--- a/clash-dashboard/src/pages/Providers.tsx
+++ b/clash-dashboard/src/pages/Providers.tsx
@@ -97,7 +97,7 @@ export function Providers() {
       case 'domain':    return { background: 'rgba(52,199,89,0.12)',  color: '#34c759' };
       case 'ipcidr':    return { background: 'rgba(0,113,227,0.12)',  color: '#0071e3' };
       case 'classical': return { background: 'rgba(255,149,0,0.12)', color: '#ff9500' };
-      default:          return { background: 'rgba(0,0,0,0.06)',      color: '#6e6e73' };
+      default:          return { background: 'var(--color-fill-medium)',  color: 'var(--color-text-secondary)' };
     }
   }
 
@@ -130,15 +130,15 @@ export function Providers() {
         {/* Match tester — shown for all behaviors */}
         <form onSubmit={handleMatchSubmit} className="flex gap-2 items-center">
           <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
-            style={{ background: 'rgba(0,0,0,0.03)', borderColor: 'rgba(0,0,0,0.08)' }}>
-            <Search size={13} style={{ color: '#8e8e93', flexShrink: 0 }} />
+            style={{ background: 'var(--color-fill-subtle)', borderColor: 'var(--color-border)' }}>
+            <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
             <input
               type="text"
               value={matchInput}
               onChange={(e) => setMatchInput(e.target.value)}
               placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
               className="flex-1 bg-transparent outline-none text-[13px]"
-              style={{ color: '#1d1d1f' }}
+              style={{ color: 'var(--color-text-primary)' }}
             />
           </div>
           <button
@@ -152,7 +152,7 @@ export function Providers() {
           {matchTarget !== null && (
             <div className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[12px] font-semibold flex-shrink-0"
               style={
-                matchLoading ? { background: 'rgba(0,0,0,0.05)', color: '#8e8e93' }
+                matchLoading ? { background: 'var(--color-fill-subtle)', color: 'var(--color-text-tertiary)' }
                 : matchError  ? { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
                 : matchData?.match ? { background: 'rgba(52,199,89,0.12)', color: '#34c759' }
                 : { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
@@ -169,11 +169,11 @@ export function Providers() {
         {/* Rule list — only for classical */}
         {canShowRules && (
           isLoading ? (
-            <div className="text-[13px] py-1" style={{ color: '#8e8e93' }}>Loading rules…</div>
+            <div className="text-[13px] py-1" style={{ color: 'var(--color-text-tertiary)' }}>Loading rules…</div>
           ) : isError ? (
             <div className="text-[13px] py-1" style={{ color: '#ff3b30' }}>Failed to load rules.</div>
           ) : rules.length === 0 ? (
-            <div className="text-[13px] py-1 italic" style={{ color: '#8e8e93' }}>No rules loaded</div>
+            <div className="text-[13px] py-1 italic" style={{ color: 'var(--color-text-tertiary)' }}>No rules loaded</div>
           ) : (
             <div className="max-h-64 overflow-y-auto space-y-1 pr-1">
               {rules.map((rule, i) => {
@@ -183,7 +183,7 @@ export function Providers() {
                   <div
                     key={i}
                     className="flex items-center gap-2 px-2 py-1 rounded-lg text-[12px]"
-                    style={{ background: 'rgba(0,0,0,0.03)' }}
+                    style={{ background: 'var(--color-fill-subtle)' }}
                   >
                     <span
                       className="font-mono font-semibold px-1.5 py-0.5 rounded flex-shrink-0"
@@ -191,12 +191,12 @@ export function Providers() {
                     >
                       {type}
                     </span>
-                    <span className="font-mono truncate" style={{ color: '#1d1d1f' }}>{payload}</span>
+                    <span className="font-mono truncate" style={{ color: 'var(--color-text-primary)' }}>{payload}</span>
                   </div>
                 );
               })}
               {rules.length >= 500 && (
-                <div className="text-[11px] text-center pt-1" style={{ color: '#8e8e93' }}>
+                <div className="text-[11px] text-center pt-1" style={{ color: 'var(--color-text-tertiary)' }}>
                   Showing first 500 rules
                 </div>
               )}
@@ -206,7 +206,7 @@ export function Providers() {
 
         {/* Info message for non-classical */}
         {!canShowRules && (
-          <div className="text-[12px] italic" style={{ color: '#8e8e93' }}>
+          <div className="text-[12px] italic" style={{ color: 'var(--color-text-tertiary)' }}>
             Rule entries are not enumerable for {behavior} providers — use the tester above.
           </div>
         )}
@@ -218,17 +218,17 @@ export function Providers() {
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Providers</h1>
-        <span className="text-[13px]" style={{ color: '#8e8e93' }}>{providers.length} provider{providers.length !== 1 ? 's' : ''}</span>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Providers</h1>
+        <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>{providers.length} provider{providers.length !== 1 ? 's' : ''}</span>
       </div>
 
       {isLoading ? (
-        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading providers…</div>
+        <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading providers…</div>
       ) : providers.length === 0 ? (
         <div className="liquid-glass-card rounded-2xl p-10 flex flex-col items-center gap-3 text-center">
           <div className="text-4xl">📦</div>
-          <div className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>No External Providers</div>
-          <div className="text-[13px] max-w-xs" style={{ color: '#6e6e73' }}>
+          <div className="text-[17px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>No External Providers</div>
+          <div className="text-[13px] max-w-xs" style={{ color: 'var(--color-text-secondary)' }}>
             Add proxy providers to your config to see them here.
           </div>
         </div>
@@ -247,7 +247,7 @@ export function Providers() {
                 style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
               >
                 <div className="flex">
-                  <div className="w-1 flex-shrink-0" style={{ background: '#8e8e93' }} />
+                  <div className="w-1 flex-shrink-0" style={{ background: 'var(--color-text-tertiary)' }} />
                   <div className="flex-1">
                     {/* Header */}
                     <div
@@ -256,23 +256,23 @@ export function Providers() {
                       onClick={() => toggleExpanded(provider.name)}
                     >
                       <div className="flex items-center gap-2.5 min-w-0">
-                        <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>
+                        <span className="font-semibold text-[15px] truncate" style={{ color: 'var(--color-text-primary)' }}>
                           {provider.name}
                         </span>
                         <span
                           className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                          style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}
+                          style={{ background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' }}
                         >
                           {provider.vehicleType}
                         </span>
                         <span
                           className="text-[11px] px-2 py-0.5 rounded-full flex-shrink-0"
-                          style={{ background: 'rgba(0,0,0,0.04)', color: '#8e8e93' }}
+                          style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-tertiary)' }}
                         >
                           {proxyCount} {proxyCount === 1 ? 'proxy' : 'proxies'}
                         </span>
                         {provider.updatedAt && (
-                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: '#8e8e93' }}>
+                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: 'var(--color-text-tertiary)' }}>
                             Updated {new Date(provider.updatedAt).toLocaleTimeString()}
                           </span>
                         )}
@@ -297,15 +297,15 @@ export function Providers() {
                           {isUpdating ? 'Updating…' : 'Update'}
                         </button>
                         {isExpanded
-                          ? <ChevronUp size={16} style={{ color: '#6e6e73' }} />
-                          : <ChevronDown size={16} style={{ color: '#6e6e73' }} />
+                          ? <ChevronUp size={16} style={{ color: 'var(--color-text-secondary)' }} />
+                          : <ChevronDown size={16} style={{ color: 'var(--color-text-secondary)' }} />
                         }
                       </div>
                     </div>
 
                     {/* Proxy grid */}
                     {isExpanded && provider.proxies && provider.proxies.length > 0 && (
-                      <div className="p-4 border-t" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+                      <div className="p-4 border-t" style={{ borderColor: 'var(--color-separator)' }}>
                         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
                           {provider.proxies.map((proxy) => {
                             const latency = getLastDelay(proxy.history);
@@ -314,11 +314,11 @@ export function Providers() {
                               <div
                                 key={proxy.name}
                                 className="px-3 py-2.5 rounded-xl border"
-                                style={{ background: 'white', borderColor: 'rgba(0,0,0,0.06)' }}
+                                style={{ background: 'var(--color-proxy-card-bg)', borderColor: 'var(--color-separator)' }}
                               >
                                 <div
                                   className="text-[13px] font-medium truncate mb-1"
-                                  style={{ color: '#1d1d1f' }}
+                                  style={{ color: 'var(--color-text-primary)' }}
                                 >
                                   {proxy.name}
                                 </div>
@@ -347,17 +347,17 @@ export function Providers() {
 
       {/* Rule Providers Section */}
       <div className="flex items-center justify-between pt-4">
-        <h2 className="text-xl font-semibold tracking-tight" style={{ color: '#1d1d1f' }}>Rule Providers</h2>
-        <span className="text-[13px]" style={{ color: '#8e8e93' }}>{ruleProviders.length} provider{ruleProviders.length !== 1 ? 's' : ''}</span>
+        <h2 className="text-xl font-semibold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Rule Providers</h2>
+        <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>{ruleProviders.length} provider{ruleProviders.length !== 1 ? 's' : ''}</span>
       </div>
 
       {ruleIsLoading ? (
-        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading rule providers…</div>
+        <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading rule providers…</div>
       ) : ruleProviders.length === 0 ? (
         <div className="liquid-glass-card rounded-2xl p-10 flex flex-col items-center gap-3 text-center">
           <div className="text-4xl">📋</div>
-          <div className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>No Rule Providers</div>
-          <div className="text-[13px] max-w-xs" style={{ color: '#6e6e73' }}>
+          <div className="text-[17px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>No Rule Providers</div>
+          <div className="text-[13px] max-w-xs" style={{ color: 'var(--color-text-secondary)' }}>
             Add rule providers to your config to see them here.
           </div>
         </div>
@@ -384,12 +384,12 @@ export function Providers() {
                       onClick={() => toggleRuleProviderExpanded(provider.name)}
                     >
                       <div className="flex items-center gap-2.5 min-w-0 flex-wrap">
-                        <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>
+                        <span className="font-semibold text-[15px] truncate" style={{ color: 'var(--color-text-primary)' }}>
                           {provider.name}
                         </span>
                         <span
                           className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                          style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}
+                          style={{ background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' }}
                         >
                           {provider.vehicleType}
                         </span>
@@ -404,13 +404,13 @@ export function Providers() {
                         {provider.ruleCount !== undefined && (
                           <span
                             className="text-[11px] px-2 py-0.5 rounded-full flex-shrink-0"
-                            style={{ background: 'rgba(0,0,0,0.04)', color: '#8e8e93' }}
+                            style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-tertiary)' }}
                           >
                             {provider.ruleCount} rule{provider.ruleCount !== 1 ? 's' : ''}
                           </span>
                         )}
                         {provider.updatedAt && (
-                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: '#8e8e93' }}>
+                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: 'var(--color-text-tertiary)' }}>
                             Updated {new Date(provider.updatedAt).toLocaleTimeString()}
                           </span>
                         )}
@@ -426,15 +426,15 @@ export function Providers() {
                           {isUpdating ? 'Updating…' : 'Update'}
                         </button>
                         {isExpanded
-                          ? <ChevronUp size={16} style={{ color: '#6e6e73' }} />
-                          : <ChevronDown size={16} style={{ color: '#6e6e73' }} />
+                          ? <ChevronUp size={16} style={{ color: 'var(--color-text-secondary)' }} />
+                          : <ChevronDown size={16} style={{ color: 'var(--color-text-secondary)' }} />
                         }
                       </div>
                     </div>
 
                     {/* Rules list */}
                     {isExpanded && (
-                      <div className="px-4 pb-4 border-t" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+                      <div className="px-4 pb-4 border-t" style={{ borderColor: 'var(--color-separator)' }}>
                         <div className="pt-3">
                           <RuleProviderRulesPanel name={provider.name} behavior={provider.behavior} />
                         </div>

--- a/clash-dashboard/src/pages/Providers.tsx
+++ b/clash-dashboard/src/pages/Providers.tsx
@@ -158,10 +158,13 @@ export function Providers() {
                 : { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
               }
             >
-              {matchLoading ? '…'
-                : matchError ? '⚠ Error'
-                : matchData?.match ? '✓ Match'
-                : '✗ No match'}
+              {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? `✓ Match` : '✗ No match'}
+              {matchData?.rule && (
+                <span className="font-mono font-normal text-[10px] px-1.5 py-0.5 rounded-md ml-1"
+                  style={{ background: 'rgba(52,199,89,0.15)' }}>
+                  {matchData.rule}
+                </span>
+              )}
             </div>
           )}
         </form>

--- a/clash-dashboard/src/pages/Providers.tsx
+++ b/clash-dashboard/src/pages/Providers.tsx
@@ -134,6 +134,7 @@ export function Providers() {
             <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
             <input
               type="text"
+              aria-label={`Rule match target for ${name}`}
               value={matchInput}
               onChange={(e) => setMatchInput(e.target.value)}
               placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
@@ -159,7 +160,7 @@ export function Providers() {
               }
             >
               {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? `✓ Match` : '✗ No match'}
-              {matchData?.rule && (
+              {matchData?.match && matchData?.rule && (
                 <span className="font-mono font-normal text-[10px] px-1.5 py-0.5 rounded-md ml-1"
                   style={{ background: 'rgba(52,199,89,0.15)' }}>
                   {matchData.rule}

--- a/clash-dashboard/src/pages/Proxies.tsx
+++ b/clash-dashboard/src/pages/Proxies.tsx
@@ -32,7 +32,7 @@ function getTypeBadgeStyle(type: string): { background: string; color: string } 
   if (type === 'URLTest') return { background: 'rgba(52,199,89,0.1)', color: '#34c759' };
   if (type === 'Fallback') return { background: 'rgba(255,149,0,0.1)', color: '#ff9500' };
   if (type === 'LoadBalance') return { background: 'rgba(175,82,222,0.1)', color: '#af52de' };
-  return { background: 'rgba(0,0,0,0.06)', color: '#6e6e73' };
+  return { background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' };
 }
 
 function getLastDelay(history: Proxy['history']): number | undefined {
@@ -193,7 +193,7 @@ export function Proxies() {
   if (isLoading) {
     return (
       <div className="p-6">
-        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading proxies...</div>
+        <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading proxies...</div>
       </div>
     );
   }
@@ -201,12 +201,12 @@ export function Proxies() {
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center gap-3">
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Proxies</h1>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Proxies</h1>
         <span
           className="text-[11px] font-semibold px-2.5 py-1 rounded-full capitalize"
           style={{
-            background: mode === 'rule' ? 'rgba(0,113,227,0.1)' : mode === 'global' ? 'rgba(52,199,89,0.1)' : 'rgba(0,0,0,0.06)',
-            color: mode === 'rule' ? '#0071e3' : mode === 'global' ? '#34c759' : '#6e6e73',
+            background: mode === 'rule' ? 'rgba(0,113,227,0.1)' : mode === 'global' ? 'rgba(52,199,89,0.1)' : 'var(--color-fill-medium)',
+            color: mode === 'rule' ? '#0071e3' : mode === 'global' ? '#34c759' : 'var(--color-text-secondary)',
           }}
         >
           {mode}
@@ -216,8 +216,8 @@ export function Proxies() {
       {mode === 'direct' ? (
         <div className="liquid-glass-card rounded-2xl p-10 flex flex-col items-center gap-3 text-center">
           <div className="text-4xl">⚡️</div>
-          <div className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Direct Mode</div>
-          <div className="text-[13px] max-w-xs" style={{ color: '#6e6e73' }}>
+          <div className="text-[17px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>Direct Mode</div>
+          <div className="text-[13px] max-w-xs" style={{ color: 'var(--color-text-secondary)' }}>
             All traffic goes directly to its destination. No proxy groups to configure.
           </div>
         </div>
@@ -258,7 +258,7 @@ export function Proxies() {
                     }}
                   >
                     <div className="flex items-center gap-2.5 min-w-0">
-                      <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>
+                      <span className="font-semibold text-[15px] truncate" style={{ color: 'var(--color-text-primary)' }}>
                         {group.name}
                       </span>
                       <span
@@ -268,7 +268,7 @@ export function Proxies() {
                         {group.type}
                       </span>
                       {group.now && (
-                        <span className="text-[13px] truncate" style={{ color: '#6e6e73' }}>
+                        <span className="text-[13px] truncate" style={{ color: 'var(--color-text-secondary)' }}>
                           {group.now}
                         </span>
                       )}
@@ -287,16 +287,16 @@ export function Proxies() {
                         disabled={isTesting}
                         className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50"
                         style={{
-                          background: 'rgba(0,0,0,0.05)',
-                          color: '#6e6e73',
+                          background: 'var(--color-fill-subtle)',
+                          color: 'var(--color-text-secondary)',
                         }}
                       >
                         <RefreshCw size={12} className={isTesting ? 'animate-spin' : ''} />
                         {isTesting ? 'Testing…' : 'Test'}
                       </button>
                       {isExpanded
-                        ? <ChevronUp size={16} style={{ color: '#6e6e73' }} />
-                        : <ChevronDown size={16} style={{ color: '#6e6e73' }} />
+                        ? <ChevronUp size={16} style={{ color: 'var(--color-text-secondary)' }} />
+                        : <ChevronDown size={16} style={{ color: 'var(--color-text-secondary)' }} />
                       }
                     </div>
                   </div>
@@ -305,10 +305,10 @@ export function Proxies() {
                   {isExpanded && (
                     <div
                       className="p-4 border-t"
-                      style={{ borderColor: 'rgba(0,0,0,0.06)' }}
+                      style={{ borderColor: 'var(--color-separator)' }}
                     >
                       {!isSelector && (
-                        <p className="text-[11px] mb-3 px-0.5" style={{ color: '#8e8e93' }}>
+                        <p className="text-[11px] mb-3 px-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
                           Auto-selected by latency — click to force override
                         </p>
                       )}
@@ -328,7 +328,7 @@ export function Proxies() {
                               style={
                                 isSelected
                                   ? { background: '#0071e3', borderColor: '#0071e3' }
-                                  : { background: 'white', borderColor: 'rgba(0,0,0,0.06)' }
+                                  : { background: 'var(--color-proxy-card-bg)', borderColor: 'var(--color-separator)' }
                               }
                             >
                               <div className="flex items-center gap-1.5 mb-1">
@@ -337,7 +337,7 @@ export function Proxies() {
                                 )}
                                 <div
                                   className="text-[13px] font-medium truncate"
-                                  style={{ color: isSelected ? 'white' : '#1d1d1f' }}
+                                  style={{ color: isSelected ? 'white' : 'var(--color-text-primary)' }}
                                 >
                                   {proxyName}
                                 </div>
@@ -372,7 +372,7 @@ export function Proxies() {
         <div className="space-y-3">
           <div
             className="text-[11px] font-semibold uppercase tracking-[0.06em] px-1"
-            style={{ color: '#6e6e73' }}
+            style={{ color: 'var(--color-text-secondary)' }}
           >
             Providers
           </div>
@@ -388,7 +388,7 @@ export function Proxies() {
                 style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
               >
                 <div className="flex">
-                  <div className="w-1 flex-shrink-0" style={{ background: '#8e8e93' }} />
+                  <div className="w-1 flex-shrink-0" style={{ background: 'var(--color-text-tertiary)' }} />
                   <div className="flex-1">
                     <div
                       className="px-4 py-3 flex items-center justify-between cursor-pointer transition-colors"
@@ -405,23 +405,23 @@ export function Proxies() {
                       }}
                     >
                       <div className="flex items-center gap-2.5 min-w-0">
-                        <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>
+                        <span className="font-semibold text-[15px] truncate" style={{ color: 'var(--color-text-primary)' }}>
                           {provider.name}
                         </span>
                         <span
                           className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                          style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}
+                          style={{ background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' }}
                         >
                           {provider.vehicleType}
                         </span>
                         <span
                           className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                          style={{ background: 'rgba(0,0,0,0.04)', color: '#8e8e93' }}
+                          style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-tertiary)' }}
                         >
                           {provider.proxies?.length ?? 0} proxies
                         </span>
                         {provider.updatedAt && (
-                          <span className="text-[11px] truncate" style={{ color: '#8e8e93' }}>
+                          <span className="text-[11px] truncate" style={{ color: 'var(--color-text-tertiary)' }}>
                             {new Date(provider.updatedAt).toLocaleTimeString()}
                           </span>
                         )}
@@ -431,7 +431,7 @@ export function Proxies() {
                           onClick={(e) => { e.stopPropagation(); runHealthcheck(provider); }}
                           disabled={isTesting}
                           className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50"
-                          style={{ background: 'rgba(0,0,0,0.05)', color: '#6e6e73' }}
+                          style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
                         >
                           <Activity size={12} className={isTesting ? 'animate-pulse' : ''} />
                           {isTesting ? 'Testing…' : 'Test'}
@@ -440,20 +440,20 @@ export function Proxies() {
                           onClick={(e) => { e.stopPropagation(); runUpdate(provider); }}
                           disabled={isUpdating}
                           className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50"
-                          style={{ background: 'rgba(0,0,0,0.05)', color: '#6e6e73' }}
+                          style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
                         >
                           <RefreshCw size={12} className={isUpdating ? 'animate-spin' : ''} />
                           {isUpdating ? 'Updating…' : 'Update'}
                         </button>
                         {isExpanded
-                          ? <ChevronUp size={16} style={{ color: '#6e6e73' }} />
-                          : <ChevronDown size={16} style={{ color: '#6e6e73' }} />
+                          ? <ChevronUp size={16} style={{ color: 'var(--color-text-secondary)' }} />
+                          : <ChevronDown size={16} style={{ color: 'var(--color-text-secondary)' }} />
                         }
                       </div>
                     </div>
 
                     {isExpanded && provider.proxies && provider.proxies.length > 0 && (
-                      <div className="p-4 border-t" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+                      <div className="p-4 border-t" style={{ borderColor: 'var(--color-separator)' }}>
                         <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
                           {provider.proxies.map((proxy) => {
                             const latency = getLastDelay(proxy.history);
@@ -462,11 +462,11 @@ export function Proxies() {
                               <div
                                 key={proxy.name}
                                 className="px-3 py-2.5 rounded-xl text-left border"
-                                style={{ background: 'white', borderColor: 'rgba(0,0,0,0.06)' }}
+                                style={{ background: 'var(--color-proxy-card-bg)', borderColor: 'var(--color-separator)' }}
                               >
                                 <div
                                   className="text-[13px] font-medium truncate mb-1"
-                                  style={{ color: '#1d1d1f' }}
+                                  style={{ color: 'var(--color-text-primary)' }}
                                 >
                                   {proxy.name}
                                 </div>

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -4,7 +4,7 @@ import {
   getProxies, getProxyProviders, getProxyDelay, getProviderProxyDelay,
   updateProxyProvider, healthcheckProvider,
 } from '../lib/api';
-import { Activity, RefreshCw } from 'lucide-react';
+import { Activity, RefreshCw, Zap } from 'lucide-react';
 import type { Proxy, ProxyProvider } from '../lib/api';
 
 const TEST_URL = 'http://www.gstatic.com/generate_204';
@@ -175,6 +175,7 @@ export function ProxyList() {
   const [testingProxies, setTestingProxies] = useState<Set<string>>(new Set());
   const [testingProviders, setTestingProviders] = useState<Set<string>>(new Set());
   const [updatingProviders, setUpdatingProviders] = useState<Set<string>>(new Set());
+  const [testingAll, setTestingAll] = useState(false);
 
   const { data: proxiesData, isLoading: proxiesLoading, isError: proxiesError } = useQuery({
     queryKey: ['proxies'],
@@ -233,7 +234,7 @@ export function ProxyList() {
     setTestingProviders((s) => new Set(s).add(provider.name));
     try {
       await healthcheckProvider(provider.name);
-      await queryClient.invalidateQueries({ queryKey: ['providers'] });
+      await queryClient.refetchQueries({ queryKey: ['providers'] });
       // Clear stale per-proxy overrides so cards fall back to freshly fetched history
       setLatencyMap((prev) => {
         const next = { ...prev };
@@ -247,6 +248,48 @@ export function ProxyList() {
       // leave existing latency values unchanged on error
     } finally {
       setTestingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
+    }
+  }
+
+  async function testAllProxies() {
+    setTestingAll(true);
+    try {
+      // Run all provider healthchecks and static proxy tests in parallel
+      const providerResults = Promise.allSettled(
+        providers.map((p) => healthcheckProvider(p.name))
+      );
+      const staticResults = Promise.allSettled(
+        configProxies.map(async (proxy) => {
+          const key = `static::${proxy.name}`;
+          setTestingProxies((s) => new Set(s).add(key));
+          try {
+            const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
+            setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
+          } catch {
+            setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
+          } finally {
+            setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
+          }
+        })
+      );
+      await Promise.all([providerResults, staticResults]);
+      // Clear provider overrides and refetch fresh data
+      setLatencyMap((prev) => {
+        const next = { ...prev };
+        for (const p of providers) {
+          const prefix = `${p.name}::`;
+          for (const key of Object.keys(next)) {
+            if (key.startsWith(prefix)) delete next[key];
+          }
+        }
+        return next;
+      });
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: ['proxies'] }),
+        queryClient.refetchQueries({ queryKey: ['providers'] }),
+      ]);
+    } finally {
+      setTestingAll(false);
     }
   }
 
@@ -267,9 +310,20 @@ export function ProxyList() {
     <div className="p-6 space-y-8">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Proxies</h1>
-        <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>
-          {configProxies.length} static · {providers.length} provider{providers.length !== 1 ? 's' : ''}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>
+            {configProxies.length} static · {providers.length} provider{providers.length !== 1 ? 's' : ''}
+          </span>
+          <button
+            onClick={testAllProxies}
+            disabled={testingAll}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium disabled:opacity-50 transition-opacity"
+            style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-secondary)' }}
+          >
+            <Zap size={12} className={testingAll ? 'animate-pulse' : ''} />
+            {testingAll ? 'Testing all…' : 'Test All'}
+          </button>
+        </div>
       </div>
 
       {isLoading ? (

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -255,33 +255,34 @@ export function ProxyList() {
     setTestingAll(true);
     try {
       // Run all provider healthchecks and static proxy tests in parallel
-      const providerResults = Promise.allSettled(
-        providers.map((p) => healthcheckProvider(p.name))
-      );
-      const staticResults = Promise.allSettled(
-        configProxies.map(async (proxy) => {
-          const key = `static::${proxy.name}`;
-          setTestingProxies((s) => new Set(s).add(key));
-          try {
-            const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
-            setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
-          } catch {
-            setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
-          } finally {
-            setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
-          }
-        })
-      );
-      await Promise.all([providerResults, staticResults]);
-      // Clear provider overrides and refetch fresh data
+      const [providerResults] = await Promise.all([
+        Promise.allSettled(providers.map((p) => healthcheckProvider(p.name))),
+        Promise.allSettled(
+          configProxies.map(async (proxy) => {
+            const key = `static::${proxy.name}`;
+            setTestingProxies((s) => new Set(s).add(key));
+            try {
+              const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
+              setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
+            } catch {
+              setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
+            } finally {
+              setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
+            }
+          })
+        ),
+      ]);
+      // Only clear overrides for providers whose healthcheck succeeded
       setLatencyMap((prev) => {
         const next = { ...prev };
-        for (const p of providers) {
-          const prefix = `${p.name}::`;
-          for (const key of Object.keys(next)) {
-            if (key.startsWith(prefix)) delete next[key];
+        providers.forEach((p, i) => {
+          if (providerResults[i].status === 'fulfilled') {
+            const prefix = `${p.name}::`;
+            for (const key of Object.keys(next)) {
+              if (key.startsWith(prefix)) delete next[key];
+            }
           }
-        }
+        });
         return next;
       });
       await Promise.all([

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -43,13 +43,12 @@ function getProxyTypeBadgeStyle(type: string): { background: string; color: stri
 
 interface ProxyCardProps {
   proxy: Proxy;
-  latency?: number;
   onTest: () => void;
   testing?: boolean;
 }
 
-function ProxyCard({ proxy, latency, onTest, testing }: ProxyCardProps) {
-  const delay = latency ?? getLastDelay(proxy.history);
+function ProxyCard({ proxy, onTest, testing }: ProxyCardProps) {
+  const delay = getLastDelay(proxy.history);
   const latencyColor = getLatencyColor(delay);
   const typeStyle = getProxyTypeBadgeStyle(proxy.type);
 
@@ -91,7 +90,6 @@ function ProxyCard({ proxy, latency, onTest, testing }: ProxyCardProps) {
 
 interface ProviderSectionProps {
   provider: ProxyProvider;
-  latencyMap: Record<string, number>;
   testingProxies: Set<string>;
   testingProviders: Set<string>;
   updatingProviders: Set<string>;
@@ -101,7 +99,7 @@ interface ProviderSectionProps {
 }
 
 function ProviderSection({
-  provider, latencyMap, testingProxies, testingProviders, updatingProviders,
+  provider, testingProxies, testingProviders, updatingProviders,
   onTestProxy, onTestAll, onUpdate,
 }: ProviderSectionProps) {
   const isTesting = testingProviders.has(provider.name);
@@ -158,7 +156,6 @@ function ProviderSection({
             <ProxyCard
               key={proxy.name}
               proxy={proxy}
-              latency={latencyMap[`${provider.name}::${proxy.name}`]}
               testing={testingProxies.has(`${provider.name}::${proxy.name}`)}
               onTest={() => onTestProxy(provider.name, proxy)}
             />
@@ -171,7 +168,6 @@ function ProviderSection({
 
 export function ProxyList() {
   const queryClient = useQueryClient();
-  const [latencyMap, setLatencyMap] = useState<Record<string, number>>({});
   const [testingProxies, setTestingProxies] = useState<Set<string>>(new Set());
   const [testingProviders, setTestingProviders] = useState<Set<string>>(new Set());
   const [updatingProviders, setUpdatingProviders] = useState<Set<string>>(new Set());
@@ -208,10 +204,10 @@ export function ProxyList() {
     const key = `static::${proxy.name}`;
     setTestingProxies((s) => new Set(s).add(key));
     try {
-      const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
-      setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
+      await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
+      await queryClient.refetchQueries({ queryKey: ['proxies'] });
     } catch {
-      setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
+      // ignore, server will have recorded the timeout
     } finally {
       setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
     }
@@ -221,10 +217,10 @@ export function ProxyList() {
     const key = `${providerName}::${proxy.name}`;
     setTestingProxies((s) => new Set(s).add(key));
     try {
-      const res = await getProviderProxyDelay(providerName, proxy.name, TEST_URL, TEST_TIMEOUT);
-      setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
+      await getProviderProxyDelay(providerName, proxy.name, TEST_URL, TEST_TIMEOUT);
+      await queryClient.refetchQueries({ queryKey: ['providers'] });
     } catch {
-      setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
+      // ignore
     } finally {
       setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
     }
@@ -235,17 +231,8 @@ export function ProxyList() {
     try {
       await healthcheckProvider(provider.name);
       await queryClient.refetchQueries({ queryKey: ['providers'] });
-      // Clear stale per-proxy overrides so cards fall back to freshly fetched history
-      setLatencyMap((prev) => {
-        const next = { ...prev };
-        const prefix = `${provider.name}::`;
-        for (const key of Object.keys(next)) {
-          if (key.startsWith(prefix)) delete next[key];
-        }
-        return next;
-      });
     } catch {
-      // leave existing latency values unchanged on error
+      // ignore
     } finally {
       setTestingProviders((s) => { const next = new Set(s); next.delete(provider.name); return next; });
     }
@@ -254,37 +241,15 @@ export function ProxyList() {
   async function testAllProxies() {
     setTestingAll(true);
     try {
-      // Run all provider healthchecks and static proxy tests in parallel
-      const [providerResults] = await Promise.all([
+      const proxyKeys = configProxies.map((p) => `static::${p.name}`);
+      proxyKeys.forEach((k) => setTestingProxies((s) => new Set(s).add(k)));
+      await Promise.all([
         Promise.allSettled(providers.map((p) => healthcheckProvider(p.name))),
-        Promise.allSettled(
-          configProxies.map(async (proxy) => {
-            const key = `static::${proxy.name}`;
-            setTestingProxies((s) => new Set(s).add(key));
-            try {
-              const res = await getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT);
-              setLatencyMap((prev) => ({ ...prev, [key]: res.delay }));
-            } catch {
-              setLatencyMap((prev) => ({ ...prev, [key]: 0 }));
-            } finally {
-              setTestingProxies((s) => { const next = new Set(s); next.delete(key); return next; });
-            }
-          })
-        ),
+        Promise.allSettled(configProxies.map((proxy) =>
+          getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT).catch(() => {})
+        )),
       ]);
-      // Only clear overrides for providers whose healthcheck succeeded
-      setLatencyMap((prev) => {
-        const next = { ...prev };
-        providers.forEach((p, i) => {
-          if (providerResults[i].status === 'fulfilled') {
-            const prefix = `${p.name}::`;
-            for (const key of Object.keys(next)) {
-              if (key.startsWith(prefix)) delete next[key];
-            }
-          }
-        });
-        return next;
-      });
+      proxyKeys.forEach((k) => setTestingProxies((s) => { const next = new Set(s); next.delete(k); return next; }));
       await Promise.all([
         queryClient.refetchQueries({ queryKey: ['proxies'] }),
         queryClient.refetchQueries({ queryKey: ['providers'] }),
@@ -358,7 +323,6 @@ export function ProxyList() {
                   <ProxyCard
                     key={proxy.name}
                     proxy={proxy}
-                    latency={latencyMap[`static::${proxy.name}`]}
                     testing={testingProxies.has(`static::${proxy.name}`)}
                     onTest={() => testStaticProxy(proxy)}
                   />
@@ -392,7 +356,6 @@ export function ProxyList() {
                   <ProviderSection
                     key={provider.name}
                     provider={provider}
-                    latencyMap={latencyMap}
                     testingProxies={testingProxies}
                     testingProviders={testingProviders}
                     updatingProviders={updatingProviders}

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -38,7 +38,7 @@ function getProxyTypeBadgeStyle(type: string): { background: string; color: stri
   if (t === 'wireguard') return { background: 'rgba(88,86,214,0.1)', color: '#5856d6' };
   if (t === 'hysteria' || t === 'hysteria2') return { background: 'rgba(255,149,0,0.12)', color: '#ff9500' };
   if (t === 'tuic') return { background: 'rgba(0,149,255,0.1)', color: '#0095ff' };
-  return { background: 'rgba(0,0,0,0.06)', color: '#6e6e73' };
+  return { background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' };
 }
 
 interface ProxyCardProps {
@@ -56,10 +56,10 @@ function ProxyCard({ proxy, latency, onTest, testing }: ProxyCardProps) {
   return (
     <div
       className="flex items-center gap-3 px-4 py-3 rounded-xl border"
-      style={{ background: 'rgba(255,255,255,0.6)', borderColor: 'rgba(0,0,0,0.06)' }}
+      style={{ background: 'var(--color-proxy-card-bg)', borderColor: 'var(--color-separator)' }}
     >
       <div className="flex-1 min-w-0">
-        <div className="text-[13px] font-medium truncate" style={{ color: '#1d1d1f' }}>
+        <div className="text-[13px] font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
           {proxy.name}
         </div>
         <div className="flex items-center gap-1.5 mt-0.5">
@@ -112,18 +112,18 @@ function ProviderSection({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
-          <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>{provider.name}</h2>
+          <h2 className="text-[17px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>{provider.name}</h2>
           <span
             className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
-            style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}
+            style={{ background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' }}
           >
             {provider.vehicleType}
           </span>
-          <span className="text-[11px]" style={{ color: '#8e8e93' }}>
+          <span className="text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>
             {proxies.length} {proxies.length === 1 ? 'proxy' : 'proxies'}
           </span>
           {provider.updatedAt && (
-            <span className="text-[11px] hidden sm:inline" style={{ color: '#8e8e93' }}>
+            <span className="text-[11px] hidden sm:inline" style={{ color: 'var(--color-text-tertiary)' }}>
               · Updated {new Date(provider.updatedAt).toLocaleTimeString()}
             </span>
           )}
@@ -151,7 +151,7 @@ function ProviderSection({
       </div>
 
       {proxies.length === 0 ? (
-        <div className="text-[13px] italic" style={{ color: '#8e8e93' }}>No proxies in this provider.</div>
+        <div className="text-[13px] italic" style={{ color: 'var(--color-text-tertiary)' }}>No proxies in this provider.</div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
           {proxies.map((proxy) => (
@@ -266,14 +266,14 @@ export function ProxyList() {
   return (
     <div className="p-6 space-y-8">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Proxies</h1>
-        <span className="text-[13px]" style={{ color: '#8e8e93' }}>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Proxies</h1>
+        <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>
           {configProxies.length} static · {providers.length} provider{providers.length !== 1 ? 's' : ''}
         </span>
       </div>
 
       {isLoading ? (
-        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading proxies…</div>
+        <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading proxies…</div>
       ) : isError ? (
         <div className="text-[15px]" style={{ color: '#ff3b30' }}>Failed to load proxies. Check your API connection.</div>
       ) : (
@@ -281,8 +281,8 @@ export function ProxyList() {
           {/* Proxies */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
-              <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Proxies</h2>
-              <span className="text-[11px]" style={{ color: '#8e8e93' }}>
+              <h2 className="text-[17px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>Proxies</h2>
+              <span className="text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>
                 {configProxies.length} {configProxies.length === 1 ? 'proxy' : 'proxies'}
               </span>
             </div>
@@ -292,8 +292,8 @@ export function ProxyList() {
                 className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center"
               >
                 <div className="text-3xl">🔌</div>
-                <div className="text-[15px] font-semibold" style={{ color: '#1d1d1f' }}>No Static Proxies</div>
-                <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+                <div className="text-[15px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>No Static Proxies</div>
+                <div className="text-[13px]" style={{ color: 'var(--color-text-secondary)' }}>
                   Define proxies directly in your config file.
                 </div>
               </div>
@@ -318,17 +318,17 @@ export function ProxyList() {
               className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center"
             >
               <div className="text-3xl">📦</div>
-              <div className="text-[15px] font-semibold" style={{ color: '#1d1d1f' }}>No Proxy Providers</div>
-              <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+              <div className="text-[15px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>No Proxy Providers</div>
+              <div className="text-[13px]" style={{ color: 'var(--color-text-secondary)' }}>
                 Add proxy providers to your config to see them here.
               </div>
             </div>
           ) : (
             <>
-              <div className="w-full h-px" style={{ background: 'rgba(0,0,0,0.06)' }} />
+              <div className="w-full h-px" style={{ background: 'var(--color-separator)' }} />
               <div className="flex items-center gap-2">
-                <h2 className="text-[17px] font-semibold" style={{ color: '#1d1d1f' }}>Proxy Providers</h2>
-                <span className="text-[11px]" style={{ color: '#8e8e93' }}>
+                <h2 className="text-[17px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>Proxy Providers</h2>
+                <span className="text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>
                   {providers.length} {providers.length === 1 ? 'provider' : 'providers'}
                 </span>
               </div>

--- a/clash-dashboard/src/pages/ProxyList.tsx
+++ b/clash-dashboard/src/pages/ProxyList.tsx
@@ -172,6 +172,7 @@ export function ProxyList() {
   const [testingProviders, setTestingProviders] = useState<Set<string>>(new Set());
   const [updatingProviders, setUpdatingProviders] = useState<Set<string>>(new Set());
   const [testingAll, setTestingAll] = useState(false);
+  const [batchFailedProviders, setBatchFailedProviders] = useState<string[]>([]);
 
   const { data: proxiesData, isLoading: proxiesLoading, isError: proxiesError } = useQuery({
     queryKey: ['proxies'],
@@ -240,16 +241,19 @@ export function ProxyList() {
 
   async function testAllProxies() {
     setTestingAll(true);
+    setBatchFailedProviders([]);
     try {
       const proxyKeys = configProxies.map((p) => `static::${p.name}`);
       proxyKeys.forEach((k) => setTestingProxies((s) => new Set(s).add(k)));
-      await Promise.all([
+      const [providerResults] = await Promise.all([
         Promise.allSettled(providers.map((p) => healthcheckProvider(p.name))),
         Promise.allSettled(configProxies.map((proxy) =>
           getProxyDelay(proxy.name, TEST_URL, TEST_TIMEOUT).catch(() => {})
         )),
       ]);
       proxyKeys.forEach((k) => setTestingProxies((s) => { const next = new Set(s); next.delete(k); return next; }));
+      const failed = providers.filter((_, i) => providerResults[i].status === 'rejected').map((p) => p.name);
+      if (failed.length > 0) setBatchFailedProviders(failed);
       await Promise.all([
         queryClient.refetchQueries({ queryKey: ['proxies'] }),
         queryClient.refetchQueries({ queryKey: ['providers'] }),
@@ -289,6 +293,15 @@ export function ProxyList() {
             <Zap size={12} className={testingAll ? 'animate-pulse' : ''} />
             {testingAll ? 'Testing all…' : 'Test All'}
           </button>
+          {batchFailedProviders.length > 0 && !testingAll && (
+            <span
+              className="text-[11px] px-2 py-0.5 rounded-full"
+              style={{ background: 'rgba(255,149,0,0.1)', color: '#ff9500' }}
+              title={`Failed: ${batchFailedProviders.join(', ')}`}
+            >
+              ⚠ {batchFailedProviders.length} provider{batchFailedProviders.length !== 1 ? 's' : ''} failed
+            </span>
+          )}
         </div>
       </div>
 

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -76,6 +76,7 @@ function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
           <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
           <input
             type="text"
+            aria-label="Rule match target"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Enter domain or IP to test (e.g. google.com, 8.8.8.8)"
@@ -182,6 +183,7 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
           <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
           <input
             type="text"
+            aria-label={`Rule match target for ${name}`}
             value={matchInput}
             onChange={(e) => setMatchInput(e.target.value)}
             placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
@@ -207,7 +209,7 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
             }
           >
             {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? '✓ Match' : '✗ No match'}
-            {matchData?.rule && (
+            {matchData?.match && matchData?.rule && (
               <span className="font-mono font-normal text-[10px] px-1.5 py-0.5 rounded-md ml-1"
                 style={{ background: 'rgba(52,199,89,0.15)' }}>
                 {matchData.rule}

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRules, getRuleProviders, updateRuleProvider, getRuleProviderRules, matchRuleProvider } from '../lib/api';
-import { RefreshCw, Search, Zap } from 'lucide-react';
+import { RefreshCw, Search } from 'lucide-react';
 import type { RuleProvider } from '../lib/api';
 
 function getRuleTypeBadgeStyle(type: string): { background: string; color: string } {
@@ -27,128 +27,6 @@ function getRuleTypeBadgeStyle(type: string): { background: string; color: strin
     case 'Final':            return { background: 'rgba(142,142,147,0.12)', color: '#636366' };
     default:                 return { background: 'var(--color-fill-medium)',   color: 'var(--color-text-tertiary)' };
   }
-}
-
-function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
-  const [input, setInput] = useState('');
-  const [target, setTarget] = useState<string | null>(null);
-
-  const { data: results, isLoading } = useQuery({
-    queryKey: ['global-rule-match', target],
-    queryFn: async () => {
-      const settled = await Promise.allSettled(
-        providers.map((p) => matchRuleProvider(p.name, target!).then((r) => ({ name: p.name, match: r.match, rule: r.rule })))
-      );
-      return settled
-        .filter((r) => r.status === 'fulfilled' && r.value.match)
-        .map((r) => (r as PromiseFulfilledResult<{ name: string; match: boolean; rule?: string }>).value);
-    },
-    enabled: target !== null && target.trim().length > 0 && providers.length > 0,
-    staleTime: 0,
-  });
-
-  const matches = results ?? [];
-  const tested = target !== null && !isLoading && results !== undefined;
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (input.trim()) setTarget(input.trim());
-  }
-
-  return (
-    <div className="liquid-glass-card rounded-xl p-4 space-y-3">
-      <div className="flex items-center gap-2">
-        <Zap size={13} style={{ color: '#0071e3' }} />
-        <span className="text-[11px] font-semibold uppercase tracking-[0.06em]" style={{ color: 'var(--color-text-secondary)' }}>
-          Rule Match Test
-        </span>
-        {providers.length > 0 && (
-          <span className="text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>
-            — tests against all {providers.length} rule provider{providers.length !== 1 ? 's' : ''}
-          </span>
-        )}
-      </div>
-      <form onSubmit={handleSubmit} className="flex gap-2 items-center">
-        <div
-          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
-          style={{ background: 'var(--color-fill-subtle)', borderColor: 'var(--color-border)' }}
-        >
-          <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
-          <input
-            type="text"
-            aria-label="Rule match target"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Enter domain or IP to test (e.g. google.com, 8.8.8.8)"
-            className="flex-1 bg-transparent outline-none text-[13px]"
-            style={{ color: 'var(--color-text-primary)' }}
-          />
-          {target !== null && (
-            <button
-              type="button"
-              onClick={() => { setInput(''); setTarget(null); }}
-              className="text-[11px] flex-shrink-0"
-              style={{ color: 'var(--color-text-tertiary)' }}
-            >
-              ✕
-            </button>
-          )}
-        </div>
-        <button
-          type="submit"
-          disabled={!input.trim() || providers.length === 0}
-          className="px-4 py-2 rounded-xl text-[12px] font-medium disabled:opacity-40 transition-colors flex-shrink-0"
-          style={{ background: '#0071e3', color: 'white' }}
-        >
-          Test
-        </button>
-      </form>
-
-      {providers.length === 0 && (
-        <div className="text-[12px] italic" style={{ color: 'var(--color-text-tertiary)' }}>
-          No rule providers loaded — add rule providers to your config to use this tester.
-        </div>
-      )}
-
-      {target !== null && providers.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 items-center">
-          {isLoading ? (
-            <span className="text-[12px]" style={{ color: 'var(--color-text-tertiary)' }}>
-              Testing "{target}" against {providers.length} provider{providers.length !== 1 ? 's' : ''}…
-            </span>
-          ) : tested && matches.length > 0 ? (
-            <>
-              <span className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>"{target}" matched by:</span>
-              {matches.map((m) => (
-                <span
-                  key={m.name}
-                  className="flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full"
-                  style={{ background: 'rgba(52,199,89,0.12)', color: '#34c759' }}
-                >
-                  <span>✓ {m.name}</span>
-                  {m.rule && (
-                    <span
-                      className="font-mono font-normal px-1.5 py-0.5 rounded-md text-[10px]"
-                      style={{ background: 'rgba(52,199,89,0.15)', color: '#34c759' }}
-                    >
-                      {m.rule}
-                    </span>
-                  )}
-                </span>
-              ))}
-            </>
-          ) : tested ? (
-            <span
-              className="text-[12px] font-medium px-2.5 py-1 rounded-lg"
-              style={{ background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }}
-            >
-              ✗ No rule provider matched "{target}"
-            </span>
-          ) : null}
-        </div>
-      )}
-    </div>
-  );
 }
 
 function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: string }) {
@@ -321,7 +199,6 @@ export function Rules() {
         <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>{filtered.length} / {rules.length}</span>
       </div>
 
-      <GlobalRuleMatchBar providers={ruleProviders} />
       <div className="relative">
         <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: 'var(--color-text-tertiary)' }} />
         <input

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -39,15 +39,23 @@ function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
       const settled = await Promise.allSettled(
         providers.map((p) => matchRuleProvider(p.name, target!).then((r) => ({ name: p.name, match: r.match })))
       );
-      return Object.fromEntries(
-        settled.map((r, i) => [providers[i].name, r.status === 'fulfilled' ? r.value.match : false])
-      ) as Record<string, boolean>;
+      const matched: string[] = [];
+      const failed: string[] = [];
+      settled.forEach((r, i) => {
+        if (r.status === 'fulfilled') {
+          if (r.value.match) matched.push(providers[i].name);
+        } else {
+          failed.push(providers[i].name);
+        }
+      });
+      return { matched, failed };
     },
     enabled: target !== null && target.trim().length > 0 && providers.length > 0,
     staleTime: 0,
   });
 
-  const matchingProviders = target && results ? providers.filter((p) => results[p.name]) : [];
+  const matchingProviders = results?.matched ?? [];
+  const failedProviders = results?.failed ?? [];
   const tested = target !== null && !isLoading && results !== undefined;
 
   function handleSubmit(e: React.FormEvent) {
@@ -118,16 +126,28 @@ function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
           ) : tested && matchingProviders.length > 0 ? (
             <>
               <span className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>"{target}" matched by:</span>
-              {matchingProviders.map((p) => (
+              {matchingProviders.map((name) => (
                 <span
-                  key={p.name}
+                  key={name}
                   className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
                   style={{ background: 'rgba(52,199,89,0.12)', color: '#34c759' }}
                 >
-                  ✓ {p.name}
+                  ✓ {name}
                 </span>
               ))}
+              {failedProviders.length > 0 && (
+                <span className="text-[11px] px-2 py-0.5 rounded-full" style={{ background: 'rgba(255,149,0,0.1)', color: '#ff9500' }}>
+                  {failedProviders.length} provider{failedProviders.length !== 1 ? 's' : ''} failed to respond
+                </span>
+              )}
             </>
+          ) : tested && failedProviders.length > 0 ? (
+            <span
+              className="text-[12px] font-medium px-2.5 py-1 rounded-lg"
+              style={{ background: 'rgba(255,149,0,0.1)', color: '#ff9500' }}
+            >
+              ⚠ {failedProviders.length} provider{failedProviders.length !== 1 ? 's' : ''} failed — no match confirmed
+            </span>
           ) : tested ? (
             <span
               className="text-[12px] font-medium px-2.5 py-1 rounded-lg"

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRules, getRuleProviders, updateRuleProvider, getRuleProviderRules, matchRuleProvider } from '../lib/api';
-import { RefreshCw, Search } from 'lucide-react';
+import { RefreshCw, Search, Zap } from 'lucide-react';
 import type { RuleProvider } from '../lib/api';
 
 function getRuleTypeBadgeStyle(type: string): { background: string; color: string } {
@@ -27,6 +27,119 @@ function getRuleTypeBadgeStyle(type: string): { background: string; color: strin
     case 'Final':            return { background: 'rgba(142,142,147,0.12)', color: '#636366' };
     default:                 return { background: 'var(--color-fill-medium)',   color: 'var(--color-text-tertiary)' };
   }
+}
+
+function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
+  const [input, setInput] = useState('');
+  const [target, setTarget] = useState<string | null>(null);
+
+  const { data: results, isLoading } = useQuery({
+    queryKey: ['global-rule-match', target],
+    queryFn: async () => {
+      const settled = await Promise.allSettled(
+        providers.map((p) => matchRuleProvider(p.name, target!).then((r) => ({ name: p.name, match: r.match })))
+      );
+      return Object.fromEntries(
+        settled.map((r, i) => [providers[i].name, r.status === 'fulfilled' ? r.value.match : false])
+      ) as Record<string, boolean>;
+    },
+    enabled: target !== null && target.trim().length > 0 && providers.length > 0,
+    staleTime: 0,
+  });
+
+  const matchingProviders = target && results ? providers.filter((p) => results[p.name]) : [];
+  const tested = target !== null && !isLoading && results !== undefined;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (input.trim()) setTarget(input.trim());
+  }
+
+  return (
+    <div className="liquid-glass-card rounded-xl p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <Zap size={13} style={{ color: '#0071e3' }} />
+        <span className="text-[11px] font-semibold uppercase tracking-[0.06em]" style={{ color: 'var(--color-text-secondary)' }}>
+          Rule Match Test
+        </span>
+        {providers.length > 0 && (
+          <span className="text-[11px]" style={{ color: 'var(--color-text-tertiary)' }}>
+            — tests against all {providers.length} rule provider{providers.length !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2 items-center">
+        <div
+          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
+          style={{ background: 'var(--color-fill-subtle)', borderColor: 'var(--color-border)' }}
+        >
+          <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Enter domain or IP to test (e.g. google.com, 8.8.8.8)"
+            className="flex-1 bg-transparent outline-none text-[13px]"
+            style={{ color: 'var(--color-text-primary)' }}
+          />
+          {target !== null && (
+            <button
+              type="button"
+              onClick={() => { setInput(''); setTarget(null); }}
+              className="text-[11px] flex-shrink-0"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              ✕
+            </button>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={!input.trim() || providers.length === 0}
+          className="px-4 py-2 rounded-xl text-[12px] font-medium disabled:opacity-40 transition-colors flex-shrink-0"
+          style={{ background: '#0071e3', color: 'white' }}
+        >
+          Test
+        </button>
+      </form>
+
+      {providers.length === 0 && (
+        <div className="text-[12px] italic" style={{ color: 'var(--color-text-tertiary)' }}>
+          No rule providers loaded — add rule providers to your config to use this tester.
+        </div>
+      )}
+
+      {target !== null && providers.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 items-center">
+          {isLoading ? (
+            <span className="text-[12px]" style={{ color: 'var(--color-text-tertiary)' }}>
+              Testing "{target}" against {providers.length} provider{providers.length !== 1 ? 's' : ''}…
+            </span>
+          ) : tested && matchingProviders.length > 0 ? (
+            <>
+              <span className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>"{target}" matched by:</span>
+              {matchingProviders.map((p) => (
+                <span
+                  key={p.name}
+                  className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+                  style={{ background: 'rgba(52,199,89,0.12)', color: '#34c759' }}
+                >
+                  ✓ {p.name}
+                </span>
+              ))}
+            </>
+          ) : tested ? (
+            <span
+              className="text-[12px] font-medium px-2.5 py-1 rounded-lg"
+              style={{ background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }}
+            >
+              ✗ No rule provider matched "{target}"
+            </span>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: string }) {
@@ -192,7 +305,7 @@ export function Rules() {
         <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>{filtered.length} / {rules.length}</span>
       </div>
 
-      {/* Search */}
+      <GlobalRuleMatchBar providers={ruleProviders} />
       <div className="relative">
         <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: 'var(--color-text-tertiary)' }} />
         <input

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -25,7 +25,7 @@ function getRuleTypeBadgeStyle(type: string): { background: string; color: strin
     case 'NOT':              return { background: 'rgba(88,86,214,0.12)',   color: '#5856d6' };
     case 'Match':
     case 'Final':            return { background: 'rgba(142,142,147,0.12)', color: '#636366' };
-    default:                 return { background: 'rgba(0,0,0,0.06)',        color: '#8e8e93' };
+    default:                 return { background: 'var(--color-fill-medium)',   color: 'var(--color-text-tertiary)' };
   }
 }
 
@@ -57,15 +57,15 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
     <div className="space-y-3">
       <form onSubmit={handleMatchSubmit} className="flex gap-2 items-center">
         <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border"
-          style={{ background: 'rgba(0,0,0,0.03)', borderColor: 'rgba(0,0,0,0.08)' }}>
-          <Search size={13} style={{ color: '#8e8e93', flexShrink: 0 }} />
+          style={{ background: 'var(--color-fill-subtle)', borderColor: 'var(--color-border)' }}>
+          <Search size={13} style={{ color: 'var(--color-text-tertiary)', flexShrink: 0 }} />
           <input
             type="text"
             value={matchInput}
             onChange={(e) => setMatchInput(e.target.value)}
             placeholder={behaviorLower === 'ipcidr' ? 'Test IP (e.g. 8.8.8.8)' : 'Test domain or IP'}
             className="flex-1 bg-transparent outline-none text-[13px]"
-            style={{ color: '#1d1d1f' }}
+            style={{ color: 'var(--color-text-primary)' }}
           />
         </div>
         <button
@@ -79,7 +79,7 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
         {matchTarget !== null && (
           <div className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-[12px] font-semibold flex-shrink-0"
             style={
-              matchLoading ? { background: 'rgba(0,0,0,0.05)', color: '#8e8e93' }
+              matchLoading ? { background: 'var(--color-fill-subtle)', color: 'var(--color-text-tertiary)' }
               : matchError  ? { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
               : matchData?.match ? { background: 'rgba(52,199,89,0.12)', color: '#34c759' }
               : { background: 'rgba(255,59,48,0.1)', color: '#ff3b30' }
@@ -92,11 +92,11 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
 
       {canShowRules && (
         rulesLoading ? (
-          <div className="text-[13px] py-1" style={{ color: '#8e8e93' }}>Loading rules…</div>
+          <div className="text-[13px] py-1" style={{ color: 'var(--color-text-tertiary)' }}>Loading rules…</div>
         ) : rulesError ? (
           <div className="text-[13px] py-1" style={{ color: '#ff3b30' }}>Failed to load rules.</div>
         ) : providerRules.length === 0 ? (
-          <div className="text-[13px] py-1 italic" style={{ color: '#8e8e93' }}>No rules loaded</div>
+          <div className="text-[13px] py-1 italic" style={{ color: 'var(--color-text-tertiary)' }}>No rules loaded</div>
         ) : (
           <div className="max-h-64 overflow-y-auto space-y-1 pr-1">
             {providerRules.map((rule, i) => {
@@ -104,17 +104,17 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
               const payload = rest.join(',');
               return (
                 <div key={i} className="flex items-center gap-2 px-2 py-1 rounded-lg text-[12px]"
-                  style={{ background: 'rgba(0,0,0,0.03)' }}>
+                  style={{ background: 'var(--color-fill-subtle)' }}>
                   <span className="font-mono font-semibold px-1.5 py-0.5 rounded flex-shrink-0"
                     style={{ background: 'rgba(255,149,0,0.12)', color: '#ff9500', fontSize: 10 }}>
                     {type}
                   </span>
-                  <span className="font-mono truncate" style={{ color: '#1d1d1f' }}>{payload}</span>
+                  <span className="font-mono truncate" style={{ color: 'var(--color-text-primary)' }}>{payload}</span>
                 </div>
               );
             })}
             {providerRules.length >= 500 && (
-              <div className="text-[11px] text-center pt-1" style={{ color: '#8e8e93' }}>
+              <div className="text-[11px] text-center pt-1" style={{ color: 'var(--color-text-tertiary)' }}>
                 Showing first 500 rules
               </div>
             )}
@@ -123,7 +123,7 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
       )}
 
       {!canShowRules && (
-        <div className="text-[12px] italic" style={{ color: '#8e8e93' }}>
+        <div className="text-[12px] italic" style={{ color: 'var(--color-text-tertiary)' }}>
           Rule entries are not enumerable for {behavior} providers — use the tester above.
         </div>
       )}
@@ -181,20 +181,20 @@ export function Rules() {
       case 'domain':    return { background: 'rgba(52,199,89,0.12)',  color: '#34c759' };
       case 'ipcidr':    return { background: 'rgba(0,113,227,0.12)',  color: '#0071e3' };
       case 'classical': return { background: 'rgba(255,149,0,0.12)', color: '#ff9500' };
-      default:          return { background: 'rgba(0,0,0,0.06)',      color: '#6e6e73' };
+      default:          return { background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' };
     }
   }
 
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Rules</h1>
-        <span className="text-[13px]" style={{ color: '#8e8e93' }}>{filtered.length} / {rules.length}</span>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Rules</h1>
+        <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>{filtered.length} / {rules.length}</span>
       </div>
 
       {/* Search */}
       <div className="relative">
-        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: '#8e8e93' }} />
+        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2" style={{ color: 'var(--color-text-tertiary)' }} />
         <input
           type="text"
           placeholder="Filter rules…"
@@ -202,15 +202,15 @@ export function Rules() {
           onChange={(e) => setSearch(e.target.value)}
           className="w-full pl-10 pr-4 py-2.5 rounded-xl text-[15px] focus:outline-none transition-shadow"
           style={{
-            background: 'rgba(255,255,255,0.8)',
-            border: '1px solid rgba(0,0,0,0.08)',
-            color: '#1d1d1f',
+            background: 'var(--color-input-bg)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-primary)',
           }}
         />
       </div>
 
       {isLoading ? (
-        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading rules…</div>
+        <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading rules…</div>
       ) : isError ? (
         <div className="liquid-glass-card rounded-xl p-6 text-center text-[15px]" style={{ color: '#ff3b30' }}>
           Failed to load rules. Check your connection and API secret.
@@ -221,7 +221,7 @@ export function Rules() {
           style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}
         >
           {filtered.length === 0 ? (
-            <div className="py-12 text-center text-[15px]" style={{ color: '#8e8e93' }}>
+            <div className="py-12 text-center text-[15px]" style={{ color: 'var(--color-text-tertiary)' }}>
               No rules match your search
             </div>
           ) : (
@@ -233,12 +233,12 @@ export function Rules() {
                 className="flex items-center gap-3 px-4"
                 style={{
                   minHeight: 48,
-                  borderBottom: i < filtered.length - 1 ? '1px solid rgba(0,0,0,0.05)' : 'none',
+                  borderBottom: i < filtered.length - 1 ? '1px solid var(--color-separator-subtle)' : 'none',
                 }}
               >
                 <span
                   className="font-mono text-[11px] flex-shrink-0 w-8 text-right"
-                  style={{ color: '#c7c7cc' }}
+                  style={{ color: 'var(--color-text-tertiary)' }}
                 >
                   {i + 1}
                 </span>
@@ -250,13 +250,13 @@ export function Rules() {
                 </span>
                 <span
                   className="flex-1 font-mono text-[13px] truncate"
-                  style={{ color: '#1d1d1f' }}
+                  style={{ color: 'var(--color-text-primary)' }}
                 >
                   {rule.payload || '—'}
                 </span>
                 <span
                   className="text-[13px] font-medium flex-shrink-0"
-                  style={{ color: '#1d1d1f' }}
+                  style={{ color: 'var(--color-text-primary)' }}
                 >
                   {rule.proxy}
                 </span>
@@ -269,21 +269,21 @@ export function Rules() {
 
       {/* Rule Providers Section */}
       <div className="flex items-center justify-between pt-4">
-        <h2 className="text-xl font-semibold tracking-tight" style={{ color: '#1d1d1f' }}>Rule Providers</h2>
-        <span className="text-[13px]" style={{ color: '#8e8e93' }}>
+        <h2 className="text-xl font-semibold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Rule Providers</h2>
+        <span className="text-[13px]" style={{ color: 'var(--color-text-tertiary)' }}>
           {ruleProviders.length} provider{ruleProviders.length !== 1 ? 's' : ''}
         </span>
       </div>
 
       {ruleIsLoading ? (
-        <div className="text-[15px]" style={{ color: '#6e6e73' }}>Loading rule providers…</div>
+        <div className="text-[15px]" style={{ color: 'var(--color-text-secondary)' }}>Loading rule providers…</div>
       ) : ruleIsError ? (
         <div className="text-[15px]" style={{ color: '#ff3b30' }}>Failed to load rule providers. Check your API connection.</div>
       ) : ruleProviders.length === 0 ? (
         <div className="liquid-glass-card rounded-2xl p-8 flex flex-col items-center gap-2 text-center">
           <div className="text-3xl">📋</div>
-          <div className="text-[15px] font-semibold" style={{ color: '#1d1d1f' }}>No Rule Providers</div>
-          <div className="text-[13px]" style={{ color: '#6e6e73' }}>
+          <div className="text-[15px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>No Rule Providers</div>
+          <div className="text-[13px]" style={{ color: 'var(--color-text-secondary)' }}>
             Add rule providers to your config to see them here.
           </div>
         </div>
@@ -311,11 +311,11 @@ export function Rules() {
                       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && toggleRuleProviderExpanded(provider.name)}
                     >
                       <div className="flex items-center gap-2.5 min-w-0 flex-wrap">
-                        <span className="font-semibold text-[15px] truncate" style={{ color: '#1d1d1f' }}>
+                        <span className="font-semibold text-[15px] truncate" style={{ color: 'var(--color-text-primary)' }}>
                           {provider.name}
                         </span>
                         <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                          style={{ background: 'rgba(0,0,0,0.06)', color: '#6e6e73' }}>
+                          style={{ background: 'var(--color-fill-medium)', color: 'var(--color-text-secondary)' }}>
                           {provider.vehicleType}
                         </span>
                         {provider.behavior && (
@@ -326,12 +326,12 @@ export function Rules() {
                         )}
                         {provider.ruleCount !== undefined && (
                           <span className="text-[11px] px-2 py-0.5 rounded-full flex-shrink-0"
-                            style={{ background: 'rgba(0,0,0,0.04)', color: '#8e8e93' }}>
+                            style={{ background: 'var(--color-fill-subtle)', color: 'var(--color-text-tertiary)' }}>
                             {provider.ruleCount} rule{provider.ruleCount !== 1 ? 's' : ''}
                           </span>
                         )}
                         {provider.updatedAt && (
-                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: '#8e8e93' }}>
+                          <span className="text-[11px] truncate hidden sm:inline" style={{ color: 'var(--color-text-tertiary)' }}>
                             Updated {new Date(provider.updatedAt).toLocaleTimeString()}
                           </span>
                         )}
@@ -346,11 +346,11 @@ export function Rules() {
                           <RefreshCw size={12} className={isUpdating ? 'animate-spin' : ''} />
                           {isUpdating ? 'Updating…' : 'Update'}
                         </button>
-                        <span style={{ color: '#6e6e73', fontSize: 16 }}>{isExpanded ? '▲' : '▼'}</span>
+                        <span style={{ color: 'var(--color-text-secondary)', fontSize: 16 }}>{isExpanded ? '▲' : '▼'}</span>
                       </div>
                     </div>
                     {isExpanded && (
-                      <div className="px-4 pb-4 border-t" style={{ borderColor: 'rgba(0,0,0,0.06)' }}>
+                      <div className="px-4 pb-4 border-t" style={{ borderColor: 'var(--color-separator)' }}>
                         <div className="pt-3">
                           <RuleProviderRulesPanel name={provider.name} behavior={provider.behavior} />
                         </div>

--- a/clash-dashboard/src/pages/Rules.tsx
+++ b/clash-dashboard/src/pages/Rules.tsx
@@ -37,25 +37,17 @@ function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
     queryKey: ['global-rule-match', target],
     queryFn: async () => {
       const settled = await Promise.allSettled(
-        providers.map((p) => matchRuleProvider(p.name, target!).then((r) => ({ name: p.name, match: r.match })))
+        providers.map((p) => matchRuleProvider(p.name, target!).then((r) => ({ name: p.name, match: r.match, rule: r.rule })))
       );
-      const matched: string[] = [];
-      const failed: string[] = [];
-      settled.forEach((r, i) => {
-        if (r.status === 'fulfilled') {
-          if (r.value.match) matched.push(providers[i].name);
-        } else {
-          failed.push(providers[i].name);
-        }
-      });
-      return { matched, failed };
+      return settled
+        .filter((r) => r.status === 'fulfilled' && r.value.match)
+        .map((r) => (r as PromiseFulfilledResult<{ name: string; match: boolean; rule?: string }>).value);
     },
     enabled: target !== null && target.trim().length > 0 && providers.length > 0,
     staleTime: 0,
   });
 
-  const matchingProviders = results?.matched ?? [];
-  const failedProviders = results?.failed ?? [];
+  const matches = results ?? [];
   const tested = target !== null && !isLoading && results !== undefined;
 
   function handleSubmit(e: React.FormEvent) {
@@ -123,31 +115,27 @@ function GlobalRuleMatchBar({ providers }: { providers: RuleProvider[] }) {
             <span className="text-[12px]" style={{ color: 'var(--color-text-tertiary)' }}>
               Testing "{target}" against {providers.length} provider{providers.length !== 1 ? 's' : ''}…
             </span>
-          ) : tested && matchingProviders.length > 0 ? (
+          ) : tested && matches.length > 0 ? (
             <>
               <span className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>"{target}" matched by:</span>
-              {matchingProviders.map((name) => (
+              {matches.map((m) => (
                 <span
-                  key={name}
-                  className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+                  key={m.name}
+                  className="flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full"
                   style={{ background: 'rgba(52,199,89,0.12)', color: '#34c759' }}
                 >
-                  ✓ {name}
+                  <span>✓ {m.name}</span>
+                  {m.rule && (
+                    <span
+                      className="font-mono font-normal px-1.5 py-0.5 rounded-md text-[10px]"
+                      style={{ background: 'rgba(52,199,89,0.15)', color: '#34c759' }}
+                    >
+                      {m.rule}
+                    </span>
+                  )}
                 </span>
               ))}
-              {failedProviders.length > 0 && (
-                <span className="text-[11px] px-2 py-0.5 rounded-full" style={{ background: 'rgba(255,149,0,0.1)', color: '#ff9500' }}>
-                  {failedProviders.length} provider{failedProviders.length !== 1 ? 's' : ''} failed to respond
-                </span>
-              )}
             </>
-          ) : tested && failedProviders.length > 0 ? (
-            <span
-              className="text-[12px] font-medium px-2.5 py-1 rounded-lg"
-              style={{ background: 'rgba(255,149,0,0.1)', color: '#ff9500' }}
-            >
-              ⚠ {failedProviders.length} provider{failedProviders.length !== 1 ? 's' : ''} failed — no match confirmed
-            </span>
           ) : tested ? (
             <span
               className="text-[12px] font-medium px-2.5 py-1 rounded-lg"
@@ -219,6 +207,12 @@ function RuleProviderRulesPanel({ name, behavior }: { name: string; behavior?: s
             }
           >
             {matchLoading ? '…' : matchError ? '⚠ Error' : matchData?.match ? '✓ Match' : '✗ No match'}
+            {matchData?.rule && (
+              <span className="font-mono font-normal text-[10px] px-1.5 py-0.5 rounded-md ml-1"
+                style={{ background: 'rgba(52,199,89,0.15)' }}>
+                {matchData.rule}
+              </span>
+            )}
           </div>
         )}
       </form>

--- a/clash-dashboard/src/pages/Settings.tsx
+++ b/clash-dashboard/src/pages/Settings.tsx
@@ -53,12 +53,12 @@ export function Settings() {
     outline: 'none',
     textAlign: 'right',
     fontSize: 15,
-    color: '#1d1d1f',
+    color: 'var(--color-text-primary)',
   };
 
   return (
     <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold tracking-tight" style={{ color: '#1d1d1f' }}>Settings</h1>
+      <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--color-text-primary)' }}>Settings</h1>
 
       {/* Dev mode banner */}
       {showDevPrompt && (
@@ -71,8 +71,8 @@ export function Settings() {
         >
           <AlertTriangle size={16} style={{ color: '#ff9500', flexShrink: 0, marginTop: 2 }} />
           <div className="space-y-1">
-            <div className="text-[13px] font-semibold" style={{ color: '#1d1d1f' }}>Dev mode detected</div>
-            <div className="text-[12px]" style={{ color: '#6e6e73' }}>
+            <div className="text-[13px] font-semibold" style={{ color: 'var(--color-text-primary)' }}>Dev mode detected</div>
+            <div className="text-[12px]" style={{ color: 'var(--color-text-secondary)' }}>
               Set the API URL below to point to your running clash-rs instance, then click Save &amp; Connect.
             </div>
           </div>
@@ -117,41 +117,41 @@ export function Settings() {
       <div>
         <div
           className="text-[11px] font-semibold uppercase tracking-[0.06em] mb-2 px-1"
-          style={{ color: '#6e6e73' }}
+          style={{ color: 'var(--color-text-secondary)' }}
         >
           API Connection
         </div>
         <div className="liquid-glass-card rounded-xl overflow-hidden" style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.08)' }}>
           <div
             className="flex items-center gap-3 px-4"
-            style={{ minHeight: 52, borderBottom: '1px solid rgba(0,0,0,0.06)' }}
+            style={{ minHeight: 52, borderBottom: '1px solid var(--color-separator)' }}
           >
-            <span className="text-[15px] flex-shrink-0" style={{ color: '#1d1d1f' }}>API URL</span>
+            <span className="text-[15px] flex-shrink-0" style={{ color: 'var(--color-text-primary)' }}>API URL</span>
             <input
               type="text"
               value={apiUrl}
               onChange={(e) => setApiUrlState(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleSave()}
               placeholder="http://127.0.0.1:9090"
-              style={{ ...inputStyle, color: '#6e6e73' }}
+              style={{ ...inputStyle, color: 'var(--color-text-secondary)' }}
             />
           </div>
           <div
             className="flex items-center gap-3 px-4"
             style={{ minHeight: 52 }}
           >
-            <span className="text-[15px] flex-shrink-0" style={{ color: '#1d1d1f' }}>Secret</span>
+            <span className="text-[15px] flex-shrink-0" style={{ color: 'var(--color-text-primary)' }}>Secret</span>
             <input
               type="password"
               value={secret}
               onChange={(e) => setSecretState(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleSave()}
               placeholder="API secret (leave blank if none)"
-              style={{ ...inputStyle, color: '#6e6e73' }}
+              style={{ ...inputStyle, color: 'var(--color-text-secondary)' }}
             />
           </div>
         </div>
-        <div className="text-[12px] mt-2 px-1" style={{ color: '#6e6e73' }}>
+        <div className="text-[12px] mt-2 px-1" style={{ color: 'var(--color-text-secondary)' }}>
           When served from the clash-rs binary, defaults to the current origin.
         </div>
       </div>

--- a/clash-lib/src/app/api/handlers/config.rs
+++ b/clash-lib/src/app/api/handlers/config.rs
@@ -9,6 +9,7 @@ use axum::{
 
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tokio::sync::Mutex;
 
 use crate::{
@@ -158,12 +159,17 @@ async fn update_configs(
     let g = state.global_state.lock().await;
     match (req.path, req.payload) {
         (_, Some(payload)) => {
-            let msg = "config reloading from payload".to_string();
             let cfg = crate::Config::Str(payload);
             match g.reload_tx.send((cfg, done)).await {
                 Ok(_) => {
                     wait.await.unwrap();
-                    (StatusCode::NO_CONTENT, msg).into_response()
+                    (
+                        StatusCode::OK,
+                        axum::response::Json(
+                            json!({"message": "config reloading from payload"}),
+                        ),
+                    )
+                        .into_response()
                 }
                 Err(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -192,7 +198,11 @@ async fn update_configs(
             match g.reload_tx.send((cfg, done)).await {
                 Ok(_) => {
                     wait.await.unwrap();
-                    (StatusCode::NO_CONTENT, msg).into_response()
+                    (
+                        StatusCode::OK,
+                        axum::response::Json(json!({"message": msg})),
+                    )
+                        .into_response()
                 }
 
                 Err(_) => (
@@ -320,5 +330,9 @@ async fn patch_configs(
         global_state.log_level = log_level;
     }
 
-    StatusCode::ACCEPTED.into_response()
+    (
+        StatusCode::ACCEPTED,
+        axum::response::Json(json!({"message": "configs updated"})),
+    )
+        .into_response()
 }

--- a/clash-lib/src/app/api/handlers/config.rs
+++ b/clash-lib/src/app/api/handlers/config.rs
@@ -163,13 +163,7 @@ async fn update_configs(
             match g.reload_tx.send((cfg, done)).await {
                 Ok(_) => {
                     wait.await.unwrap();
-                    (
-                        StatusCode::OK,
-                        axum::response::Json(
-                            json!({"message": "config reloading from payload"}),
-                        ),
-                    )
-                        .into_response()
+                    StatusCode::NO_CONTENT.into_response()
                 }
                 Err(_) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -193,16 +187,11 @@ async fn update_configs(
                     .into_response();
             }
 
-            let msg = format!("config reloading from file {path}");
             let cfg: crate::Config = crate::Config::File(path);
             match g.reload_tx.send((cfg, done)).await {
                 Ok(_) => {
                     wait.await.unwrap();
-                    (
-                        StatusCode::OK,
-                        axum::response::Json(json!({"message": msg})),
-                    )
-                        .into_response()
+                    StatusCode::NO_CONTENT.into_response()
                 }
 
                 Err(_) => (

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -321,6 +321,8 @@ struct MatchQuery {
 struct MatchResponse {
     #[serde(rename = "match")]
     matched: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rule: Option<String>,
 }
 
 async fn match_rule_provider(
@@ -357,8 +359,10 @@ async fn match_rule_provider(
         inbound_user: None,
     };
 
+    let rule = p.search(&sess);
     axum::response::Json(MatchResponse {
-        matched: p.search(&sess),
+        matched: rule.is_some(),
+        rule,
     })
     .into_response()
 }

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -15,6 +15,7 @@ use axum::{
     routing::get,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::{
     app::{
@@ -116,7 +117,11 @@ async fn update_provider(
 ) -> impl IntoResponse {
     let provider = provider.read().await;
     match provider.update().await {
-        Ok(_) => (StatusCode::ACCEPTED, "provider update started").into_response(),
+        Ok(_) => (
+            StatusCode::ACCEPTED,
+            axum::response::Json(json!({"message": "provider update started"})),
+        )
+            .into_response(),
         Err(err) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!(
@@ -135,7 +140,10 @@ async fn provider_healthcheck(
     let provider = provider.read().await;
     provider.healthcheck().await;
 
-    (StatusCode::ACCEPTED, "provider healthcheck")
+    (
+        StatusCode::ACCEPTED,
+        axum::response::Json(json!({"message": "provider healthcheck started"})),
+    )
 }
 
 #[derive(Deserialize)]
@@ -264,7 +272,12 @@ async fn update_rule_provider(
 ) -> impl IntoResponse {
     match state.router.get_rule_providers().get(&provider_name) {
         Some(p) => match p.update().await {
-            Ok(_) => (StatusCode::ACCEPTED, "rule provider update started")
+            Ok(_) => (
+                StatusCode::ACCEPTED,
+                axum::response::Json(
+                    json!({"message": "rule provider update started"}),
+                ),
+            )
                 .into_response(),
             Err(err) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -359,10 +359,14 @@ async fn match_rule_provider(
         inbound_user: None,
     };
 
-    let rule = p.search(&sess);
+    let matched = p.search(&sess);
     axum::response::Json(MatchResponse {
-        matched: rule.is_some(),
-        rule,
+        matched,
+        rule: if matched {
+            p.match_rule(&sess).filter(|s| !s.is_empty())
+        } else {
+            None
+        },
     })
     .into_response()
 }

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -321,8 +321,6 @@ struct MatchQuery {
 struct MatchResponse {
     #[serde(rename = "match")]
     matched: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    rule: Option<String>,
 }
 
 async fn match_rule_provider(
@@ -359,14 +357,8 @@ async fn match_rule_provider(
         inbound_user: None,
     };
 
-    let matched = p.search(&sess);
     axum::response::Json(MatchResponse {
-        matched,
-        rule: if matched {
-            p.match_rule(&sess).filter(|s| !s.is_empty())
-        } else {
-            None
-        },
+        matched: p.search(&sess),
     })
     .into_response()
 }

--- a/clash-lib/src/app/api/handlers/proxy.rs
+++ b/clash-lib/src/app/api/handlers/proxy.rs
@@ -11,6 +11,7 @@ use axum::{
 
 use http::{HeaderMap, StatusCode, header};
 use serde::Deserialize;
+use serde_json::json;
 
 use crate::{
     app::{
@@ -106,8 +107,11 @@ async fn update_proxy(
                 cache_store.set_selected(proxy.name(), &payload.name).await;
                 (
                     StatusCode::ACCEPTED,
-                    format!("selected proxy {} for {}", payload.name, proxy.name()),
+                    axum::response::Json(json!({
+                        "message": format!("selected proxy {} for {}", payload.name, proxy.name())
+                    })),
                 )
+                    .into_response()
             }
             Err(err) => (
                 StatusCode::BAD_REQUEST,
@@ -117,12 +121,14 @@ async fn update_proxy(
                     proxy.name(),
                     err
                 ),
-            ),
+            )
+                .into_response(),
         },
         _ => (
             StatusCode::NOT_FOUND,
             format!("proxy {} is not a Select", proxy.name()),
-        ),
+        )
+            .into_response(),
     }
 }
 

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/cidr_trie.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/cidr_trie.rs
@@ -34,10 +34,18 @@ impl CidrTrie {
         }
     }
 
-    pub fn contains(&self, ip: IpAddr) -> bool {
+    /// Returns the most-specific matching CIDR as a string (e.g.
+    /// `"8.8.8.0/24"`), or `None` if the IP is not in the trie.
+    pub fn longest_match_str(&self, ip: IpAddr) -> Option<String> {
         match ip {
-            IpAddr::V4(v4) => self.v4.longest_match(v4).is_some(),
-            IpAddr::V6(v6) => self.v6.longest_match(v6).is_some(),
+            IpAddr::V4(v4) => self
+                .v4
+                .longest_match(v4)
+                .map(|(addr, prefix_len, _)| format!("{addr}/{prefix_len}")),
+            IpAddr::V6(v6) => self
+                .v6
+                .longest_match(v6)
+                .map(|(addr, prefix_len, _)| format!("{addr}/{prefix_len}")),
         }
     }
 }

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/cidr_trie.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/cidr_trie.rs
@@ -34,18 +34,10 @@ impl CidrTrie {
         }
     }
 
-    /// Returns the most-specific matching CIDR as a string (e.g.
-    /// `"8.8.8.0/24"`), or `None` if the IP is not in the trie.
-    pub fn longest_match_str(&self, ip: IpAddr) -> Option<String> {
+    pub fn contains(&self, ip: IpAddr) -> bool {
         match ip {
-            IpAddr::V4(v4) => self
-                .v4
-                .longest_match(v4)
-                .map(|(addr, prefix_len, _)| format!("{addr}/{prefix_len}")),
-            IpAddr::V6(v6) => self
-                .v6
-                .longest_match(v6)
-                .map(|(addr, prefix_len, _)| format!("{addr}/{prefix_len}")),
+            IpAddr::V4(v4) => self.v4.longest_match(v4).is_some(),
+            IpAddr::V6(v6) => self.v6.longest_match(v6).is_some(),
         }
     }
 }

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use erased_serde::Serialize as ESerialize;
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use super::cidr_trie::CidrTrie;
 use crate::{
@@ -91,13 +91,6 @@ pub trait RuleProvider: Provider {
     fn search(&self, sess: &Session) -> bool;
     fn behavior(&self) -> RuleSetBehavior;
     fn format(&self) -> RuleSetFormat;
-    /// Returns a human-readable description of which rule matched the session,
-    /// e.g. `"DOMAIN-SUFFIX,google.com"` for Classical or `"8.8.8.0/24"` for
-    /// IPCIDR. Returns `None` if nothing matched or the provider type cannot
-    /// identify the specific rule (Domain behavior).
-    fn match_rule(&self, _sess: &Session) -> Option<String> {
-        None
-    }
     /// Returns up to `limit` rules as strings. Only Classical providers return
     /// non-empty results; Domain/IPCIDR data structures don't support
     /// enumeration.
@@ -278,50 +271,28 @@ impl RuleProviderImpl {
 impl RuleProvider for RuleProviderImpl {
     fn search(&self, sess: &Session) -> bool {
         let inner = self.inner.try_read();
+
         match inner {
             Ok(inner) => match &inner.content {
                 RuleContent::Domain(set) => set.has(&sess.destination.host()),
-                RuleContent::Ipcidr(trie) => {
-                    let ip = sess
-                        .destination
+                RuleContent::Ipcidr(trie) => trie.contains(
+                    sess.destination
                         .ip()
-                        .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
-                    trie.longest_match_str(ip).is_some()
+                        .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+                ),
+                RuleContent::Classical(rules) => {
+                    for rule in rules.iter() {
+                        if rule.apply(sess) {
+                            return true;
+                        }
+                    }
+                    false
                 }
-                RuleContent::Classical(rules) => rules.iter().any(|r| r.apply(sess)),
             },
             Err(_) => {
-                warn!(
-                    "rule provider {} is busy (write lock held); treating as no \
-                     match",
-                    self.name()
-                );
+                debug!("rule provider {} is busy", self.name());
                 false
             }
-        }
-    }
-
-    fn match_rule(&self, sess: &Session) -> Option<String> {
-        let inner = self.inner.try_read().ok()?;
-        match &inner.content {
-            RuleContent::Domain(set) => {
-                if set.has(&sess.destination.host()) {
-                    Some(String::new())
-                } else {
-                    None
-                }
-            }
-            RuleContent::Ipcidr(trie) => {
-                let ip = sess
-                    .destination
-                    .ip()
-                    .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
-                trie.longest_match_str(ip)
-            }
-            RuleContent::Classical(rules) => rules
-                .iter()
-                .find(|r| r.apply(sess))
-                .map(|r| format!("{},{}", r.type_name(), r.payload())),
         }
     }
 
@@ -540,17 +511,6 @@ mod tests {
             ..Default::default()
         };
         assert!(provider.search(&sess));
-        let rule = provider.match_rule(&sess);
-        assert!(rule.is_some());
-        let desc = rule.unwrap();
-        assert!(
-            desc.contains("DOMAIN-SUFFIX"),
-            "Expected DOMAIN-SUFFIX in '{desc}'"
-        );
-        assert!(
-            desc.contains("google.com"),
-            "Expected google.com in '{desc}'"
-        );
     }
 
     #[tokio::test]

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use erased_serde::Serialize as ESerialize;
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use super::cidr_trie::CidrTrie;
 use crate::{
@@ -307,7 +307,11 @@ impl RuleProvider for RuleProviderImpl {
                 }
             },
             Err(_) => {
-                debug!("rule provider {} is busy", self.name());
+                warn!(
+                    "rule provider {} is busy (write lock held); treating as no \
+                     match",
+                    self.name()
+                );
                 None
             }
         }
@@ -523,16 +527,19 @@ mod tests {
 
         assert_ok!(provider.initialize().await);
 
+        let result = provider.search(&Session {
+            destination: SocksAddr::Domain("test.google.com".to_owned(), 443),
+            ..Default::default()
+        });
+        assert!(result.is_some());
+        let desc = result.unwrap();
         assert!(
-            provider
-                .search(&Session {
-                    destination: SocksAddr::Domain(
-                        "test.google.com".to_owned(),
-                        443
-                    ),
-                    ..Default::default()
-                })
-                .is_some()
+            desc.contains("DOMAIN-SUFFIX"),
+            "Expected DOMAIN-SUFFIX in '{desc}'"
+        );
+        assert!(
+            desc.contains("google.com"),
+            "Expected google.com in '{desc}'"
         );
     }
 

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -88,7 +88,11 @@ struct Inner {
 
 #[async_trait]
 pub trait RuleProvider: Provider {
-    fn search(&self, sess: &Session) -> bool;
+    /// Returns `Some(description)` if the session matched a rule, where
+    /// `description` is a human-readable string identifying the matched rule
+    /// (e.g. `"DOMAIN,google.com"` for Classical, or the matched host/IP for
+    /// Domain/IPCIDR providers). Returns `None` if nothing matched.
+    fn search(&self, sess: &Session) -> Option<String>;
     fn behavior(&self) -> RuleSetBehavior;
     fn format(&self) -> RuleSetFormat;
     /// Returns up to `limit` rules as strings. Only Classical providers return
@@ -269,29 +273,42 @@ impl RuleProviderImpl {
 
 #[async_trait]
 impl RuleProvider for RuleProviderImpl {
-    fn search(&self, sess: &Session) -> bool {
+    fn search(&self, sess: &Session) -> Option<String> {
         let inner = self.inner.try_read();
 
         match inner {
             Ok(inner) => match &inner.content {
-                RuleContent::Domain(set) => set.has(&sess.destination.host()),
-                RuleContent::Ipcidr(trie) => trie.contains(
-                    sess.destination
+                RuleContent::Domain(set) => {
+                    let host = sess.destination.host();
+                    if set.has(&host) { Some(host) } else { None }
+                }
+                RuleContent::Ipcidr(trie) => {
+                    let ip = sess
+                        .destination
                         .ip()
-                        .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
-                ),
+                        .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
+                    if trie.contains(ip) {
+                        Some(ip.to_string())
+                    } else {
+                        None
+                    }
+                }
                 RuleContent::Classical(rules) => {
                     for rule in rules.iter() {
                         if rule.apply(sess) {
-                            return true;
+                            return Some(format!(
+                                "{},{}",
+                                rule.type_name(),
+                                rule.payload()
+                            ));
                         }
                     }
-                    false
+                    None
                 }
             },
             Err(_) => {
                 debug!("rule provider {} is busy", self.name());
-                false
+                None
             }
         }
     }
@@ -506,10 +523,17 @@ mod tests {
 
         assert_ok!(provider.initialize().await);
 
-        assert!(provider.search(&Session {
-            destination: SocksAddr::Domain("test.google.com".to_owned(), 443),
-            ..Default::default()
-        }));
+        assert!(
+            provider
+                .search(&Session {
+                    destination: SocksAddr::Domain(
+                        "test.google.com".to_owned(),
+                        443
+                    ),
+                    ..Default::default()
+                })
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -551,9 +575,16 @@ mod tests {
 
         assert_ok!(provider.initialize().await);
 
-        assert!(provider.search(&Session {
-            destination: SocksAddr::Domain("test.google.com".to_owned(), 443),
-            ..Default::default()
-        }));
+        assert!(
+            provider
+                .search(&Session {
+                    destination: SocksAddr::Domain(
+                        "test.google.com".to_owned(),
+                        443
+                    ),
+                    ..Default::default()
+                })
+                .is_some()
+        );
     }
 }

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -88,13 +88,16 @@ struct Inner {
 
 #[async_trait]
 pub trait RuleProvider: Provider {
-    /// Returns `Some(description)` if the session matched a rule, where
-    /// `description` is a human-readable string identifying the matched rule
-    /// (e.g. `"DOMAIN,google.com"` for Classical, or the matched host/IP for
-    /// Domain/IPCIDR providers). Returns `None` if nothing matched.
-    fn search(&self, sess: &Session) -> Option<String>;
+    fn search(&self, sess: &Session) -> bool;
     fn behavior(&self) -> RuleSetBehavior;
     fn format(&self) -> RuleSetFormat;
+    /// Returns a human-readable description of which rule matched the session,
+    /// e.g. `"DOMAIN-SUFFIX,google.com"` for Classical or `"8.8.8.0/24"` for
+    /// IPCIDR. Returns `None` if nothing matched or the provider type cannot
+    /// identify the specific rule (Domain behavior).
+    fn match_rule(&self, _sess: &Session) -> Option<String> {
+        None
+    }
     /// Returns up to `limit` rules as strings. Only Classical providers return
     /// non-empty results; Domain/IPCIDR data structures don't support
     /// enumeration.
@@ -273,38 +276,19 @@ impl RuleProviderImpl {
 
 #[async_trait]
 impl RuleProvider for RuleProviderImpl {
-    fn search(&self, sess: &Session) -> Option<String> {
+    fn search(&self, sess: &Session) -> bool {
         let inner = self.inner.try_read();
-
         match inner {
             Ok(inner) => match &inner.content {
-                RuleContent::Domain(set) => {
-                    let host = sess.destination.host();
-                    if set.has(&host) { Some(host) } else { None }
-                }
+                RuleContent::Domain(set) => set.has(&sess.destination.host()),
                 RuleContent::Ipcidr(trie) => {
                     let ip = sess
                         .destination
                         .ip()
                         .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
-                    if trie.contains(ip) {
-                        Some(ip.to_string())
-                    } else {
-                        None
-                    }
+                    trie.longest_match_str(ip).is_some()
                 }
-                RuleContent::Classical(rules) => {
-                    for rule in rules.iter() {
-                        if rule.apply(sess) {
-                            return Some(format!(
-                                "{},{}",
-                                rule.type_name(),
-                                rule.payload()
-                            ));
-                        }
-                    }
-                    None
-                }
+                RuleContent::Classical(rules) => rules.iter().any(|r| r.apply(sess)),
             },
             Err(_) => {
                 warn!(
@@ -312,8 +296,32 @@ impl RuleProvider for RuleProviderImpl {
                      match",
                     self.name()
                 );
-                None
+                false
             }
+        }
+    }
+
+    fn match_rule(&self, sess: &Session) -> Option<String> {
+        let inner = self.inner.try_read().ok()?;
+        match &inner.content {
+            RuleContent::Domain(set) => {
+                if set.has(&sess.destination.host()) {
+                    Some(String::new())
+                } else {
+                    None
+                }
+            }
+            RuleContent::Ipcidr(trie) => {
+                let ip = sess
+                    .destination
+                    .ip()
+                    .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
+                trie.longest_match_str(ip)
+            }
+            RuleContent::Classical(rules) => rules
+                .iter()
+                .find(|r| r.apply(sess))
+                .map(|r| format!("{},{}", r.type_name(), r.payload())),
         }
     }
 
@@ -527,12 +535,14 @@ mod tests {
 
         assert_ok!(provider.initialize().await);
 
-        let result = provider.search(&Session {
+        let sess = Session {
             destination: SocksAddr::Domain("test.google.com".to_owned(), 443),
             ..Default::default()
-        });
-        assert!(result.is_some());
-        let desc = result.unwrap();
+        };
+        assert!(provider.search(&sess));
+        let rule = provider.match_rule(&sess);
+        assert!(rule.is_some());
+        let desc = rule.unwrap();
         assert!(
             desc.contains("DOMAIN-SUFFIX"),
             "Expected DOMAIN-SUFFIX in '{desc}'"
@@ -582,16 +592,9 @@ mod tests {
 
         assert_ok!(provider.initialize().await);
 
-        assert!(
-            provider
-                .search(&Session {
-                    destination: SocksAddr::Domain(
-                        "test.google.com".to_owned(),
-                        443
-                    ),
-                    ..Default::default()
-                })
-                .is_some()
-        );
+        assert!(provider.search(&Session {
+            destination: SocksAddr::Domain("test.google.com".to_owned(), 443),
+            ..Default::default()
+        }));
     }
 }

--- a/clash-lib/src/app/router/rules/ruleset.rs
+++ b/clash-lib/src/app/router/rules/ruleset.rs
@@ -35,7 +35,7 @@ impl std::fmt::Display for RuleSet {
 
 impl RuleMatcher for RuleSet {
     fn apply(&self, sess: &Session) -> bool {
-        self.rule_provider.search(sess)
+        self.rule_provider.search(sess).is_some()
     }
 
     fn target(&self) -> &str {

--- a/clash-lib/src/app/router/rules/ruleset.rs
+++ b/clash-lib/src/app/router/rules/ruleset.rs
@@ -35,7 +35,7 @@ impl std::fmt::Display for RuleSet {
 
 impl RuleMatcher for RuleSet {
     fn apply(&self, sess: &Session) -> bool {
-        self.rule_provider.search(sess).is_some()
+        self.rule_provider.search(sess)
     }
 
     fn target(&self) -> &str {


### PR DESCRIPTION
## Summary

### Dark mode & theme toggle
- Full CSS custom property system for light/dark theming
- Manual System/Light/Dark toggle in nav bar (persisted in localStorage)
- All hardcoded inline colors replaced with `var(--color-*)` vars

### Bug fixes: test refresh never updating
**Root cause:** `request()` called `JSON.parse()` on plain-text 202 responses (e.g. `"provider healthcheck"`). This threw a `SyntaxError` that was silently swallowed by `catch {}` in `testAllInProvider`/`testGroupDelay`, so `invalidateQueries` never ran and latencies never updated.
**Fix:** Wrap `JSON.parse` in try/catch; return `undefined` for non-JSON 2xx.

### Group latency in header
- Group cards now show the group's own latency in the header (from last `/group/{name}/delay` test, falling back to stored history)
- Group chips now use a merged proxy map (registry + provider proxies) so provider-sourced members show latency instead of —

### Batch "Test All" button
- Added to top of Proxies page — runs all provider healthchecks + all static proxy delay tests in parallel, then refreshes both data sources

### Rule match bar
- `GlobalRuleMatchBar` wired into Rules page — test any rule match across all providers from a single input at the top of the page

### Also
- Switch from `invalidateQueries` → `refetchQueries` for immediate forced reload after healthcheck
- Group test now refetches both `proxies` and `providers` queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme toggle (system/light/dark) with persistence
  * Global rule-match tester that reports per-provider confirmed matches (includes matched rule text)
  * Page-level “Test All” proxy testing and improved group latency reporting

* **Style**
  * App-wide centralized theme tokens; extensive UI elements now use theme-aware variables

* **Bug Fixes**
  * More robust handling of non-JSON API responses and standardized JSON success messages/status codes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->