### PR TITLE
chore: bump rust-proxy/workflows to v1.0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.12
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.13
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -40,7 +40,7 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.12
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.13
     with:
       cliff-config: '.github/cliff.toml'
       create-latest-on-push: true
@@ -48,7 +48,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.12
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.13
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Picks up two fixes from [rust-proxy/workflows#4](https://github.com/rust-proxy/workflows/pull/4):

- **Fix**: release notes containing double quotes no longer break the stable release `gh release create` command (was causing v0.10.3 release failure)
- **Feat**: nightly `latest` release now gets a real git-cliff `--unreleased` changelog instead of a static SHA message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->