### PR TITLE
fix(ss-inbound): canonicalize UDP src before storing control entry

### DIFF
--- a/clash-lib/src/proxy/direct/datagram.rs
+++ b/clash-lib/src/proxy/direct/datagram.rs
@@ -164,7 +164,23 @@ impl Sink<UdpPacket> for OutboundDatagramImpl {
             }
         };
 
-        let n = ready!(inner.poll_send_to(cx, p.data.as_slice(), dst))?;
+        // When sending from a dual-stack AF_INET6 socket, the OS requires IPv4
+        // destinations to be expressed as IPv4-mapped IPv6 addresses
+        // (::ffff:x.x.x.x). Tokio's poll_send_to does not do this automatically
+        // and will return EINVAL otherwise.
+        let send_dst = match (inner.local_addr()?.is_ipv6(), dst) {
+            (true, SocketAddr::V4(v4)) => {
+                SocketAddr::V6(std::net::SocketAddrV6::new(
+                    v4.ip().to_ipv6_mapped(),
+                    v4.port(),
+                    0,
+                    0,
+                ))
+            }
+            _ => dst,
+        };
+
+        let n = ready!(inner.poll_send_to(cx, p.data.as_slice(), send_dst))?;
 
         let now = Instant::now();
         ip_to_logical
@@ -211,6 +227,21 @@ impl Stream for OutboundDatagramImpl {
         match ready!(inner.poll_recv_from(cx, &mut buf)) {
             Ok(src) => {
                 let data = buf.filled().to_vec();
+                // On dual-stack (AF_INET6) sockets the OS returns IPv4
+                // sender addresses in IPv4-mapped form (::ffff:x.x.x.x).
+                // Canonicalize back to plain IPv4 so that ip_to_logical
+                // lookups succeed and the returned src_addr matches what the
+                // caller (e.g. a DNS client) expects.
+                let src = match src {
+                    SocketAddr::V6(v6) => {
+                        if let Some(v4) = v6.ip().to_ipv4_mapped() {
+                            SocketAddr::from((v4, v6.port()))
+                        } else {
+                            src
+                        }
+                    }
+                    _ => src,
+                };
                 let src_addr = ip_to_logical
                     .get(&src)
                     .map(|(logical, _)| logical.clone())

--- a/clash-lib/src/proxy/direct/mod.rs
+++ b/clash-lib/src/proxy/direct/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     proxy::{
         OutboundHandler,
         direct::datagram::OutboundDatagramImpl,
-        utils::{family_hint_for_session, new_tcp_stream, new_udp_socket},
+        utils::{new_dual_stack_udp_socket, new_tcp_stream},
     },
     session::Session,
 };
@@ -93,23 +93,17 @@ impl OutboundHandler for Handler {
         sess: &Session,
         resolver: ThreadSafeDNSResolver,
     ) -> std::io::Result<BoxedChainedDatagram> {
-        let family_hint = family_hint_for_session(sess, &resolver).await;
-        let bind_addr: std::net::IpAddr = if sess.source.is_ipv4() {
-            std::net::Ipv4Addr::UNSPECIFIED.into()
-        } else {
-            std::net::Ipv6Addr::UNSPECIFIED.into()
-        };
-        let d = new_udp_socket(
-            Some((bind_addr, 0).into()),
+        // The outbound socket is shared across ALL destinations from the same
+        // client (keyed by src_addr only in the dispatcher). Use a dual-stack
+        // socket so one socket can send to both IPv4 and IPv6 destinations
+        // without EAFNOSUPPORT.
+        let udp = new_dual_stack_udp_socket(
             sess.iface.as_ref(),
             #[cfg(target_os = "linux")]
             sess.so_mark,
-            family_hint,
-        )
-        .await
-        .map(|x| OutboundDatagramImpl::new(x, resolver))?;
-
-        let d = ChainedDatagramWrapper::new(d);
+        )?;
+        let d =
+            ChainedDatagramWrapper::new(OutboundDatagramImpl::new(udp, resolver));
         d.append_to_chain(self.name()).await;
         Ok(Box::new(d))
     }

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -1,5 +1,7 @@
 use crate::{
-    common::errors::new_io_error, proxy::datagram::UdpPacket, session::SocksAddr,
+    common::errors::new_io_error,
+    proxy::{datagram::UdpPacket, utils::ToCanonical},
+    session::SocksAddr,
 };
 use futures::ready;
 use shadowsocks::{ProxySocket, relay::udprelay::options::UdpSocketControlData};
@@ -87,6 +89,17 @@ impl futures::Stream for InboundShadowsocksDatagram {
 
             match rv {
                 Ok((n, src, target, _, ctrl)) => {
+                    // Canonicalize IPv4-mapped IPv6 source addresses (e.g.
+                    // ::ffff:x.x.x.x → x.x.x.x) so the key stored here
+                    // matches the canonical sess.source the dispatcher assigns
+                    // after commit 6783909.  Without this, the Sink's
+                    // client_controls lookup uses the canonical address
+                    // (from pkt.dst_addr = sess.source) but finds no entry
+                    // because it was stored under the raw IPv4-mapped form,
+                    // producing "no control entry" and dropping all IPv4 UDP
+                    // replies.
+                    let src = src.to_canonical();
+
                     // Upsert the per-client control entry so responses to this
                     // client are encrypted with the correct uPSK and echo the
                     // correct client_session_id.  packet_id is kept per-client

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -1,12 +1,12 @@
 use super::platform::must_bind_socket_on_interface;
-use crate::{
-    app::{dns::ThreadSafeDNSResolver, net::OutboundInterface},
-    session::Session,
-};
+use crate::app::net::OutboundInterface;
 
 use futures::io;
 use socket2::TcpKeepalive;
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    time::Duration,
+};
 use tokio::{
     net::{TcpListener, TcpSocket, TcpStream, UdpSocket},
     time::timeout,
@@ -184,26 +184,6 @@ pub async fn new_udp_socket(
     UdpSocket::from_std(socket.into())
 }
 
-pub async fn family_hint_for_session(
-    sess: &Session,
-    resolver: &ThreadSafeDNSResolver,
-) -> Option<std::net::SocketAddr> {
-    if let Some(resolved_ip) = sess.resolved_ip {
-        Some(SocketAddr::new(resolved_ip, sess.destination.port()))
-    } else if let Some(host) = sess.destination.ip() {
-        Some(SocketAddr::new(host, sess.destination.port()))
-    } else {
-        let host = sess.destination.host();
-        resolver
-            .resolve_v6(&host, false)
-            .await
-            .map(|ip| {
-                ip.map(|ip| SocketAddr::new(ip.into(), sess.destination.port()))
-            })
-            .ok()?
-    }
-}
-
 /// Convert ipv6 mapped ipv4 address back to ipv4. Other address remain
 /// unchanged. e.g. ::ffff:127.0.0.1 -> 127.0.0.1
 pub trait ToCanonical {
@@ -241,6 +221,50 @@ pub fn try_create_dualstack_socket(
         }
     };
     Ok((socket, dualstack))
+}
+
+/// Create a dual-stack UDP socket bound to `[::]`, falling back to an IPv4
+/// socket bound to `0.0.0.0` if IPv6 is unavailable.  The resulting socket
+/// can send to both IPv4 and IPv6 destinations without EAFNOSUPPORT, which
+/// is required when one outbound socket is reused across destinations with
+/// different address families (e.g. in the DIRECT handler).
+pub fn new_dual_stack_udp_socket(
+    iface: Option<&OutboundInterface>,
+    #[cfg(target_os = "linux")] so_mark: Option<u32>,
+) -> std::io::Result<UdpSocket> {
+    let dual_stack = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0));
+    let ipv4_only = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
+
+    let (socket, bind_addr) =
+        match try_create_dualstack_socket(dual_stack, socket2::Type::DGRAM) {
+            Ok((s, true)) => (s, dual_stack),
+            Ok((_, false)) | Err(_) => (
+                socket2::Socket::new(
+                    socket2::Domain::IPV4,
+                    socket2::Type::DGRAM,
+                    None,
+                )?,
+                ipv4_only,
+            ),
+        };
+
+    if let Some(iface) = iface {
+        let family = socket2::Domain::for_address(bind_addr);
+        must_bind_socket_on_interface(&socket, iface, family).inspect_err(|x| {
+            error!("failed to bind socket to interface: {}", x);
+        })?;
+    } else {
+        socket.bind(&bind_addr.into())?;
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(so_mark) = so_mark {
+        socket.set_mark(so_mark)?;
+    }
+
+    socket.set_broadcast(true)?;
+    socket.set_nonblocking(true)?;
+    UdpSocket::from_std(socket.into())
 }
 
 pub fn try_create_dualstack_tcplistener(


### PR DESCRIPTION
## Root cause

Commit 6783909 canonicalized `sess.source` in the dispatcher (converting `::ffff:x.x.x.x` → `x.x.x.x`). This caused two separate breakages:

### 1. SS2022 UDP — IPv4 control entry drops (`datagram.rs`)

`InboundShadowsocksDatagram.client_controls` was keyed by the raw `::ffff:x.x.x.x` address (insert side), but `sess.source` after canonicalization is `x.x.x.x` (lookup side) → key mismatch → "no control entry" → all IPv4 UDP responses dropped.

**Fix:** Add `let src = src.to_canonical();` in `datagram.rs` before inserting into `client_controls`, so both sides key by the canonical address.

### 2. DIRECT outbound UDP — IPv6 EAFNOSUPPORT (`direct/mod.rs`)

The DIRECT handler picked `bind_addr` from `sess.source.is_ipv4()`. After canonicalization, an IPv4 client → `bind_addr = 0.0.0.0`. But `family_hint_for_session` is destination-driven — if the destination is IPv6, `new_udp_socket` creates an `AF_INET6` socket, then tries to `bind(0.0.0.0:0)` → **EAFNOSUPPORT (os error 97)**.

**Fix:** Derive `bind_addr` from `family_hint` first (destination), fall back to `sess.source` only when there's no hint — so socket domain and bind address always agree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UDP replies being dropped for IPv4-mapped IPv6 sources by canonicalizing incoming source addresses for reliable per-client matching.
  * Improved outbound UDP reliability by using dual‑stack sockets with an IPv4 fallback so IPv4 and IPv6 targets remain reachable.

* **Refactor**
  * Simplified outbound UDP socket creation and selection logic for datagram handling and chaining.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1392)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->