### PR TITLE
fix(dispatcher): canonicalize IPv4-mapped IPv6 UDP source to prevent EAFNOSUPPORT

### DIFF
--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -279,7 +279,18 @@ impl Dispatcher {
                     }
                 };
 
-                sess.source = packet.src_addr.clone().must_into_socket_addr();
+                // Canonicalize IPv4-mapped IPv6 source addresses (e.g. a
+                // client connecting via IPv4 on a dual-stack inbound socket
+                // appears as ::ffff:x.x.x.x).  Without canonicalization,
+                // direct/mod.rs sees sess.source.is_ipv4() == false and picks
+                // bind_addr=:: while family_hint picks AF_INET for the
+                // destination — binding an AF_INET socket to [::]:0 fails with
+                // EAFNOSUPPORT (os error 97), silently dropping all UDP replies.
+                sess.source = packet
+                    .src_addr
+                    .clone()
+                    .must_into_socket_addr()
+                    .to_canonical();
                 sess.destination = dest.clone();
                 sess.inbound_user = packet.inbound_user.clone();
 


### PR DESCRIPTION
## Problem

When an SS2022 inbound listener is bound to `::` (dual-stack socket, used when `ipv6_enabled=true`), incoming IPv4 clients appear with source address `::ffff:x.x.x.x`.

`sess.source` was set directly from `packet.src_addr` without canonicalization. In `direct/mod.rs connect_datagram`, the outbound bind address is chosen with:

```rust
let bind_addr = if sess.source.is_ipv4() { 0.0.0.0 } else { :: };
```

Since `::ffff:x.x.x.x` is `SocketAddr::V6`, `is_ipv4()` returns `false`, selecting `bind_addr=::`.

Meanwhile `family_hint_for_session` uses `sess.resolved_ip` (already canonicalized to plain IPv4 in #1312) and produces `Some([1.1.1.1]:53)`, causing `new_udp_socket` to create an **AF_INET socket**. Binding that AF_INET socket to `[::]:0` fails with **EAFNOSUPPORT (os error 97)**, silently dropping all outbound UDP datagrams — IPv4 clients on dual-stack inbound sockets receive no response.

This was observed in production: nodes with `listen: '::'\ (all nodes with `ipv6_enabled=true`) that had been restarted after the dual-stack config was introduced showed consistent UDP probe timeouts, while nodes still running the old `0.0.0.0` config were unaffected.

## Fix

Canonicalize `sess.source` immediately after deriving it from `packet.src_addr`, converting `::ffff:x.x.x.x → x.x.x.x`. This ensures `bind_addr` correctly resolves to `0.0.0.0` for IPv4 clients connecting through dual-stack inbound sockets.

The `ToCanonical` trait was already imported in `dispatcher_impl.rs` (added in #1312 for `packet.dst_addr`); this PR applies the same canonicalization to the source side.

## Related

- #1312 — canonicalized `packet.dst_addr` (destination side); this PR covers the source side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of UDP source address canonicalization to ensure correct IPv4/IPv6 address family behavior for network replies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1391)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->