### PR TITLE
fix: timeout on hyper handshake and consolidate proxy state writes

### DIFF
--- a/clash-lib/src/app/remote_content_manager/mod.rs
+++ b/clash-lib/src/app/remote_content_manager/mod.rs
@@ -167,10 +167,21 @@ impl ProxyManager {
             .unwrap_or(true) // if not found, assume it's alive
     }
 
-    pub async fn report_alive(&self, name: &str, alive: bool) {
+    pub async fn report_alive(
+        &self,
+        name: &str,
+        alive: bool,
+        history: Option<DelayHistory>,
+    ) {
         let mut state = self.proxy_state.write().await;
-        let state = state.entry(name.to_owned()).or_default();
-        state.alive.store(alive, Ordering::Relaxed)
+        let entry = state.entry(name.to_owned()).or_default();
+        entry.alive.store(alive, Ordering::Relaxed);
+        if let Some(ins) = history {
+            entry.delay_history.push_back(ins);
+            if entry.delay_history.len() > 10 {
+                entry.delay_history.pop_front();
+            }
+        }
     }
 
     pub async fn delay_history(&self, name: &str) -> Vec<DelayHistory> {
@@ -747,10 +758,15 @@ impl ProxyManager {
             let resp = match uri.scheme() {
                 Some(scheme) if scheme == &http::uri::Scheme::HTTP => {
                     let io = TokioIo::new(stream);
-                    let (mut sender, conn) =
-                        hyper::client::conn::http1::handshake(io).await.map_err(
-                            |e| new_io_error(format!("failed to handshake: {e}")),
-                        )?;
+                    let (mut sender, conn) = tokio::time::timeout(
+                        timeout,
+                        hyper::client::conn::http1::handshake(io),
+                    )
+                    .await
+                    .map_err(|_| new_io_error("HTTP handshake timed out"))?
+                    .map_err(|e| {
+                        new_io_error(format!("failed to handshake: {e}"))
+                    })?;
 
                     tokio::task::spawn(async move {
                         if let Err(err) = conn.await {
@@ -786,10 +802,15 @@ impl ProxyManager {
 
                     let io = TokioIo::new(stream);
 
-                    let (mut sender, conn) =
-                        hyper::client::conn::http1::handshake(io).await.map_err(
-                            |e| new_io_error(format!("failed to handshake: {e}")),
-                        )?;
+                    let (mut sender, conn) = tokio::time::timeout(
+                        timeout,
+                        hyper::client::conn::http1::handshake(io),
+                    )
+                    .await
+                    .map_err(|_| new_io_error("HTTPS handshake timed out"))?
+                    .map_err(|e| {
+                        new_io_error(format!("failed to handshake: {e}"))
+                    })?;
 
                     tokio::task::spawn(async move {
                         if let Err(err) = conn.await {
@@ -842,23 +863,18 @@ impl ProxyManager {
 
         let result = tester.await;
 
-        self.report_alive(&name, result.is_ok()).await;
-
-        let ins = DelayHistory {
-            time: Utc::now(),
-            delay: result
-                .as_ref()
-                .map(|(actual, _)| *actual)
-                .unwrap_or_default(),
-        };
-
-        let mut state = self.proxy_state.write().await;
-        let state = state.entry(name.to_owned()).or_default();
-
-        state.delay_history.push_back(ins);
-        if state.delay_history.len() > 10 {
-            state.delay_history.pop_front();
-        }
+        self.report_alive(
+            &name,
+            result.is_ok(),
+            Some(DelayHistory {
+                time: Utc::now(),
+                delay: result
+                    .as_ref()
+                    .map(|(actual, _)| *actual)
+                    .unwrap_or_default(),
+            }),
+        )
+        .await;
 
         result
     }
@@ -1040,7 +1056,7 @@ mod tests {
         );
         assert!(!manager.delay_history(PROXY_DIRECT).await.is_empty());
 
-        manager.report_alive(PROXY_DIRECT, false).await;
+        manager.report_alive(PROXY_DIRECT, false, None).await;
         assert!(!manager.alive(PROXY_DIRECT).await);
 
         for _ in 0..10 {

--- a/clash-lib/src/proxy/group/loadbalance/helpers.rs
+++ b/clash-lib/src/proxy/group/loadbalance/helpers.rs
@@ -204,9 +204,9 @@ mod tests {
         let manager = ProxyManager::new(resolver, None);
         // if the proxy alive state isn't set, will return true by default
         // so we need to clear the alive states first
-        manager.report_alive("a", false).await;
-        manager.report_alive("b", false).await;
-        manager.report_alive("c", false).await;
+        manager.report_alive("a", false, None).await;
+        manager.report_alive("b", false, None).await;
+        manager.report_alive("c", false, None).await;
 
         let mut strategy_fn = strategy_sticky_session(manager.clone());
 
@@ -215,9 +215,9 @@ mod tests {
         assert!(res.is_err());
         assert_cache_state!(CACHE_MISS);
 
-        manager.report_alive("a", true).await;
-        manager.report_alive("b", true).await;
-        manager.report_alive("c", true).await;
+        manager.report_alive("a", true, None).await;
+        manager.report_alive("b", true, None).await;
+        manager.report_alive("c", true, None).await;
 
         let mut session1 = Session::default();
         let src1 = Ipv4Addr::new(127, 0, 0, 1);


### PR DESCRIPTION
Concurrent latency testing (via `/ui`) and proxy switching (via nyanpasu or any external client) could freeze all API responses and proxy traffic indefinitely, requiring a restart. No panic — pure liveness failure from compounding async lock misuse.

## Root cause chain

Tokio's `RwLock` is write-preferring: one pending writer blocks all subsequent readers. The hang followed this sequence:

1. `GET /providers/{name}/healthcheck` → `provider.healthcheck()` held the `ProxySetProvider.inner` **L2 read lock** across the entire 5–15s network probe phase (Rust temporary lifetime rule kept an unnamed `RwLockReadGuard` alive through a chained `.await`)
2. If any proxy accepted TCP but stalled before responding to HTTP, `hyper::handshake()` had **no timeout** → L2 read held **forever**
3. Fetcher's periodic pull attempted L2 **write** → blocked → L2 became write-pending
4. Every subsequent L2 read (routing decisions, `PUT /proxies/{group}`, all API handlers touching the provider) → **blocked**

## Fixes

**`proxy_set_provider.rs`** — drop lock before long awaits
- `healthcheck()` and `touch()`: clone `Arc<HealthCheck>` so the L2 read guard drops at the semicolon, then await with no lock held
  ```rust
  // Before — L2 read held for entire check duration
  self.inner.read().await.hc.check().await;
  // After — L2 read released immediately
  let hc = self.inner.read().await.hc.clone();
  hc.check().await;
  ```
- Updater closure: scope the L2 write guard to drop it before `hc.update(input).await`

**`mod.rs` — `url_test()`**
- Wrap both `hyper::client::conn::http1::handshake()` calls (HTTP + HTTPS) in `tokio::time::timeout(timeout, ...)` — without this, a stalling proxy turns the L2 hold into a permanent hang
- Combine the two sequential `proxy_state` write-lock acquisitions (`report_alive` + delay history append) into one, reducing write-burst pressure when many probes finish simultaneously

**`healthcheck.rs` — `kick_off()`**
- Re-read `inner.proxies` inside the tick loop instead of capturing a stale clone at spawn time; previously, provider updates (fetcher pulls) were invisible to the background health-check task

**`provider_helper.rs`**
- Separate the single L1 `ThreadSafeProxyProvider` read guard into two independent acquisitions so `touch()` and `proxies()` don't hold L1 across each other

**`provider.rs` API handlers**
- `provider_healthcheck`: spawn the check as a background task and return `202` immediately — handler no longer holds L1 for the probe duration
- `update_provider`: extract provider name from the same guard used for `update()`, removing an accidental double lock acquisition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable proxy connection timeouts to avoid spurious hangs during URL tests.
  * Clearer, distinct error messages for handshake failures to aid troubleshooting.
  * Consolidated proxy liveness and delay recording for more consistent connectivity status and trimmed delay history to keep recent performance metrics accurate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1404)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->