### PR TITLE
Optimize 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11641,7 +11641,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",

--- a/clash-lib/src/app/dispatcher/tracked.rs
+++ b/clash-lib/src/app/dispatcher/tracked.rs
@@ -276,14 +276,18 @@ impl AsyncRead for TrackedStream {
 
         let v = Pin::new(self.inner.as_mut()).poll_read(cx, buf);
         let download = buf.filled().len();
-        self.manager.push_downloaded(download);
-        self.tracker
-            .download_total
-            .fetch_add(download as u64, std::sync::atomic::Ordering::Release);
-        if self.tracker.session_holder.inbound_user.is_some() {
+        // Skip atomic counter updates when no bytes were read (e.g. Poll::Pending),
+        // avoiding multiple no-op fetch_add calls on every wakeup in the hot path.
+        if download > 0 {
+            self.manager.push_downloaded(download);
             self.tracker
-                .user_download
-                .fetch_add(download as u64, std::sync::atomic::Ordering::Relaxed);
+                .download_total
+                .fetch_add(download as u64, std::sync::atomic::Ordering::Release);
+            if self.tracker.session_holder.inbound_user.is_some() {
+                self.tracker
+                    .user_download
+                    .fetch_add(download as u64, std::sync::atomic::Ordering::Relaxed);
+            }
         }
 
         v

--- a/clash-lib/src/common/io/mod.rs
+++ b/clash-lib/src/common/io/mod.rs
@@ -69,18 +69,6 @@ pub struct CopyBuffer {
 }
 
 impl CopyBuffer {
-    #[allow(unused)]
-    pub fn new() -> Self {
-        Self {
-            read_done: false,
-            need_flush: false,
-            pos: 0,
-            cap: 0,
-            amt: 0,
-            buf: vec![0; 2 * 1024].into_boxed_slice(),
-        }
-    }
-
     pub fn new_with_capacity(size: usize) -> Result<Self, std::io::Error> {
         let mut buf = Vec::new();
         buf.try_reserve(size)
@@ -153,26 +141,39 @@ impl CopyBuffer {
             }
 
             // If our buffer has some data, let's write it out!
+            //
+            // We track the position before the write loop so that we can
+            // reset the idle timer at most once per poll_copy invocation
+            // rather than once per partial-write chunk, avoiding redundant
+            // Sleep::reset() and Instant::now() calls on the hot path.
+            let pos_before_write = self.pos;
             while self.pos < self.cap {
                 let me = &mut *self;
-                let i =
-                    ready!(writer.as_mut().poll_write(cx, &me.buf[me.pos..me.cap]))?;
-                if i == 0 {
-                    return Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::WriteZero,
-                        "write zero byte into writer",
-                    )));
-                } else {
-                    self.pos += i;
-                    self.amt += i as u64;
-                    self.need_flush = true;
-                    // Reset idle timeout on successful write
-                    if let (Some(timeout), Some(duration)) =
-                        (idle_timeout.as_mut(), idle_timeout_duration)
-                    {
-                        timeout
-                            .as_mut()
-                            .reset(tokio::time::Instant::now() + duration);
+                match writer.as_mut().poll_write(cx, &me.buf[me.pos..me.cap]) {
+                    Poll::Ready(Ok(0)) => {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "write zero byte into writer",
+                        )));
+                    }
+                    Poll::Ready(Ok(i)) => {
+                        self.pos += i;
+                        self.amt += i as u64;
+                        self.need_flush = true;
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => {
+                        // If any bytes were written before the write stalled,
+                        // reset the idle timer once to keep the connection alive.
+                        if self.pos > pos_before_write
+                            && let (Some(timeout), Some(duration)) =
+                                (idle_timeout.as_mut(), idle_timeout_duration)
+                        {
+                            timeout
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + duration);
+                        }
+                        return Poll::Pending;
                     }
                 }
             }
@@ -184,6 +185,17 @@ impl CopyBuffer {
                 self.pos <= self.cap,
                 "writer returned length larger than input slice"
             );
+
+            // Reset the idle timer once after successfully draining the write
+            // buffer — at most one Sleep::reset() per poll_copy invocation.
+            if self.pos > pos_before_write
+                && let (Some(timeout), Some(duration)) =
+                    (idle_timeout.as_mut(), idle_timeout_duration)
+            {
+                timeout
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + duration);
+            }
 
             // If we've written all the data and we've seen EOF, flush out the
             // data and finish the transfer.

