### PR TITLE
refactor: remove outer RwLock from ThreadSafeProxyProvider

### DIFF
--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -67,7 +67,6 @@ async fn get_providers(State(state): State<ProviderState>) -> impl IntoResponse 
     let mut providers = HashMap::new();
 
     for (name, p) in outbound_manager.get_proxy_providers() {
-        let p = p.read().await;
         let proxies = p.proxies().await;
         let proxies = futures::future::join_all(
             proxies.iter().map(|x| outbound_manager.get_proxy(x)),
@@ -108,14 +107,12 @@ async fn find_proxy_provider_by_name(
 async fn get_provider(
     Extension(provider): Extension<ThreadSafeProxyProvider>,
 ) -> impl IntoResponse {
-    let provider = provider.read().await;
     axum::response::Json(provider.as_map().await)
 }
 
 async fn update_provider(
     Extension(provider): Extension<ThreadSafeProxyProvider>,
 ) -> impl IntoResponse {
-    let provider = provider.read().await;
     match provider.update().await {
         Ok(_) => (
             StatusCode::ACCEPTED,
@@ -137,7 +134,6 @@ async fn update_provider(
 async fn provider_healthcheck(
     Extension(provider): Extension<ThreadSafeProxyProvider>,
 ) -> impl IntoResponse {
-    let provider = provider.read().await;
     provider.healthcheck().await;
 
     (
@@ -156,7 +152,6 @@ async fn find_proxy_provider_proxy_by_name(
     mut req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    let provider = provider.read().await;
     let proxies = provider.proxies().await;
     let proxy = proxies.iter().find(|x| x.name() == proxy_name);
 

--- a/clash-lib/src/app/api/handlers/provider.rs
+++ b/clash-lib/src/app/api/handlers/provider.rs
@@ -20,7 +20,7 @@ use serde_json::json;
 use crate::{
     app::{
         api::AppState, outbound::manager::ThreadSafeOutboundManager,
-        remote_content_manager::providers::proxy_provider::ThreadSafeProxyProvider,
+        remote_content_manager::providers::proxy_provider::ArcProxyProvider,
         router::ArcRouter,
     },
     proxy::AnyOutboundHandler,
@@ -105,13 +105,13 @@ async fn find_proxy_provider_by_name(
 }
 
 async fn get_provider(
-    Extension(provider): Extension<ThreadSafeProxyProvider>,
+    Extension(provider): Extension<ArcProxyProvider>,
 ) -> impl IntoResponse {
     axum::response::Json(provider.as_map().await)
 }
 
 async fn update_provider(
-    Extension(provider): Extension<ThreadSafeProxyProvider>,
+    Extension(provider): Extension<ArcProxyProvider>,
 ) -> impl IntoResponse {
     match provider.update().await {
         Ok(_) => (
@@ -132,7 +132,7 @@ async fn update_provider(
 }
 
 async fn provider_healthcheck(
-    Extension(provider): Extension<ThreadSafeProxyProvider>,
+    Extension(provider): Extension<ArcProxyProvider>,
 ) -> impl IntoResponse {
     provider.healthcheck().await;
 
@@ -147,7 +147,7 @@ struct ProviderProxyPath {
     proxy_name: String,
 }
 async fn find_proxy_provider_proxy_by_name(
-    Extension(provider): Extension<ThreadSafeProxyProvider>,
+    Extension(provider): Extension<ArcProxyProvider>,
     Path(ProviderProxyPath { proxy_name }): Path<ProviderProxyPath>,
     mut req: Request<axum::body::Body>,
     next: Next,

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -51,7 +51,6 @@ use anyhow::Result;
 use erased_serde::Serialize;
 use hyper::Uri;
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
-use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 use uuid::Uuid;
 
@@ -500,16 +499,13 @@ impl OutboundManager {
             self.proxy_manager.clone(),
         );
 
-        let pd = Arc::new(RwLock::new(PlainProvider::new(
-            PROXY_GLOBAL.to_owned(),
-            g,
-            hc,
-        )?));
+        let pd: ThreadSafeProxyProvider =
+            Arc::new(PlainProvider::new(PROXY_GLOBAL.to_owned(), g, hc)?);
 
         let stored_selection = cache_store.get_selected(PROXY_GLOBAL).await;
         let mut providers: Vec<ThreadSafeProxyProvider> = vec![pd.clone()];
         for p in self.proxy_providers.values() {
-            let vehicle_type = p.read().await.vehicle_type();
+            let vehicle_type = p.vehicle_type();
             if matches!(
                 vehicle_type,
                 ProviderVehicleType::Http | ProviderVehicleType::File
@@ -636,11 +632,11 @@ impl OutboundManager {
                 proxy_manager,
             );
 
-            let pd = Arc::new(RwLock::new(
+            let pd: ThreadSafeProxyProvider = Arc::new(
                 PlainProvider::new(name.to_owned(), proxies, hc).map_err(|x| {
                     Error::InvalidConfig(format!("invalid provider config: {x}"))
                 })?,
-            ));
+            );
 
             provider_registry.insert(name.to_owned(), pd.clone());
 
@@ -891,7 +887,7 @@ impl OutboundManager {
                 vehicle,
                 hc,
             )
-            .map(|p| Arc::new(RwLock::new(p)) as ThreadSafeProxyProvider)
+            .map(|p| Arc::new(p) as ThreadSafeProxyProvider)
             .map_err(|x| {
                 Error::InvalidConfig(format!("invalid provider config: {x}"))
             })
@@ -944,9 +940,8 @@ impl OutboundManager {
 
         let mut failed = Vec::new();
         for p in provider_registry.values() {
-            let name = p.read().await.name().to_owned();
+            let name = p.name().to_owned();
             info!("initializing provider {}", name);
-            let p = p.write().await;
             if let Err(err) = p.initialize().await {
                 error!("failed to initialize proxy provider {}: {}", name, err);
                 failed.push(name);

--- a/clash-lib/src/app/outbound/manager.rs
+++ b/clash-lib/src/app/outbound/manager.rs
@@ -25,7 +25,7 @@ use crate::{
                 ProviderVehicleType, ThreadSafeProviderVehicle, file_vehicle,
                 http_vehicle,
                 proxy_provider::{
-                    PlainProvider, ProxySetProvider, ThreadSafeProxyProvider,
+                    ArcProxyProvider, PlainProvider, ProxySetProvider,
                 },
             },
         },
@@ -62,7 +62,7 @@ pub struct OutboundManager {
     /// single source of truth for all handlers after initialization.
     registry: OutboundHandlerRegistry,
     /// name -> provider
-    proxy_providers: HashMap<String, ThreadSafeProxyProvider>,
+    proxy_providers: HashMap<String, ArcProxyProvider>,
     proxy_manager: ProxyManager,
     selector_control: HashMap<String, ThreadSafeSelectorControl>,
 }
@@ -157,7 +157,7 @@ impl OutboundManager {
     }
 
     /// this doesn't populate history/liveness information
-    pub fn get_proxy_provider(&self, name: &str) -> Option<ThreadSafeProxyProvider> {
+    pub fn get_proxy_provider(&self, name: &str) -> Option<ArcProxyProvider> {
         self.proxy_providers.get(name).cloned()
     }
 
@@ -259,7 +259,7 @@ impl OutboundManager {
         proxy_manager.check(outbounds, url, Some(timeout)).await
     }
 
-    pub fn get_proxy_providers(&self) -> HashMap<String, ThreadSafeProxyProvider> {
+    pub fn get_proxy_providers(&self) -> HashMap<String, ArcProxyProvider> {
         self.proxy_providers.clone()
     }
 
@@ -499,11 +499,11 @@ impl OutboundManager {
             self.proxy_manager.clone(),
         );
 
-        let pd: ThreadSafeProxyProvider =
+        let pd: ArcProxyProvider =
             Arc::new(PlainProvider::new(PROXY_GLOBAL.to_owned(), g, hc)?);
 
         let stored_selection = cache_store.get_selected(PROXY_GLOBAL).await;
-        let mut providers: Vec<ThreadSafeProxyProvider> = vec![pd.clone()];
+        let mut providers: Vec<ArcProxyProvider> = vec![pd.clone()];
         for p in self.proxy_providers.values() {
             let vehicle_type = p.vehicle_type();
             if matches!(
@@ -552,7 +552,7 @@ impl OutboundManager {
         let selector_control = &mut self.selector_control;
 
         /// Common boilerplate: build providers list from proxies and
-        /// use_provider. Returns `Vec<ThreadSafeProxyProvider>`
+        /// use_provider. Returns `Vec<ArcProxyProvider>`
         /// directly — the caller checks for emptiness.
         #[allow(clippy::too_many_arguments)]
         fn build_group_providers(
@@ -563,9 +563,9 @@ impl OutboundManager {
             lazy: bool,
             handlers: &HashMap<String, AnyOutboundHandler>,
             proxy_manager: &ProxyManager,
-            provider_registry: &mut HashMap<String, ThreadSafeProxyProvider>,
-        ) -> Result<Vec<ThreadSafeProxyProvider>, Error> {
-            let mut providers: Vec<ThreadSafeProxyProvider> = vec![];
+            provider_registry: &mut HashMap<String, ArcProxyProvider>,
+        ) -> Result<Vec<ArcProxyProvider>, Error> {
+            let mut providers: Vec<ArcProxyProvider> = vec![];
 
             if let Some(proxies) = proxies
                 && !proxies.is_empty()
@@ -605,8 +605,8 @@ impl OutboundManager {
             lazy: bool,
             handlers: &HashMap<String, AnyOutboundHandler>,
             proxy_manager: ProxyManager,
-            provider_registry: &mut HashMap<String, ThreadSafeProxyProvider>,
-        ) -> Result<ThreadSafeProxyProvider, Error> {
+            provider_registry: &mut HashMap<String, ArcProxyProvider>,
+        ) -> Result<ArcProxyProvider, Error> {
             if name == PROXY_DIRECT || name == PROXY_REJECT {
                 return Err(Error::InvalidConfig(format!(
                     "proxy group name `{name}` is reserved"
@@ -632,7 +632,7 @@ impl OutboundManager {
                 proxy_manager,
             );
 
-            let pd: ThreadSafeProxyProvider = Arc::new(
+            let pd: ArcProxyProvider = Arc::new(
                 PlainProvider::new(name.to_owned(), proxies, hc).map_err(|x| {
                     Error::InvalidConfig(format!("invalid provider config: {x}"))
                 })?,
@@ -880,14 +880,14 @@ impl OutboundManager {
             vehicle: ThreadSafeProviderVehicle,
             interval_secs: u64,
             hc: HealthCheck,
-        ) -> Result<ThreadSafeProxyProvider, Error> {
+        ) -> Result<ArcProxyProvider, Error> {
             ProxySetProvider::new(
                 name.to_owned(),
                 Duration::from_secs(interval_secs),
                 vehicle,
                 hc,
             )
-            .map(|p| Arc::new(p) as ThreadSafeProxyProvider)
+            .map(|p| Arc::new(p) as ArcProxyProvider)
             .map_err(|x| {
                 Error::InvalidConfig(format!("invalid provider config: {x}"))
             })

--- a/clash-lib/src/app/remote_content_manager/healthcheck.rs
+++ b/clash-lib/src/app/remote_content_manager/healthcheck.rs
@@ -47,14 +47,9 @@ impl HealthCheck {
         let interval = self.interval;
         let lazy = self.lazy;
         let proxies = self.inner.read().await.proxies.clone();
-
-        {
-            let url = self.url.clone();
-            let proxies = proxies.clone();
-            tokio::spawn(async move {
-                proxy_manager.check(&proxies, &url, None).await;
-            });
-        }
+        let url = self.url.clone();
+        let pm = proxy_manager.clone();
+        tokio::spawn(async move { pm.check(&proxies, &url, None).await });
 
         let inner = self.inner.clone();
         let proxy_manager = self.proxy_manager.clone();
@@ -69,9 +64,9 @@ impl HealthCheck {
                         let now = tokio::time::Instant::now();
                         let last_check = inner.read().await.last_check;
                         if !lazy || now.duration_since(last_check).as_secs() >= interval {
+                            let proxies = inner.read().await.proxies.clone();
                             proxy_manager.check(&proxies, &url, None).await;
-                            let mut w = inner.write().await;
-                            w.last_check = now;
+                            inner.write().await.last_check = now;
                         }
                     },
                 }

--- a/clash-lib/src/app/remote_content_manager/providers/proxy_provider/mod.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/proxy_provider/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     app::remote_content_manager::providers::Provider, proxy::AnyOutboundHandler,
 };
 
-pub type ThreadSafeProxyProvider = Arc<dyn ProxyProvider + Send + Sync>;
+pub type ArcProxyProvider = Arc<dyn ProxyProvider + Send + Sync>;
 
 #[async_trait]
 pub trait ProxyProvider: Provider {

--- a/clash-lib/src/app/remote_content_manager/providers/proxy_provider/mod.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/proxy_provider/mod.rs
@@ -8,13 +8,12 @@ pub use proxy_set_provider::ProxySetProvider;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::sync::RwLock;
 
 use crate::{
     app::remote_content_manager::providers::Provider, proxy::AnyOutboundHandler,
 };
 
-pub type ThreadSafeProxyProvider = Arc<RwLock<dyn ProxyProvider + Send + Sync>>;
+pub type ThreadSafeProxyProvider = Arc<dyn ProxyProvider + Send + Sync>;
 
 #[async_trait]
 pub trait ProxyProvider: Provider {

--- a/clash-lib/src/app/remote_content_manager/providers/proxy_provider/proxy_set_provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/proxy_provider/proxy_set_provider.rs
@@ -44,7 +44,6 @@ struct ProviderScheme {
 
 struct Inner {
     proxies: Vec<AnyOutboundHandler>,
-    hc: Arc<HealthCheck>,
 }
 
 type ProxyUpdater = Box<
@@ -59,6 +58,7 @@ type ProxyParser = Box<
 
 pub struct ProxySetProvider {
     fetcher: Fetcher<ProxyUpdater, ProxyParser>,
+    hc: Arc<HealthCheck>,
     inner: Arc<tokio::sync::RwLock<Inner>>,
 }
 
@@ -79,25 +79,24 @@ impl ProxySetProvider {
             });
         }
 
-        let inner = Arc::new(tokio::sync::RwLock::new(Inner {
-            proxies: vec![],
-            hc: hc.clone(),
-        }));
+        let inner = Arc::new(tokio::sync::RwLock::new(Inner { proxies: vec![] }));
 
         let inner_clone = inner.clone();
 
         let n = name.clone();
+        let hc_updater = hc.clone();
         let updater: ProxyUpdater = Box::new(
             move |input: Vec<AnyOutboundHandler>| -> BoxFuture<'static, ()> {
-                let hc = hc.clone();
+                let hc = hc_updater.clone();
                 let n = n.clone();
                 let inner: Arc<tokio::sync::RwLock<Inner>> = inner_clone.clone();
                 Box::pin(async move {
-                    let mut inner = inner.write().await;
-                    debug!("updating {} proxies for: {}", n, input.len());
-                    inner.proxies.clone_from(&input);
+                    {
+                        let mut inner = inner.write().await;
+                        debug!("updating {} proxies for: {}", n, input.len());
+                        inner.proxies.clone_from(&input);
+                    }
                     hc.update(input).await;
-                    // check once after update
                     tokio::spawn(async move {
                         hc.check().await;
                     });
@@ -200,7 +199,7 @@ impl ProxySetProvider {
         );
 
         let fetcher = Fetcher::new(name, interval, vehicle, parser, Some(updater));
-        Ok(Self { fetcher, inner })
+        Ok(Self { fetcher, hc, inner })
     }
 }
 
@@ -267,11 +266,11 @@ impl ProxyProvider for ProxySetProvider {
     }
 
     async fn touch(&self) {
-        self.inner.read().await.hc.touch().await;
+        self.hc.touch().await;
     }
 
     async fn healthcheck(&self) {
-        self.inner.read().await.hc.check().await;
+        self.hc.check().await;
     }
 }
 

--- a/clash-lib/src/proxy/group/fallback/mod.rs
+++ b/clash-lib/src/proxy/group/fallback/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
         dns::ThreadSafeDNSResolver,
         remote_content_manager::{
-            ProxyManager, providers::proxy_provider::ThreadSafeProxyProvider,
+            ProxyManager, providers::proxy_provider::ArcProxyProvider,
         },
     },
     proxy::{
@@ -29,7 +29,7 @@ pub struct HandlerOptions {
 
 pub struct Handler {
     opts: HandlerOptions,
-    providers: Vec<ThreadSafeProxyProvider>,
+    providers: Vec<ArcProxyProvider>,
     proxy_manager: ProxyManager,
 }
 
@@ -44,7 +44,7 @@ impl Debug for Handler {
 impl Handler {
     pub fn new(
         opts: HandlerOptions,
-        providers: Vec<ThreadSafeProxyProvider>,
+        providers: Vec<ArcProxyProvider>,
         proxy_manager: ProxyManager,
     ) -> Self {
         Self {

--- a/clash-lib/src/proxy/group/loadbalance/mod.rs
+++ b/clash-lib/src/proxy/group/loadbalance/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
         dns::ThreadSafeDNSResolver,
         remote_content_manager::{
-            ProxyManager, providers::proxy_provider::ThreadSafeProxyProvider,
+            ProxyManager, providers::proxy_provider::ArcProxyProvider,
         },
     },
     config::internal::proxy::LoadBalanceStrategy,
@@ -40,7 +40,7 @@ struct HandlerInner {
 pub struct Handler {
     opts: HandlerOptions,
 
-    providers: Vec<ThreadSafeProxyProvider>,
+    providers: Vec<ArcProxyProvider>,
 
     inner: Arc<Mutex<HandlerInner>>,
 }
@@ -56,7 +56,7 @@ impl std::fmt::Debug for Handler {
 impl Handler {
     pub fn new(
         opts: HandlerOptions,
-        providers: Vec<ThreadSafeProxyProvider>,
+        providers: Vec<ArcProxyProvider>,
         proxy_manager: ProxyManager,
     ) -> Self {
         let strategy_fn = match opts.strategy {

--- a/clash-lib/src/proxy/group/relay/mod.rs
+++ b/clash-lib/src/proxy/group/relay/mod.rs
@@ -11,7 +11,7 @@ use crate::{
             ChainedDatagramWrapper, ChainedStream, ChainedStreamWrapper,
         },
         dns::ThreadSafeDNSResolver,
-        remote_content_manager::providers::proxy_provider::ThreadSafeProxyProvider,
+        remote_content_manager::providers::proxy_provider::ArcProxyProvider,
     },
     common::errors::new_io_error,
     proxy::{
@@ -34,7 +34,7 @@ pub struct HandlerOptions {
 
 pub struct Handler {
     opts: HandlerOptions,
-    providers: Vec<ThreadSafeProxyProvider>,
+    providers: Vec<ArcProxyProvider>,
 }
 
 impl std::fmt::Debug for Handler {
@@ -49,7 +49,7 @@ impl Handler {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
         opts: HandlerOptions,
-        providers: Vec<ThreadSafeProxyProvider>,
+        providers: Vec<ArcProxyProvider>,
     ) -> AnyOutboundHandler {
         Arc::new(Self { opts, providers })
     }

--- a/clash-lib/src/proxy/group/relay/mod.rs
+++ b/clash-lib/src/proxy/group/relay/mod.rs
@@ -206,8 +206,6 @@ impl GroupProxyAPIResponse for Handler {
 #[cfg(all(test, docker_test))]
 mod tests {
 
-    use tokio::sync::RwLock;
-
     use super::*;
     use crate::{
         proxy::{
@@ -271,8 +269,7 @@ mod tests {
             .expect_proxies()
             .returning(move || vec![ss_handler.clone()]);
 
-        let handler =
-            Handler::new(Default::default(), vec![Arc::new(RwLock::new(provider))]);
+        let handler = Handler::new(Default::default(), vec![Arc::new(provider)]);
         run_test_suites_and_cleanup(handler, container, Suite::all()).await
     }
 
@@ -308,8 +305,7 @@ mod tests {
             .expect_proxies()
             .returning(move || vec![ss_handler.clone(), ss_handler.clone()]);
 
-        let handler =
-            Handler::new(Default::default(), vec![Arc::new(RwLock::new(provider))]);
+        let handler = Handler::new(Default::default(), vec![Arc::new(provider)]);
         run_test_suites_and_cleanup(handler, container, Suite::all()).await
     }
 }

--- a/clash-lib/src/proxy/group/selector/mod.rs
+++ b/clash-lib/src/proxy/group/selector/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     app::{
         dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
         dns::ThreadSafeDNSResolver,
-        remote_content_manager::providers::proxy_provider::ThreadSafeProxyProvider,
+        remote_content_manager::providers::proxy_provider::ArcProxyProvider,
     },
     proxy::{
         AnyOutboundHandler, ConnectorType, DialWithConnector, HandlerCommonOptions,
@@ -41,7 +41,7 @@ pub struct HandlerOptions {
 #[derive(Clone)]
 pub struct Handler {
     opts: HandlerOptions,
-    providers: Vec<ThreadSafeProxyProvider>,
+    providers: Vec<ArcProxyProvider>,
     current_selected_index: Arc<AtomicU16>,
 }
 
@@ -56,7 +56,7 @@ impl std::fmt::Debug for Handler {
 impl Handler {
     pub async fn new(
         opts: HandlerOptions,
-        providers: Vec<ThreadSafeProxyProvider>,
+        providers: Vec<ArcProxyProvider>,
         selected: Option<String>,
     ) -> Self {
         let provider = providers.first().unwrap();

--- a/clash-lib/src/proxy/group/selector/mod.rs
+++ b/clash-lib/src/proxy/group/selector/mod.rs
@@ -60,7 +60,7 @@ impl Handler {
         selected: Option<String>,
     ) -> Self {
         let provider = providers.first().unwrap();
-        let proxies = provider.read().await.proxies().await;
+        let proxies = provider.proxies().await;
 
         Self {
             opts,
@@ -229,8 +229,6 @@ impl GroupProxyAPIResponse for Handler {
 mod tests {
     use std::sync::Arc;
 
-    use tokio::sync::RwLock;
-
     use crate::proxy::{
         group::selector::ThreadSafeSelectorControl,
         mocks::{MockDummyOutboundHandler, MockDummyProxyProvider},
@@ -257,7 +255,7 @@ mod tests {
                 udp: false,
                 ..Default::default()
             },
-            vec![Arc::new(RwLock::new(mock_provider))],
+            vec![Arc::new(mock_provider)],
             None,
         )
         .await;

--- a/clash-lib/src/proxy/group/smart/mod.rs
+++ b/clash-lib/src/proxy/group/smart/mod.rs
@@ -766,7 +766,6 @@ mod tests {
         tests::initialize,
     };
     use tempfile::tempdir;
-    use tokio::sync::RwLock;
 
     // Constants for the mock Shadowsocks server
     const PASSWORD: &str = "FzcLbKs2dY9mhL_smart";
@@ -813,8 +812,7 @@ mod tests {
         provider
             .expect_proxies()
             .returning(move || vec![ss_handler.clone()]);
-        let thread_safe_provider: ThreadSafeProxyProvider =
-            Arc::new(RwLock::new(provider));
+        let thread_safe_provider: ThreadSafeProxyProvider = Arc::new(provider);
 
         // Setup HandlerOptions for Smart group
         let smart_opts = super::HandlerOptions {

--- a/clash-lib/src/proxy/group/smart/mod.rs
+++ b/clash-lib/src/proxy/group/smart/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
         dns::ThreadSafeDNSResolver,
         remote_content_manager::{
-            ProxyManager, providers::proxy_provider::ThreadSafeProxyProvider,
+            ProxyManager, providers::proxy_provider::ArcProxyProvider,
         },
     },
     proxy::{
@@ -88,7 +88,7 @@ pub struct Handler {
     /// Configuration options
     opts: HandlerOptions,
     /// Proxy providers for obtaining available proxies
-    providers: Vec<ThreadSafeProxyProvider>,
+    providers: Vec<ArcProxyProvider>,
     /// Proxy manager for health checks and metrics
     proxy_manager: ProxyManager,
     /// Centralized state management
@@ -109,7 +109,7 @@ impl Handler {
     /// Create a new smart proxy group handler with persistence support
     pub fn new_with_cache(
         opts: HandlerOptions,
-        providers: Vec<ThreadSafeProxyProvider>,
+        providers: Vec<ArcProxyProvider>,
         proxy_manager: ProxyManager,
         cache_store: crate::app::profile::ThreadSafeCacheFile,
     ) -> Self {
@@ -812,7 +812,7 @@ mod tests {
         provider
             .expect_proxies()
             .returning(move || vec![ss_handler.clone()]);
-        let thread_safe_provider: ThreadSafeProxyProvider = Arc::new(provider);
+        let thread_safe_provider: ArcProxyProvider = Arc::new(provider);
 
         // Setup HandlerOptions for Smart group
         let smart_opts = super::HandlerOptions {

--- a/clash-lib/src/proxy/group/urltest/mod.rs
+++ b/clash-lib/src/proxy/group/urltest/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
         dns::ThreadSafeDNSResolver,
         remote_content_manager::{
-            ProxyManager, providers::proxy_provider::ThreadSafeProxyProvider,
+            ProxyManager, providers::proxy_provider::ArcProxyProvider,
         },
     },
     proxy::{
@@ -31,7 +31,7 @@ pub struct Handler {
     opts: HandlerOptions,
     tolerance: u16,
 
-    providers: Vec<ThreadSafeProxyProvider>,
+    providers: Vec<ArcProxyProvider>,
     proxy_manager: ProxyManager,
     fastest_proxy_index: AtomicU16,
 }
@@ -48,7 +48,7 @@ impl Handler {
     pub fn new(
         opts: HandlerOptions,
         tolerance: u16,
-        providers: Vec<ThreadSafeProxyProvider>,
+        providers: Vec<ArcProxyProvider>,
         proxy_manager: ProxyManager,
     ) -> Self {
         Self {

--- a/clash-lib/src/proxy/utils/provider_helper.rs
+++ b/clash-lib/src/proxy/utils/provider_helper.rs
@@ -1,11 +1,11 @@
 use crate::{
-    app::remote_content_manager::providers::proxy_provider::ThreadSafeProxyProvider,
+    app::remote_content_manager::providers::proxy_provider::ArcProxyProvider,
     proxy::AnyOutboundHandler,
 };
 use std::collections::HashSet;
 
 pub async fn get_proxies_from_providers(
-    providers: &Vec<ThreadSafeProxyProvider>,
+    providers: &Vec<ArcProxyProvider>,
     touch: bool,
 ) -> Vec<AnyOutboundHandler> {
     let mut proxies = vec![];

--- a/clash-lib/src/proxy/utils/provider_helper.rs
+++ b/clash-lib/src/proxy/utils/provider_helper.rs
@@ -11,12 +11,11 @@ pub async fn get_proxies_from_providers(
     let mut proxies = vec![];
     let mut proxy_names = HashSet::new();
     for provider in providers {
-        let p = provider.read().await;
         if touch {
-            p.touch().await;
+            provider.touch().await;
         }
 
-        let mut proxies_from_provider = p.proxies().await.to_vec();
+        let mut proxies_from_provider = provider.proxies().await.to_vec();
 
         proxies_from_provider.retain(|p| proxy_names.insert(p.name().to_owned()));
 


### PR DESCRIPTION
## Summary

`ThreadSafeProxyProvider` was typed as `Arc<RwLock<dyn ProxyProvider + Send + Sync>>` but the `ProxyProvider` trait has no `&mut self` methods — all mutation goes through interior mutability inside each implementation. The outer lock was unnecessary overhead on every provider access.

Changed to `Arc<dyn ProxyProvider + Send + Sync>`, renamed to `ArcProxyProvider`.

## Changes

- Remove `RwLock` wrapper from `ArcProxyProvider` — all `provider.read().await` call sites simplified to direct method calls
- Move `Arc<HealthCheck>` out of `RwLock<Inner>` in `ProxySetProvider` — `hc` is immutable after construction and needs no lock protection; `touch()` and `healthcheck()` now call `self.hc.*` directly with no locking
- Fix `HealthCheck::kick_off` to re-read the proxy list on each tick — previously a stale clone captured at spawn time was used, making fetcher updates invisible to the background health-check task