### PR TITLE
fix(socket): bind dual-stack UDP socket when interface is set (fixes Windows WSAEINVAL #1399)

### DIFF
--- a/clash-lib/src/proxy/direct/mod.rs
+++ b/clash-lib/src/proxy/direct/mod.rs
@@ -165,3 +165,155 @@ impl PlainProxyAPIResponse for Handler {
         HashMap::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        app::dns::MockClashResolver,
+        proxy::datagram::UdpPacket,
+        session::{Network, Session, SocksAddr, Type},
+    };
+    use futures::{SinkExt, StreamExt};
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        sync::Arc,
+        time::Duration,
+    };
+    use tokio::net::UdpSocket;
+
+    async fn spawn_udp_echo(bind: &str) -> SocketAddr {
+        let sock = UdpSocket::bind(bind).await.unwrap();
+        let addr = sock.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 4096];
+            loop {
+                let Ok((n, peer)) = sock.recv_from(&mut buf).await else {
+                    break;
+                };
+                let _ = sock.send_to(&buf[..n], peer).await;
+            }
+        });
+        addr
+    }
+
+    fn make_resolver() -> ThreadSafeDNSResolver {
+        // IP destinations never touch the resolver; an empty mock is enough.
+        Arc::new(MockClashResolver::new())
+    }
+
+    /// Full round-trip through Handler::connect_datagram →
+    /// new_dual_stack_udp_socket → IPv4 echo server.  This exercises the
+    /// real socket-creation path (the source of the Windows WSAEINVAL
+    /// regression in #1399).
+    #[tokio::test]
+    async fn test_connect_datagram_ipv4_roundtrip() {
+        let echo = spawn_udp_echo("127.0.0.1:0").await;
+        let handler = Handler::new("DIRECT");
+        let sess = Session {
+            network: Network::Udp,
+            typ: Type::Socks5,
+            destination: SocksAddr::Ip(echo),
+            ..Default::default()
+        };
+
+        let mut d = handler
+            .connect_datagram(&sess, make_resolver())
+            .await
+            .expect("connect_datagram failed");
+
+        d.send(UdpPacket {
+            data: b"hello-v4".to_vec(),
+            dst_addr: SocksAddr::Ip(echo),
+            ..Default::default()
+        })
+        .await
+        .expect("send failed");
+
+        let pkt = tokio::time::timeout(Duration::from_secs(2), d.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended");
+        assert_eq!(pkt.data, b"hello-v4");
+    }
+
+    /// Same path but sending to two different IPv4 destinations via the same
+    /// socket — validates the 1→N multiplexing that requires a dual-stack
+    /// socket in the first place.
+    #[tokio::test]
+    async fn test_connect_datagram_ipv4_multi_dest() {
+        let echo_a = spawn_udp_echo("127.0.0.1:0").await;
+        let echo_b = spawn_udp_echo("127.0.0.1:0").await;
+        let handler = Handler::new("DIRECT");
+        let sess = Session {
+            network: Network::Udp,
+            typ: Type::Socks5,
+            destination: SocksAddr::Ip(echo_a),
+            ..Default::default()
+        };
+
+        let mut d = handler
+            .connect_datagram(&sess, make_resolver())
+            .await
+            .expect("connect_datagram failed");
+
+        for (dst, payload) in [(echo_a, b"to-a" as &[u8]), (echo_b, b"to-b")] {
+            d.send(UdpPacket {
+                data: payload.to_vec(),
+                dst_addr: SocksAddr::Ip(dst),
+                ..Default::default()
+            })
+            .await
+            .expect("send failed");
+        }
+
+        let mut received = std::collections::HashSet::new();
+        for _ in 0..2 {
+            let pkt = tokio::time::timeout(Duration::from_secs(2), d.next())
+                .await
+                .expect("timed out")
+                .expect("stream ended");
+            received.insert(pkt.data);
+        }
+        assert!(received.contains(b"to-a".as_ref()));
+        assert!(received.contains(b"to-b".as_ref()));
+    }
+
+    /// IPv6 round-trip — skipped when the host has no IPv6 loopback.
+    #[tokio::test]
+    async fn test_connect_datagram_ipv6_roundtrip() {
+        // Probe for IPv6 loopback availability.
+        if UdpSocket::bind("[::1]:0").await.is_err() {
+            eprintln!("skipping: no IPv6 loopback");
+            return;
+        }
+        let echo = spawn_udp_echo("[::1]:0").await;
+        let handler = Handler::new("DIRECT");
+        let sess = Session {
+            network: Network::Udp,
+            typ: Type::Socks5,
+            destination: SocksAddr::Ip(echo),
+            source: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+            ..Default::default()
+        };
+
+        let mut d = handler
+            .connect_datagram(&sess, make_resolver())
+            .await
+            .expect("connect_datagram failed");
+
+        d.send(UdpPacket {
+            data: b"hello-v6".to_vec(),
+            dst_addr: SocksAddr::Ip(echo),
+            ..Default::default()
+        })
+        .await
+        .expect("send failed");
+
+        let pkt = tokio::time::timeout(Duration::from_secs(2), d.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended");
+        assert_eq!(pkt.data, b"hello-v6");
+    }
+}

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -253,9 +253,12 @@ pub fn new_dual_stack_udp_socket(
         must_bind_socket_on_interface(&socket, iface, family).inspect_err(|x| {
             error!("failed to bind socket to interface: {}", x);
         })?;
-    } else {
-        socket.bind(&bind_addr.into())?;
     }
+    // must_bind_socket_on_interface only sets a socket option (SO_BINDTODEVICE
+    // / IP_BOUND_IF / IPV6_UNICAST_IF); it does not assign a local port.
+    // Always bind explicitly so the socket has a valid local address on all
+    // platforms — required on Windows to avoid WSAEINVAL (10022) from sendto.
+    socket.bind(&bind_addr.into())?;
 
     #[cfg(target_os = "linux")]
     if let Some(so_mark) = so_mark {
@@ -281,4 +284,121 @@ pub fn try_create_dualstack_tcplistener(
 
     let listener = TcpListener::from_std(socket.into())?;
     Ok(listener)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{net::SocketAddrV6, time::Duration};
+
+    /// Locate the loopback network interface on the current host.
+    /// Returns `None` if the interface cannot be found or enumeration fails.
+    fn find_loopback_iface() -> Option<OutboundInterface> {
+        use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+        let ifaces = NetworkInterface::show().ok()?;
+        let lo = ifaces.into_iter().find(|iface| {
+            iface.addr.iter().any(|a| match a {
+                Addr::V4(v4) => v4.ip.is_loopback(),
+                _ => false,
+            })
+        })?;
+        Some(OutboundInterface {
+            name: lo.name,
+            addr_v4: Some(Ipv4Addr::LOCALHOST),
+            addr_v6: Some(Ipv6Addr::LOCALHOST),
+            index: lo.index,
+            netmask_v4: None,
+            broadcast_v4: None,
+            netmask_v6: None,
+            broadcast_v6: None,
+            mac_addr: None,
+        })
+    }
+
+    // Regression test for https://github.com/Watfaq/clash-rs/issues/1399.
+    //
+    // new_dual_stack_udp_socket must call bind() even when `iface` is provided.
+    // Before the fix, the iface branch skipped bind() so the socket was
+    // "unbound"; sendto with an IPv4-mapped destination then returned
+    // WSAEINVAL (os error 10022) on Windows.
+
+    /// Without an iface: socket is bound and IPv4-mapped round-trip works.
+    #[tokio::test]
+    async fn test_dual_stack_no_iface_is_bound_and_sends_ipv4_mapped() {
+        let sock = new_dual_stack_udp_socket(
+            None,
+            #[cfg(target_os = "linux")]
+            None,
+        )
+        .expect("failed to create dual-stack socket");
+
+        let local = sock.local_addr().expect("local_addr failed");
+        assert_ne!(local.port(), 0, "socket must have a non-zero local port");
+
+        // Only exercise IPv4-mapped sendto when we actually got a dual-stack
+        // (IPv6) socket; on hosts without IPv6 the fallback is an IPv4 socket.
+        if !local.is_ipv6() {
+            return;
+        }
+
+        let echo = UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind echo server");
+        let echo_port = echo.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 64];
+            if let Ok((n, peer)) = echo.recv_from(&mut buf).await {
+                let _ = echo.send_to(&buf[..n], peer).await;
+            }
+        });
+
+        let dst = SocketAddr::V6(SocketAddrV6::new(
+            Ipv4Addr::LOCALHOST.to_ipv6_mapped(),
+            echo_port,
+            0,
+            0,
+        ));
+        sock.send_to(b"ping", dst).await.expect("send_to failed");
+
+        let mut buf = vec![0u8; 64];
+        let (n, _) =
+            tokio::time::timeout(Duration::from_secs(2), sock.recv_from(&mut buf))
+                .await
+                .expect("timed out")
+                .expect("recv_from failed");
+        assert_eq!(&buf[..n], b"ping");
+    }
+
+    /// With an iface (loopback): socket must still be bound after
+    /// must_bind_socket_on_interface so that sendto does not return WSAEINVAL.
+    ///
+    /// Skipped on Linux when SO_BINDTODEVICE requires elevated privileges.
+    #[tokio::test]
+    async fn test_dual_stack_with_iface_is_bound() {
+        let Some(iface) = find_loopback_iface() else {
+            eprintln!("skipping: loopback interface not found");
+            return;
+        };
+
+        let result = new_dual_stack_udp_socket(
+            Some(&iface),
+            #[cfg(target_os = "linux")]
+            None,
+        );
+
+        // On Linux, SO_BINDTODEVICE requires CAP_NET_RAW; skip gracefully.
+        #[cfg(target_os = "linux")]
+        if result.is_err() {
+            eprintln!("skipping: SO_BINDTODEVICE requires elevated privileges");
+            return;
+        }
+
+        let sock = result.expect("failed to create dual-stack socket with iface");
+        let local = sock.local_addr().expect("local_addr failed");
+        assert_ne!(
+            local.port(),
+            0,
+            "socket must have a non-zero local port even when iface is set"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Fixes #1399 — all direct UDP in TUN mode fails on Windows with WSAEINVAL (os error 10022) when `interface-name` is configured.

## Root Cause

PR #1392 introduced `new_dual_stack_udp_socket`. When an `iface` is provided it calls `must_bind_socket_on_interface` (which sets `setsockopt(IPV6_UNICAST_IF)`) but then **skips `socket.bind()`**:

```rust
if let Some(iface) = iface {
    must_bind_socket_on_interface(&socket, iface, family)?;
    // ← no bind() here!  socket is unbound on Windows
} else {
    socket.bind(&bind_addr.into())?;
}
```

`setsockopt(IPV6_UNICAST_IF)` is a routing option — it only sets the outgoing interface. It does **not** assign a local address/port. The socket remains unbound, and `sendto(::ffff:x.x.x.x)` on an unbound Windows socket returns WSAEINVAL.

This is exactly the same bug that was already fixed for `new_udp_socket` in PR #960 (`fix(shadowquic): fix quinn not work when bound to interface`) — that PR added `#[cfg(windows)] socket.bind(src)` in the iface branch with the comment _"binding is not necessary for linux but is required on windows"_. `new_dual_stack_udp_socket` was introduced after that fix without carrying the lesson forward.

## Fix

Always call `socket.bind()` unconditionally — both when `iface` is set and when it isn't. All three platform implementations of `must_bind_socket_on_interface` (Linux `SO_BINDTODEVICE`, Apple `IP_BOUND_IF`/`IPV6_BOUND_IF`, Windows `IP_UNICAST_IF`/`IPV6_UNICAST_IF`) are socket *options* that set routing behaviour; none of them assign a local port.

```rust
// after:
if let Some(iface) = iface {
    must_bind_socket_on_interface(...)?;
}
socket.bind(&bind_addr.into())?;  // always
```

## Tests

Two regression tests added to `socket_helpers::tests`:

- `test_dual_stack_no_iface_is_bound_and_sends_ipv4_mapped` — verifies the socket has a non-zero local port and can complete an IPv4-mapped (::ffff:127.0.0.1) round-trip
- `test_dual_stack_with_iface_is_bound` — uses the loopback interface to exercise the iface branch directly; skips gracefully on Linux when `SO_BINDTODEVICE` requires elevated privileges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured UDP sockets reliably obtain a local address across platforms; fixes send failures on Windows when an outbound interface is specified.

* **Documentation**
  * Clarified notes distinguishing interface-only socket options from explicit local port binding.

* **Tests**
  * Added async regression tests covering socket binding with and without an explicit interface (with graceful skip on restricted Linux).
  * Added integration-style UDP round-trip tests: IPv4 roundtrip, multi-destination over one datagram stream, and IPv6 roundtrip (skipped if unavailable).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1401)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->