--- a/clash-lib/src/proxy/anytls/inbound/framing.rs
+++ b/clash-lib/src/proxy/anytls/inbound/framing.rs
@@ -14,12 +14,17 @@ pub(crate) const CMD_ALERT: u8 = 5;
 pub(crate) const UDP_OVER_TCP_V2_MAGIC_HOST: &str = "sp.v2.udp-over-tcp.arpa";
 
 /// Read one AnyTLS frame: `CMD(1) | StreamID(u32-BE) | DataLen(u16-BE) | Data`.
+///
+/// The 7-byte header is read in a single `read_exact` call to avoid the
+/// overhead of three separate async read round-trips.
 pub(crate) async fn read_frame(
     reader: &mut (impl AsyncRead + Unpin),
 ) -> std::io::Result<(u8, u32, Vec<u8>)> {
-    let command = reader.read_u8().await?;
-    let stream_id = reader.read_u32().await?;
-    let data_len = reader.read_u16().await? as usize;
+    let mut header = [0u8; 7];
+    reader.read_exact(&mut header).await?;
+    let command = header[0];
+    let stream_id = u32::from_be_bytes(header[1..5].try_into().unwrap());
+    let data_len = u16::from_be_bytes(header[5..7].try_into().unwrap()) as usize;
     let mut data = vec![0u8; data_len];
     if data_len > 0 {
         reader.read_exact(&mut data).await?;
@@ -28,6 +33,9 @@ pub(crate) async fn read_frame(
 }
 
 /// Write one AnyTLS frame to `writer`.
+///
+/// The 7-byte header is written in a single `write_all` call to avoid the
+/// overhead of three separate async write round-trips.
 pub(crate) async fn write_frame(
     writer: &mut (impl AsyncWrite + Unpin),
     command: u8,
@@ -40,9 +48,11 @@ pub(crate) async fn write_frame(
             "anytls frame payload exceeds 65535 bytes",
         ));
     }
-    writer.write_u8(command).await?;
-    writer.write_u32(stream_id).await?;
-    writer.write_u16(data.len() as u16).await?;
+    let mut header = [0u8; 7];
+    header[0] = command;
+    header[1..5].copy_from_slice(&stream_id.to_be_bytes());
+    header[5..7].copy_from_slice(&(data.len() as u16).to_be_bytes());
+    writer.write_all(&header).await?;
     if !data.is_empty() {
         writer.write_all(data).await?;
     }

--- a/clash-lib/src/proxy/anytls/mod.rs
+++ b/clash-lib/src/proxy/anytls/mod.rs
@@ -279,6 +279,8 @@ impl Handler {
         Ok(buf)
     }
 
+    /// Write one AnyTLS frame. The 7-byte header is batched into a single
+    /// `write_all` to avoid three separate async write round-trips per frame.
     async fn write_frame(
         writer: &mut (impl AsyncWrite + Unpin),
         command: u8,
@@ -291,22 +293,27 @@ impl Handler {
                 "anytls frame payload exceeds 65535 bytes",
             ));
         }
-
-        writer.write_u8(command).await?;
-        writer.write_u32(stream_id).await?;
-        writer.write_u16(data.len() as u16).await?;
+        let mut header = [0u8; 7];
+        header[0] = command;
+        header[1..5].copy_from_slice(&stream_id.to_be_bytes());
+        header[5..7].copy_from_slice(&(data.len() as u16).to_be_bytes());
+        writer.write_all(&header).await?;
         if !data.is_empty() {
             writer.write_all(data).await?;
         }
         Ok(())
     }
 
