### PR TITLE
fix(dns): DNS client rebuild resilience

### DIFF
--- a/clash-lib/src/app/dns/dns_client.rs
+++ b/clash-lib/src/app/dns/dns_client.rs
@@ -286,6 +286,43 @@ pub struct DnsClient {
 }
 
 impl DnsClient {
+    /// Rebuild the DNS stream with retries, waiting between attempts.
+    /// This is needed because iOS can temporarily return EADDRNOTAVAIL during
+    /// network transitions (Wi-Fi ↔ cellular), and the DNS client's TCP
+    /// connection must be re-established to recover.
+    async fn rebuild_with_retries(
+        &self,
+    ) -> anyhow::Result<(client::Client<DnsRuntimeProvider>, JoinHandle<()>)> {
+        const MAX_RETRIES: u32 = 3;
+        const RETRY_DELAY: Duration = Duration::from_millis(200);
+
+        for attempt in 0..=MAX_RETRIES {
+            match dns_stream_builder(&self.cfg).await {
+                Ok(result) => return Ok(result),
+                Err(e) if attempt < MAX_RETRIES => {
+                    warn!(
+                        "dns client rebuild attempt {}/{} failed: {e}, \
+                         retrying in {}ms",
+                        attempt + 1,
+                        MAX_RETRIES,
+                        RETRY_DELAY.as_millis()
+                    );
+                    tokio::time::sleep(RETRY_DELAY).await;
+                }
+                Err(e) => {
+                    warn!(
+                        "dns client rebuild failed after {} attempts: {e}",
+                        MAX_RETRIES + 1
+                    );
+                    return Err(e.into());
+                }
+            }
+        }
+        unreachable!()
+    }
+}
+
+impl DnsClient {
     pub async fn new_client(opts: Opts) -> anyhow::Result<ThreadSafeDNSClient> {
         // TODO: use proxy to connect?
 
@@ -519,7 +556,7 @@ impl Client for DnsClient {
                             "dns client background task is finished, likely \
                              connection closed, restarting a new one"
                         );
-                        let (client, bg) = dns_stream_builder(&self.cfg).await?;
+                        let (client, bg) = self.rebuild_with_retries().await?;
                         inner.c.replace(client);
                         inner.bg_handle.replace(bg);
                     } else {
@@ -532,7 +569,7 @@ impl Client for DnsClient {
                 _ => {
                     // initializing client
                     info!("initializing dns client: {}", &self.cfg);
-                    let (client, bg) = dns_stream_builder(&self.cfg).await?;
+                    let (client, bg) = self.rebuild_with_retries().await?;
                     inner.c.replace(client);
                     inner.bg_handle.replace(bg);
                 }

--- a/clash-lib/src/app/dns/dns_client.rs
+++ b/clash-lib/src/app/dns/dns_client.rs
@@ -287,9 +287,8 @@ pub struct DnsClient {
 
 impl DnsClient {
     /// Rebuild the DNS stream with retries, waiting between attempts.
-    /// This is needed because iOS can temporarily return EADDRNOTAVAIL during
-    /// network transitions (Wi-Fi ↔ cellular), and the DNS client's TCP
-    /// connection must be re-established to recover.
+    /// Observed on iOS: EADDRNOTAVAIL during network transitions can break
+    /// DNS client connections; retrying gives the OS time to settle.
     async fn rebuild_with_retries(
         &self,
     ) -> anyhow::Result<(client::Client<DnsRuntimeProvider>, JoinHandle<()>)> {
@@ -298,20 +297,32 @@ impl DnsClient {
 
         for attempt in 0..=MAX_RETRIES {
             match dns_stream_builder(&self.cfg).await {
-                Ok(result) => return Ok(result),
+                Ok(result) => {
+                    if attempt > 0 {
+                        info!(
+                            "{}: dns client rebuild succeeded on attempt {}/{}",
+                            self.id(),
+                            attempt + 1,
+                            MAX_RETRIES + 1
+                        );
+                    }
+                    return Ok(result);
+                }
                 Err(e) if attempt < MAX_RETRIES => {
                     warn!(
-                        "dns client rebuild attempt {}/{} failed: {e}, \
+                        "{}: dns client rebuild attempt {}/{} failed: {e:#}, \
                          retrying in {}ms",
+                        self.id(),
                         attempt + 1,
-                        MAX_RETRIES,
+                        MAX_RETRIES + 1,
                         RETRY_DELAY.as_millis()
                     );
                     tokio::time::sleep(RETRY_DELAY).await;
                 }
                 Err(e) => {
                     warn!(
-                        "dns client rebuild failed after {} attempts: {e}",
+                        "{}: dns client rebuild failed after {} attempts: {e:#}",
+                        self.id(),
                         MAX_RETRIES + 1
                     );
                     return Err(e.into());


### PR DESCRIPTION
### What does this PR do?

DNS client rebuild resilience

Problem：Observed on iOS: EADDRNOTAVAIL can cause DNS client's dns_stream_builder to fail. The ? operator propagates the error immediately — no retry, no recovery — causing a total DNS outage.

Fix：Add rebuild_with_retries() to DnsClient:
-  Retries up to 3 times with 200ms delay between attempts
-  Replaces both direct dns_stream_builder(...).await? calls in exchange() (initial connection + reconnection after background task exit)
-  Logs include the client id (e.g. DoH#223.5.5.5:443), attempt number, and full error chain ({e:#})
-  Successful retry is logged at info level so recovery is visible
-  Final failure is logged at warn level with total attempt count


Log examples
WARN  DoH#223.5.5.5:443: dns client rebuild attempt 1/4 failed: Can't assign requested address (os error 49), retrying in 200ms
INFO  DoH#223.5.5.5:443: dns client rebuild succeeded on attempt 2/4

**Note:** 代码由 LLM 生成，仅供参考。只是为了说明问题，请求加固。

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / cleanup
- [ ] Other

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS client reliability with automatic retry logic for connection failures, enhancing stability and recovery of DNS operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1410)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->