### PR TITLE
fix: use child_token() instead of clone() for reload API server cancellation token

### DIFF
--- a/clash-lib/src/app/remote_content_manager/mod.rs
+++ b/clash-lib/src/app/remote_content_manager/mod.rs
@@ -1001,15 +1001,24 @@ mod tests {
         tests::initialize,
     };
     use futures::TryFutureExt;
+    use httpmock::{Method::GET, MockServer};
     use std::{net::Ipv4Addr, sync::Arc, time::Duration};
 
     #[tokio::test]
     async fn test_proxy_manager_alive() {
         initialize();
-        let mut mock_resolver = MockClashResolver::new();
-        mock_resolver.expect_resolve().returning(|_, _| {
-            Ok(Some(std::net::IpAddr::V4(Ipv4Addr::new(142, 250, 66, 227))))
+
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/generate_204");
+            then.status(204);
         });
+        let url = server.url("/generate_204");
+
+        let mut mock_resolver = MockClashResolver::new();
+        mock_resolver
+            .expect_resolve()
+            .returning(|_, _| Ok(Some(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST))));
         mock_resolver.expect_ipv6().return_const(false);
 
         let manager =
@@ -1018,11 +1027,7 @@ mod tests {
         let mock_handler = Arc::new(direct::Handler::new(PROXY_DIRECT));
 
         manager
-            .url_test(
-                mock_handler.clone(),
-                "http://www.gstatic.com/generate_204",
-                None,
-            )
+            .url_test(mock_handler.clone(), &url, None)
             .await
             .expect("test failed");
 
@@ -1031,7 +1036,7 @@ mod tests {
             manager
                 .last_delay(PROXY_DIRECT)
                 .await
-                .is_some_and(|x| x.as_millis() > 0)
+                .is_some_and(|x| x.as_nanos() > 0)
         );
         assert!(!manager.delay_history(PROXY_DIRECT).await.is_empty());
 
@@ -1040,11 +1045,7 @@ mod tests {
 
         for _ in 0..10 {
             manager
-                .url_test(
-                    mock_handler.clone(),
-                    "http://www.gstatic.com/generate_204",
-                    None,
-                )
+                .url_test(mock_handler.clone(), &url, None)
                 .await
                 .expect("test failed");
         }
@@ -1054,7 +1055,7 @@ mod tests {
             manager
                 .last_delay(PROXY_DIRECT)
                 .await
-                .is_some_and(|x| x.as_millis() > 0)
+                .is_some_and(|x| x.as_nanos() > 0)
         );
         assert_eq!(manager.delay_history(PROXY_DIRECT).await.len(), 10);
     }

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -342,7 +342,7 @@ pub async fn start(
                 new_components.cache_store.clone(),
                 new_components.router.clone(),
                 cwd_clone.to_string_lossy().to_string(),
-                Some(reload_token.clone()),
+                Some(reload_token.child_token()),
                 new_components.dns_listen.clone(),
                 new_components.dns_enabled,
             ));


### PR DESCRIPTION
CancellationToken::clone() shares cancellation state, so shutting down the old API server on reload would also cancel the new one's token, causing delay/healthcheck endpoints to become unreachable after the second hot-reload cycle.

### What does this PR do?

<!-- Briefly describe the change and why it's needed. Link related issues with `closes #xxx` if applicable. -->

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / cleanup
- [ ] Other

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling during configuration reloads to reduce resource leaks and increase stability of the API server lifecycle.

* **Tests**
  * Updated unit tests to use local mock endpoints and more reliable timing checks, improving test robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->