+    /// Read one AnyTLS frame. The 7-byte header is read in a single
+    /// `read_exact` to avoid three separate async read round-trips per frame.
     async fn read_frame(
         reader: &mut (impl AsyncRead + Unpin),
     ) -> io::Result<(u8, u32, Vec<u8>)> {
-        let command = reader.read_u8().await?;
-        let stream_id = reader.read_u32().await?;
-        let data_len = reader.read_u16().await? as usize;
+        let mut header = [0u8; 7];
+        reader.read_exact(&mut header).await?;
+        let command = header[0];
+        let stream_id = u32::from_be_bytes(header[1..5].try_into().unwrap());
+        let data_len = u16::from_be_bytes(header[5..7].try_into().unwrap()) as usize;
         let mut data = vec![0u8; data_len];
         if data_len > 0 {
             reader.read_exact(&mut data).await?;

--- a/clash-lib/src/proxy/http/inbound/connector.rs
+++ b/clash-lib/src/proxy/http/inbound/connector.rs
@@ -65,7 +65,7 @@ impl tower::Service<Uri> for Connector {
         let destination = maybe_socks_addr(&url);
         let fw_mark = self.fw_mark;
         async move {
-            let (left, right) = duplex(1024 * 1024);
+            let (left, right) = duplex(64 * 1024);
 
             let sess = Session {
                 network: Network::Tcp,

--- a/clash-lib/src/proxy/http/inbound/proxy.rs
+++ b/clash-lib/src/proxy/http/inbound/proxy.rs
@@ -47,6 +47,7 @@ async fn proxy(
     src: SocketAddr,
     dispatcher: Arc<Dispatcher>,
     authenticator: ThreadSafeAuthenticator,
+    client: Client<Connector, hyper::body::Incoming>,
     fw_mark: Option<u32>,
 ) -> Result<Response<BoxBody<Bytes, std::io::Error>>, ProxyError> {
     if authenticator.enabled()
@@ -54,11 +55,6 @@ async fn proxy(
     {
         return Ok(res);
     }
-
-    let client = Client::builder(TokioExecutor::new())
-        .http1_title_case_headers(true)
-        .http1_preserve_header_case(true)
-        .build(Connector::new(src, dispatcher.clone(), fw_mark));
 
     // TODO: handle other upgrades: https://github.com/hyperium/hyper/blob/master/examples/upgrades.rs
     if req.method() == Method::CONNECT {
@@ -121,6 +117,7 @@ struct ProxyService {
     src: SocketAddr,
     dispatcher: Arc<Dispatcher>,
     authenticator: ThreadSafeAuthenticator,
+    client: Client<Connector, hyper::body::Incoming>,
     fw_mark: Option<u32>,
 }
 
@@ -135,6 +132,7 @@ impl hyper::service::Service<Request<hyper::body::Incoming>> for ProxyService {
             self.src,
             self.dispatcher.clone(),
             self.authenticator.clone(),
+            self.client.clone(),
             self.fw_mark,
         ))
     }
@@ -148,6 +146,11 @@ pub async fn handle(
     authenticator: ThreadSafeAuthenticator,
     fw_mark: Option<u32>,
 ) {
+    let client = Client::builder(TokioExecutor::new())
+        .http1_title_case_headers(true)
+        .http1_preserve_header_case(true)
+        .build(Connector::new(src, dispatcher.clone(), fw_mark));
+
     let result = http1::Builder::new()
         .preserve_header_case(true)
         .title_case_headers(true)
@@ -157,6 +160,7 @@ pub async fn handle(
                 src,
                 dispatcher,
                 authenticator,
+                client,
                 fw_mark,
             },
         )


### PR DESCRIPTION
- [x] AnyTLS `write_frame`/`read_frame`: batch 7-byte header into single I/O op (both inbound `framing.rs` and outbound `mod.rs`)
- [x] `TrackedStream::poll_read`: skip no-op atomic counters when `Poll::Pending` returns 0 bytes
- [x] HTTP inbound `connector.rs`: reduce per-request duplex pipe from 1 MB to 64 KB
- [x] `common/io/mod.rs` — `poll_copy` write loop:
  - Replace `ready!` macro with explicit `match` to enable precise tracking of bytes written
  - Reset `Sleep::reset()` + `Instant::now()` at most once per `poll_copy` invocation instead of once per partial-write chunk (O(N) → O(1))
  - `Pending` branch resets timer only if bytes were actually written before stalling
- [x] Remove dead `CopyBuffer::new()` (`#[allow(unused)]`)
- [x] Build passes, 202 tests pass (7 network failures are sandbox environment restrictions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized frame I/O by batching header operations into single read/write calls
  * Improved download tracking accuracy by eliminating spurious counter updates
  * Enhanced idle-timeout handling for better resource efficiency
  * Reduced HTTP connector buffer memory usage
  * Refactored HTTP proxy client management for improved lifecycle handling

* **Breaking Changes**
  * Removed `CopyBuffer::new()` constructor; use `new_with_capacity()` instead

<!-- end of auto-generated comment: release notes by coderabbit.ai -->