### PR TITLE
 refactor!: consolidate rustls forks via [patch.crates-io]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,7 +1406,7 @@ dependencies = [
  "sock2proc",
  "socket2 0.6.3",
  "ssh-key",
- "sysinfo 0.39.0",
+ "sysinfo 0.39.1",
  "tailscale",
  "tar",
  "tempfile",
@@ -5221,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -6955,9 +6964,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -7373,7 +7382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
 dependencies = [
  "log",
- "nix 0.31.2",
+ "nix 0.31.3",
  "ssh-encoding",
  "windows-sys 0.61.2",
 ]
@@ -7505,7 +7514,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7520,7 +7529,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7570,7 +7579,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7582,18 +7591,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -8882,9 +8879,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
+checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
 dependencies = [
  "libc",
  "memchr",
@@ -9260,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "tokio-watfaq-rustls"
 version = "0.26.0"
-source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=cf8961ac1a36e580d0e38bedc8a41ca4a9b301e8#cf8961ac1a36e580d0e38bedc8a41ca4a9b301e8"
+source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=d05361bc0ff7e659cbdc5658e6929ca59aed8559#d05361bc0ff7e659cbdc5658e6929ca59aed8559"
 dependencies = [
  "rustls-pki-types",
  "tokio",
@@ -10349,7 +10346,7 @@ dependencies = [
  "pin-project",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -11150,7 +11147,7 @@ dependencies = [
  "libloading 0.9.0",
  "log",
  "netconfig-rs",
- "nix 0.31.2",
+ "nix 0.31.3",
  "route_manager",
  "scopeguard",
  "tokio",
@@ -11671,17 +11668,16 @@ dependencies = [
 
 [[package]]
 name = "watfaq-rustls"
-version = "0.23.21"
-source = "git+https://github.com/Watfaq/rustls.git?rev=c3ab043d673029d245fd618b9bc86fd6a6109bae#c3ab043d673029d245fd618b9bc86fd6a6109bae"
+version = "0.23.40"
+source = "git+https://github.com/Watfaq/rustls.git?rev=0828f676ac355efe0f335055413f3704d1fe495c#0828f676ac355efe0f335055413f3704d1fe495c"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
- "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -12352,10 +12348,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,6 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tokio-util",
- "tokio-watfaq-rustls",
  "tor-rtcompat",
  "totp-rs",
  "tower",
@@ -1437,7 +1436,6 @@ dependencies = [
  "uuid",
  "watfaq-dns",
  "watfaq-netstack",
- "watfaq-rustls",
  "webpki-roots",
  "windows 0.62.2",
  "zip",
@@ -7506,8 +7504,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+source = "git+https://github.com/Watfaq/rustls.git?branch=watfaq%2F0.23.40#8211697ce28686d72c92c2fc4b440b7ffc9a3ee3"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9180,8 +9177,7 @@ dependencies = [
 [[package]]
 name = "tokio-rustls"
 version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+source = "git+https://github.com/Watfaq/tokio-rustls.git?branch=watfaq%2F0.26.4#b26e3e2b7a0161d505fd12d6e545b16463f1a45f"
 dependencies = [
  "rustls",
  "tokio",
@@ -9252,16 +9248,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
-]
-
-[[package]]
-name = "tokio-watfaq-rustls"
-version = "0.26.0"
-source = "git+https://github.com/Watfaq/tokio-rustls.git?rev=d05361bc0ff7e659cbdc5658e6929ca59aed8559#d05361bc0ff7e659cbdc5658e6929ca59aed8559"
-dependencies = [
- "rustls-pki-types",
- "tokio",
- "watfaq-rustls",
 ]
 
 [[package]]
@@ -11664,21 +11650,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tun-rs",
-]
-
-[[package]]
-name = "watfaq-rustls"
-version = "0.23.40"
-source = "git+https://github.com/Watfaq/rustls.git?rev=0828f676ac355efe0f335055413f3704d1fe495c#0828f676ac355efe0f335055413f3704d1fe495c"
-dependencies = [
- "aws-lc-rs",
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.40"
-source = "git+https://github.com/Watfaq/rustls.git?branch=watfaq%2F0.23.40#8211697ce28686d72c92c2fc4b440b7ffc9a3ee3"
+source = "git+https://github.com/Watfaq/rustls.git?branch=watfaq%2F0.23.40#e6e8e7e1a0d65f2f273eb7b5b6179896536ac174"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7513,6 +7513,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker_test)', 'cfg(throug
 [workspace.lints.clippy]
 redundant_clone = "deny"
 needless_collect = "deny"
+
+[patch.crates-io]
+rustls = { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.40" }
+tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", branch = "watfaq/0.26.4" }

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -76,8 +76,8 @@ rcgen = { version = "0.14", features = ["pem"] }
 webpki-roots = "1.0"
 
 # shadow-tls
-tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "cf8961ac1a36e580d0e38bedc8a41ca4a9b301e8", default-features = false, features = ["logging", "tls12"] }
-watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "c3ab043d673029d245fd618b9bc86fd6a6109bae", default-features = false }
+tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "d05361bc0ff7e659cbdc5658e6929ca59aed8559", default-features = false, features = ["logging", "tls12"] }
+watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "0828f676ac355efe0f335055413f3704d1fe495c", default-features = false }
 
 # Error handing & logging
 thiserror = "2"

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -10,23 +10,21 @@ default = ["zero_copy", "aws-lc-rs", "dashboard"]
 aws-lc-rs = [
     "dep:aws-lc-rs",
     "rustls/aws-lc-rs",
-    "watfaq-rustls/aws-lc-rs",
     "quinn-proto/rustls-aws-lc-rs",
-    "watfaq-dns/aws-lc-rs",
     "russh/aws-lc-rs",
     "boringtun/aws-lc-rs",
     "hickory-client/https-aws-lc-rs",
     "tuic-quinn?/rustls-aws-lc-rs",
+    "watfaq-dns/aws-lc-rs",
 ]
 ring = [
     "rustls/ring",
-    "watfaq-rustls/ring",
     "quinn-proto/ring",
-    "watfaq-dns/ring",
     "russh/ring",
     "boringtun/ring",
     "hickory-client/https-ring",
     "tuic-quinn?/rustls-ring",
+    "watfaq-dns/ring",
 ]
 
 # Protos
@@ -74,10 +72,6 @@ rustls = { version = "0.23", default-features = false }
 rustls-pemfile = "2"
 rcgen = { version = "0.14", features = ["pem"] }
 webpki-roots = "1.0"
-
-# shadow-tls
-tokio-watfaq-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", rev = "d05361bc0ff7e659cbdc5658e6929ca59aed8559", default-features = false, features = ["logging", "tls12"] }
-watfaq-rustls = { git = "https://github.com/Watfaq/rustls.git", rev = "0828f676ac355efe0f335055413f3704d1fe495c", default-features = false }
 
 # Error handing & logging
 thiserror = "2"

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -221,19 +221,10 @@ pub fn setup_default_crypto_provider() {
         #[cfg(feature = "aws-lc-rs")]
         {
             _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-            // watfaq-rustls is a separate fork with its own global provider
-            // state. When both `ring` and `aws-lc-rs` features are active
-            // (e.g. `--all-features`), its
-            // `get_default_or_install_from_crate_features` treats the
-            // combination as ambiguous and returns None, causing a
-            // panic. Explicit installation is therefore required.
-            _ = watfaq_rustls::crypto::aws_lc_rs::default_provider()
-                .install_default();
         }
         #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
         {
             _ = rustls::crypto::ring::default_provider().install_default();
-            _ = watfaq_rustls::crypto::ring::default_provider().install_default();
         }
     });
 }

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
-use tokio_watfaq_rustls::{TlsConnector, client::TlsStream};
-use watfaq_rustls::{
+use rustls::{
     ClientConfig, RootCertStore, client::RealityConfig, pki_types::ServerName,
 };
+use tokio_rustls::{TlsConnector, client::TlsStream};
 
 use std::{
     io,

--- a/clash-lib/src/proxy/transport/shadow_tls/mod.rs
+++ b/clash-lib/src/proxy/transport/shadow_tls/mod.rs
@@ -1,13 +1,9 @@
 use async_trait::async_trait;
 use rand::{RngExt, distr::Distribution};
-use std::{
-    io,
-    ptr::copy_nonoverlapping,
-    sync::{Arc, LazyLock},
-};
+use std::{io, ptr::copy_nonoverlapping, sync::Arc};
 use stream::{ProxyTlsStream, VerifiedStream};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tokio_watfaq_rustls::{TlsConnector, client::TlsStream};
+use tokio_rustls::{TlsConnector, client::TlsStream};
 use utils::Hmac;
 
 mod prelude;
@@ -15,16 +11,11 @@ mod stream;
 mod utils;
 
 use super::Transport;
-use crate::{common::errors::map_io_error, proxy::AnyStream};
+use crate::{
+    common::{errors::map_io_error, tls::GLOBAL_ROOT_STORE},
+    proxy::AnyStream,
+};
 use prelude::*;
-
-static ROOT_STORE: LazyLock<Arc<watfaq_rustls::RootCertStore>> =
-    LazyLock::new(root_store);
-
-fn root_store() -> Arc<watfaq_rustls::RootCertStore> {
-    let root_store = webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect();
-    Arc::new(root_store)
-}
 
 pub struct Client {
     host: String,
@@ -49,14 +40,18 @@ impl Client {
 
         // handshake
         let hamc_handshake = Hmac::new(&self.password, (&[], &[]));
-        let sni_name =
-            watfaq_rustls::pki_types::ServerName::try_from(self.host.clone())
-                .map_err(map_io_error)?;
+        let sni_name = rustls::pki_types::ServerName::try_from(self.host.clone())
+            .map_err(map_io_error)?;
         let session_id_generator =
             move |data: &_| generate_session_id(&hamc_handshake, data);
         let connector = new_connector();
         let mut tls = connector
-            .connect_with(sni_name, proxy_stream, Some(session_id_generator), |_| {})
+            .connect_with_session_id_generator(
+                sni_name,
+                proxy_stream,
+                Some(session_id_generator),
+                |_| {},
+            )
             .await?;
 
         // check if is authorized
@@ -120,8 +115,8 @@ impl Transport for Client {
 }
 
 fn new_connector() -> TlsConnector {
-    let tls_config = watfaq_rustls::ClientConfig::builder()
-        .with_root_certificates(ROOT_STORE.clone())
+    let tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(GLOBAL_ROOT_STORE.clone())
         .with_no_client_auth();
 
     TlsConnector::from(Arc::new(tls_config))

--- a/clash-lib/src/proxy/transport/splice_tls.rs
+++ b/clash-lib/src/proxy/transport/splice_tls.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 
 use crate::proxy::AnyStream;
 
-pub type RealityTlsStream = tokio_watfaq_rustls::client::TlsStream<AnyStream>;
+pub type RealityTlsStream = tokio_rustls::client::TlsStream<AnyStream>;
 
 /// Options passed to `VisionStream` when XTLS-splice mode is active.
 ///


### PR DESCRIPTION
## Breaking Change

Removes `watfaq-rustls` and `tokio-watfaq-rustls` git dependencies in favour of patching crates-io `rustls` and `tokio-rustls` with the Watfaq forks via `[patch.crates-io]`.

This means there is now a **single rustls instance** in the binary — no more duplicate global crypto provider state.

## Changes

- Add `[patch.crates-io]` for `rustls` → [Watfaq/rustls@watfaq/0.23.40](https://github.com/Watfaq/rustls/tree/watfaq/0.23.40)
- Add `[patch.crates-io]` for `tokio-rustls` → [Watfaq/tokio-rustls@watfaq/0.26.4](https://github.com/Watfaq/tokio-rustls/tree/watfaq/0.26.4)
- Replace all `watfaq_rustls::` / `tokio_watfaq_rustls::` imports with `rustls::` / `tokio_rustls::`
- Remove duplicate `crypto provider install_default()` call in `lib.rs` (no longer two separate rustls copies)
- Restore `watfaq-dns/aws-lc-rs` and `watfaq-dns/ring` feature forwards accidentally dropped in previous commit

## Fork branches

Both fork branches are clean — created directly from the upstream release tag with only the custom patches applied (0 commits behind, minimal ahead):

| Fork | Branch | Custom changes |
|------|--------|----------------|
| [Watfaq/rustls](https://github.com/Watfaq/rustls/tree/watfaq/0.23.40) | `watfaq/0.23.40` | Reality protocol + `new_with_session_id_generator` |
| [Watfaq/tokio-rustls](https://github.com/Watfaq/tokio-rustls/tree/watfaq/0.26.4) | `watfaq/0.26.4` | `connect_with_session_id_generator` for Shadow-TLS V3 |