### PR TITLE
fix: gracefully handle stale interface binding on Apple platforms

### DIFF
--- a/clash-lib/src/proxy/utils/platform/apple.rs
+++ b/clash-lib/src/proxy/utils/platform/apple.rs
@@ -17,16 +17,30 @@ pub(crate) fn must_bind_socket_on_interface(
         );
         return Ok(());
     }
-    match family {
+    let result = match family {
         socket2::Domain::IPV4 => {
             socket.bind_device_by_index_v4(std::num::NonZeroU32::new(index))
         }
         socket2::Domain::IPV6 => {
             socket.bind_device_by_index_v6(std::num::NonZeroU32::new(index))
         }
-        _ => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "unsupported socket family",
-        )),
-    }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "unsupported socket family",
+            ));
+        }
+    };
+    result.or_else(|e| {
+        if e.kind() == io::ErrorKind::AddrNotAvailable {
+            warn!(
+                "stale interface index {index} for '{}', \
+                 falling back to default route: {e}",
+                iface.name
+            );
+            Ok(())
+        } else {
+            Err(e)
+        }
+    })
 }


### PR DESCRIPTION
macOS returns EADDRNOTAVAIL (os error 49) when bind_device_by_index_v4/v6 is called with a stale interface index after network changes (Wi-Fi switch, VPN connect/disconnect, etc.). Extract handle_bind_result helper to DRY the AddrNotAvailable fallback logic across IPV4/IPV6 branches.

### What does this PR do?

<!-- Briefly describe the change and why it's needed. Link related issues with `closes #xxx` if applicable. -->

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / cleanup
- [ ] Other

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network-interface binding on Apple platforms: when an interface index is stale, the app now logs a warning and gracefully falls back to the default route instead of failing, reducing connection errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1403)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->