### PR TITLE
fix: upgrade smoltcp to 0.13.1 to fix TCP sequence number underflow panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
  "sha2 0.11.0",
  "shadowquic",
  "shadowsocks",
- "smoltcp 0.12.0 (git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64)",
+ "smoltcp 0.13.1",
  "sock2proc",
  "socket2 0.6.3",
  "ssh-key",
@@ -5086,7 +5086,7 @@ dependencies = [
  "etherparse 0.16.0",
  "futures",
  "rand 0.8.6",
- "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smoltcp 0.12.0",
  "spin 0.9.8",
  "tokio",
  "tokio-util",
@@ -8385,20 +8385,6 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
-source = "git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64#ac32e643a4b7e09161193071526b3ca5a0deedb5"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "cfg-if",
- "defmt 0.3.100",
- "heapless 0.8.0",
- "log",
- "managed",
-]
-
-[[package]]
-name = "smoltcp"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
@@ -8408,6 +8394,7 @@ dependencies = [
  "cfg-if",
  "defmt 0.3.100",
  "heapless 0.9.3",
+ "log",
  "managed",
 ]
 
@@ -11530,7 +11517,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",
@@ -11542,7 +11529,7 @@ dependencies = [
  "netstack-lwip",
  "netstack-smoltcp",
  "rand 0.10.1",
- "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smoltcp 0.13.1",
  "socket2 0.6.3",
  "tokio",
  "tracing",

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -148,7 +148,7 @@ rust-embed = { version = "8", optional = true }
 # TUN
 tun-rs = { version = "2", features = ["async", "async_framed"], optional = true }
 watfaq-netstack = { path = "../clash-netstack", optional = true }
-smoltcp = { version = "0.12", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-udp", "socket-tcp"], optional = true, git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "ac32e64" }
+smoltcp = { version = "0.13", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-udp", "socket-tcp"], optional = true }
 
 # WireGuard
 boringtun = { version = "0.1.0", git = "https://github.com/Watfaq/boring-noise.git", rev = "9ddf1b5", package = "boring-noise", optional = true, default-features = false }

--- a/clash-netstack/Cargo.toml
+++ b/clash-netstack/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 default = []
 
 [dependencies]
-smoltcp = { version = "0.12", default-features = false, features = [
+smoltcp = { version = "0.13", default-features = false, features = [
     "std",
     "log",
     "medium-ip",


### PR DESCRIPTION
## Problem

Panic reported in #1405: `attempt to subtract sequence numbers with underflow` in `smoltcp-0.12.0/src/wire/tcp.rs:81`.

This is a known smoltcp bug fixed in [smoltcp-rs/smoltcp#1079](https://github.com/smoltcp-rs/smoltcp/pull/1079) ("Reject bytes outside the receive window").

## Root Cause

Two different smoltcp versions were being compiled:
- `clash-lib` (WireGuard) was correctly pinned to git rev `ac32e64` containing the fix
- `clash-netstack` (TUN stack) used `smoltcp = { version = "0.12" }` from crates.io — the **unfixed** version

So the TUN netstack path was still vulnerable.

## Fix

Upgrade both `clash-lib` and `clash-netstack` to **smoltcp 0.13.1** (released 2026-04-30), which includes:
- ✅ TCP: Reject bytes outside the receive window (the crash fix, [smoltcp-rs/smoltcp#1079](https://github.com/smoltcp-rs/smoltcp/pull/1079))
- ✅ TCP: Fix panic when listening socket receives SYN from unspecified addr
- ✅ TCP: Fix SACK sequence number overflow panic
- ✅ Zero window probe support, retransmit improvements, IPv6 SLAAC, and more

No API changes were needed — both crates compile cleanly against 0.13.1.

Closes #1405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded smoltcp dependency to version 0.13 across the project, transitioning from a git-pinned development version to the published crate release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1406)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->