### PR TITLE
fix: remove ring from aws-lc-rs code path (~500KB-1MB binary savings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,6 +4275,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de99ad8adc878ee0e68509ad256152ce23b8bbe45f5539d04e179630aca40a9"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "derive_more",
  "enum-assoc",
@@ -6634,6 +6635,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e3f04d716273d25e4923541e625e0084256f72cad7e2e7e50a0e0926aa739f"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6858,6 +6860,7 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
+ "aws-lc-rs",
  "pem",
  "ring",
  "rustls-pki-types",
@@ -7416,6 +7419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68483c81131e4f08f8d565632f8b9fec9f71e86f422648175ba03bbd84ea8228"
 dependencies = [
  "aes-gcm 0.10.3",
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -8119,11 +8123,12 @@ dependencies = [
 [[package]]
 name = "shadowquic"
 version = "0.3.4"
-source = "git+https://github.com/spongebob888/shadowquic.git?rev=277f47a59607a91d11bcb4ae98309a320617d4b2#277f47a59607a91d11bcb4ae98309a320617d4b2"
+source = "git+https://github.com/ibigbug/shadowquic.git?rev=a910118d5e3ab53e19e2b11347c5abaa93347ce6#a910118d5e3ab53e19e2b11347c5abaa93347ce6"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "aws-lc-rs",
  "brutal-core",
  "bytes",
  "clap",
@@ -8155,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "shadowquic-macros"
 version = "0.3.4"
-source = "git+https://github.com/spongebob888/shadowquic.git?rev=277f47a59607a91d11bcb4ae98309a320617d4b2#277f47a59607a91d11bcb4ae98309a320617d4b2"
+source = "git+https://github.com/ibigbug/shadowquic.git?rev=a910118d5e3ab53e19e2b11347c5abaa93347ce6#a910118d5e3ab53e19e2b11347c5abaa93347ce6"
 dependencies = [
  "crabtime",
  "proc-macro2",
@@ -11525,7 +11530,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",
@@ -12178,6 +12183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",

--- a/clash-dns/src/handler.rs
+++ b/clash-dns/src/handler.rs
@@ -384,14 +384,14 @@ mod tests {
     use futures::FutureExt;
     use hickory_net::{
         client::{Client, ClientHandle},
-        h2::{HttpsClientStream, HttpsClientStreamBuilder},
-        h3::{H3ClientStream, H3ClientStreamBuilder},
+        h2::HttpsClientStream,
+        h3::H3ClientStream,
         runtime::TokioRuntimeProvider,
         tcp::TcpClientStream,
         tls::tls_client_connect,
         udp::UdpClientStream,
     };
-    use hickory_proto::rr::{DNSClass, Name, RData, RecordType, rdata::A};
+    use hickory_proto::rr::{DNSClass, Name, RData, RecordType};
     use rustls::{ClientConfig, pki_types::ServerName};
     use std::{sync::Arc, time::Duration};
     use tokio::{

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -11,20 +11,26 @@ aws-lc-rs = [
     "dep:aws-lc-rs",
     "rustls/aws-lc-rs",
     "quinn-proto/rustls-aws-lc-rs",
+    "quinn/rustls-aws-lc-rs",
     "russh/aws-lc-rs",
     "boringtun/aws-lc-rs",
     "hickory-net/https-aws-lc-rs",
     "tuic-quinn?/rustls-aws-lc-rs",
     "watfaq-dns/aws-lc-rs",
+    "rcgen/aws_lc_rs",
+    "shadowquic?/aws-lc-rs",
 ]
 ring = [
     "rustls/ring",
     "quinn-proto/ring",
+    "quinn/rustls-ring",
     "russh/ring",
     "boringtun/ring",
     "hickory-net/https-ring",
     "tuic-quinn?/rustls-ring",
     "watfaq-dns/ring",
+    "rcgen/ring",
+    "shadowquic?/ring",
 ]
 
 # Protos
@@ -32,7 +38,7 @@ shadowsocks = ["dep:shadowsocks", "dep:blake3"]
 tuic = ["dep:tuic-core", "dep:register-count", "dep:tuic-quinn"]
 ssh = ["dep:russh", "dep:dirs", "dep:totp-rs"]
 onion = ["dep:arti-client", "dep:tor-rtcompat", "arti-client/onion-service-client"]
-shadowquic = ["dep:shadowquic"]
+shadowquic = ["dep:shadowquic", "shadowquic?/shadowquic-quinn", "shadowquic?/sunnyquic-iroh-quinn"]
 wireguard = ["dep:boringtun", "dep:smoltcp"]
 tailscale = ["dep:tailscale"]
 tproxy = [
@@ -70,7 +76,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2"] }
 rustls = { version = "0.23", default-features = false }
 rustls-pemfile = "2"
-rcgen = { version = "0.14", features = ["pem"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem"] }
 webpki-roots = "1.0"
 
 # Error handing & logging
@@ -183,7 +189,7 @@ register-count = { version = "0.1", optional = true }
 # tuic-quinn gives tuic-specific quinn fork with rustls support (same fork as tuic-core uses internally)
 tuic-quinn = { package = "quinn", branch = "bbrv3", git = "https://github.com/Tipuch/quinn.git", optional = true, default-features = false, features = ["runtime-tokio"] }
 
-quinn = { version = "0.11", default-features = false, features = ["futures-io", "runtime-tokio", "rustls"] }
+quinn = { version = "0.11", default-features = false, features = ["futures-io", "runtime-tokio"] }
 
 # hysteria2
 h3 = "0.0.8"
@@ -202,7 +208,7 @@ dirs = { version = "6.0", optional = true }
 totp-rs = { version = "^5.7", features = ["serde_support"], optional = true }
 
 # shadowquic
-shadowquic = { version = "0.3.4", optional = true, git = "https://github.com/spongebob888/shadowquic.git", rev = "277f47a59607a91d11bcb4ae98309a320617d4b2" }
+shadowquic = { version = "0.3.4", optional = true, default-features = false, git = "https://github.com/ibigbug/shadowquic.git", rev = "a910118d5e3ab53e19e2b11347c5abaa93347ce6" }
 
 # experimental
 downcast-rs = "2.0"

--- a/clash-lib/tests/integration_tests.rs
+++ b/clash-lib/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use clash_lib::{Config, Options};
-use common::{Socks5UdpSession, start_clash, wait_port_ready};
+use common::{ClashInstance, Socks5UdpSession, start_clash, wait_port_ready};
 use std::path::PathBuf;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -133,33 +133,35 @@ async fn integration_test_anytls() {
         client_config.to_string_lossy()
     );
 
-    std::thread::spawn(move || {
-        start_clash(Options {
+    // Use ClashInstance so server/client are properly shut down when the test
+    // ends, releasing ports 8902/9092 and 8998/9095 for subsequent tests.
+    let _server = ClashInstance::start(
+        Options {
             config: Config::File(server_config.to_string_lossy().to_string()),
             cwd: Some(wd_server.to_string_lossy().to_string()),
             rt: None,
             log_file: None,
-        })
-        .expect("Failed to start AnyTLS server");
-    });
+        },
+        vec![8902, 9092],
+    )
+    .expect("Failed to start AnyTLS server");
 
-    std::thread::spawn(move || {
-        start_clash(Options {
+    let _client = ClashInstance::start(
+        Options {
             config: Config::File(client_config.to_string_lossy().to_string()),
             cwd: Some(wd_client.to_string_lossy().to_string()),
             rt: None,
             log_file: None,
-        })
-        .expect("Failed to start AnyTLS client");
-    });
+        },
+        vec![8998, 9095],
+    )
+    .expect("Failed to start AnyTLS client");
 
     let mock_server = httpmock::MockServer::start();
     let mock = mock_server.mock(|when, then| {
         when.method(httpmock::Method::GET).path("/");
         then.status(200).body("Mock response for AnyTLS testing");
     });
-
-    wait_port_ready(8998).expect("AnyTLS proxy port is not ready");
 
     let proxy = reqwest::Proxy::all("socks5://127.0.0.1:8998")
         .expect("Failed to create proxy");
@@ -216,27 +218,29 @@ async fn integration_test_anytls_udp() {
     });
 
     // ── Start clash server and client ─────────────────────────────────────────
-    std::thread::spawn(move || {
-        start_clash(Options {
+    // Use ClashInstance so server/client are properly shut down when the test
+    // ends, releasing ports 8902/9092 and 8998/9095 for subsequent tests.
+    let _server = ClashInstance::start(
+        Options {
             config: Config::File(server_config.to_string_lossy().to_string()),
             cwd: Some(wd_server.to_string_lossy().to_string()),
             rt: None,
             log_file: None,
-        })
-        .expect("Failed to start AnyTLS server");
-    });
+        },
+        vec![8902, 9092],
+    )
+    .expect("Failed to start AnyTLS server");
 
-    std::thread::spawn(move || {
-        start_clash(Options {
+    let _client = ClashInstance::start(
+        Options {
             config: Config::File(client_config.to_string_lossy().to_string()),
             cwd: Some(wd_client.to_string_lossy().to_string()),
             rt: None,
             log_file: None,
-        })
-        .expect("Failed to start AnyTLS client");
-    });
-
-    wait_port_ready(8998).expect("AnyTLS proxy port is not ready");
+        },
+        vec![8998, 9095],
+    )
+    .expect("Failed to start AnyTLS client");
 
     // ── SOCKS5 UDP ASSOCIATE handshake ────────────────────────────────────────
     let mut tcp = tokio::net::TcpStream::connect("127.0.0.1:8998")


### PR DESCRIPTION
## Summary

When `aws-lc-rs` is the active crypto backend, `ring` was still being compiled in as a duplicate dependency via three paths. This PR eliminates all of them.

**Result:** `cargo tree -p clash-lib -F aws-lc-rs,shadowquic -i ring` returns empty — ring is completely absent from the `aws-lc-rs` code path. Estimated binary size reduction: **~500KB–1MB** stripped release.

## Root causes fixed

### 1. `quinn` (v0.11) — `rustls` feature aliases to `rustls-ring`

```toml
# before
quinn = { ..., features = ["futures-io", "runtime-tokio", "rustls"] }
# "rustls" in quinn v0.11 = rustls-ring, always pulls ring regardless of backend

# after
quinn = { ..., features = ["futures-io", "runtime-tokio"] }
# quinn/rustls-aws-lc-rs added to aws-lc-rs feature
# quinn/rustls-ring added to ring feature
```

### 2. `rcgen` — default features include `ring` backend

```toml
# before
rcgen = { version = "0.14", features = ["pem"] }
# default features include "ring"

# after
rcgen = { version = "0.14", default-features = false, features = ["pem"] }
# rcgen/aws_lc_rs added to aws-lc-rs feature
# rcgen/ring added to ring feature
```

### 3. `shadowquic` — hardcoded `ring` throughout

Shadowquic unconditionally required ring in all sub-crates (quinn-jls, iroh-quinn, rustls-jls, etc.) and in source code.

Switched to a fork that adds a proper `aws-lc-rs` feature flag: **https://github.com/spongebob888/shadowquic/pull/134**

```toml
# before
shadowquic = { git = "https://github.com/spongebob888/shadowquic.git", rev = "277f47a5..." }

# after
shadowquic = { git = "https://github.com/ibigbug/shadowquic.git", rev = "a6f3fde0...", default-features = false }
# shadowquic?/aws-lc-rs added to aws-lc-rs feature
# shadowquic?/ring added to ring feature
# shadowquic?/shadowquic-quinn + shadowquic?/sunnyquic-iroh-quinn added to shadowquic feature
```

Once [spongebob888/shadowquic#134](https://github.com/spongebob888/shadowquic/pull/134) merges, the dep can be pointed back to upstream.

## Verification

```
# aws-lc-rs path (default) - ring completely absent
cargo tree -p clash-lib -F aws-lc-rs,shadowquic -i ring
# → (empty)

# ring path - aws-lc-rs not pulled (was already clean)
cargo tree -p clash-lib -F ring,shadowquic -i aws-lc-rs
# → (empty)

# all-features - builds cleanly
cargo check -p clash-lib --all-features
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated crypto and QUIC feature wiring and dependency defaults to improve compatibility with alternative TLS backends and QUIC implementations, and to support alternate transport providers.
* **Tests**
  * Simplified and modernized test setup and imports; replaced manual thread-based startup with instance-based lifecycle management for more reliable integration tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1397)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->