### PR TITLE
fix: pin docker-publish workflow back to v1.0.12

### DIFF
--- a/.github/agents/rust-expert.md
+++ b/.github/agents/rust-expert.md
@@ -53,3 +53,7 @@ Key directories inside `clash-lib/src/`:
 - Do not over-engineer: no premature abstractions, no unnecessary generics.
 - Prefer editing existing files over creating new ones.
 - Follow existing patterns in the codebase before introducing new ones.
+
+## Git Workflow
+
+- **Never commit or push directly to `master`** — always create a PR branch and open a pull request.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.13
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.12
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.12
-    secrets:
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.13
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'clash-rs'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,3 +146,7 @@ Main configuration sections:
 - `rules` - Traffic routing rules
 - `proxies` - Outbound proxy definitions
 - `proxy-groups` - Proxy group configurations
+
+## Git Workflow
+
+**Never commit or push directly to `master`** — always create a PR branch and open a pull request.


### PR DESCRIPTION
v1.0.13 introduced a breaking API change in `docker-publish.yml` — it replaced separate `dockerhub-username`/`dockerhub-token` secrets with a single combined `registrys` secret.\n\nPin `docker-publish` back to v1.0.12 to keep the existing interface working, while `release-publish` and `rust-build` stay on v1.0.13 to get the release notes fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow for Docker publishing: switched to a different reusable workflow version and adjusted how publishing credentials/inputs are provided.

* **Documentation**
  * Added Git Workflow guidance across docs: contributors should not push directly to master and should create PR branches and open pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->