### PR TITLE
fix(direct): align UDP bind_addr family with family_hint destination

### DIFF
--- a/clash-lib/src/proxy/direct/mod.rs
+++ b/clash-lib/src/proxy/direct/mod.rs
@@ -94,10 +94,14 @@ impl OutboundHandler for Handler {
         resolver: ThreadSafeDNSResolver,
     ) -> std::io::Result<BoxedChainedDatagram> {
         let family_hint = family_hint_for_session(sess, &resolver).await;
-        let bind_addr: std::net::IpAddr = if sess.source.is_ipv4() {
-            std::net::Ipv4Addr::UNSPECIFIED.into()
-        } else {
-            std::net::Ipv6Addr::UNSPECIFIED.into()
+        // Align bind_addr family with the socket family driven by family_hint.
+        // Binding an AF_INET6 socket to 0.0.0.0 (IPv4) returns EAFNOSUPPORT,
+        // so when the destination (family_hint) is IPv6 we must bind to [::].
+        // Fall back to sess.source only when family_hint has no preference.
+        let bind_addr: std::net::IpAddr = match family_hint.as_ref() {
+            Some(hint) if hint.is_ipv6() => std::net::Ipv6Addr::UNSPECIFIED.into(),
+            _ if sess.source.is_ipv4() => std::net::Ipv4Addr::UNSPECIFIED.into(),
+            _ => std::net::Ipv6Addr::UNSPECIFIED.into(),
         };
         let d = new_udp_socket(
             Some((bind_addr, 0).into()),


### PR DESCRIPTION
## Root cause

After the IPv4-mapped canonicalization fix (commit 6783909), `sess.source` for a client connecting as `::ffff:x.x.x.x` is now the canonical `x.x.x.x`. So `sess.source.is_ipv4()` returns `true` and `bind_addr` is set to `0.0.0.0`.

However, `family_hint_for_session` is based on the **destination**, not the source. When the destination is IPv6, `new_udp_socket` creates an `AF_INET6` socket — then tries to `bind(0.0.0.0:0)` → **`EAFNOSUPPORT` (os error 97)**.

This is why IPv6 UDP probes fail when clients are on IPv4: the canonicalized source makes the DIRECT handler pick an IPv4 bind address, but the destination demands an IPv6 socket.

## Fix

Derive `bind_addr` from `family_hint` first (destination-driven), and only fall back to `sess.source` when there is no hint. This ensures bind address and socket domain always agree.

## Related

- #1392 — fixes the control-entry key mismatch caused by the same canonicalization (IPv4 UDP drops)
- This PR fixes the subsequent IPv6 UDP EAFNOSUPPORT caused by the same root change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP connection handling to correctly bind to the appropriate IP address family (IPv4 or IPv6), enhancing connectivity reliability in mixed network environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1393)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->