### PR TITLE
fix(tun): bind interface on windows not valid for dualstack

### DIFF
--- a/clash-lib/src/proxy/utils/platform/win.rs
+++ b/clash-lib/src/proxy/utils/platform/win.rs
@@ -91,8 +91,12 @@ pub(crate) fn must_bind_socket_on_interface(
         }
     }
     if family == socket2::Domain::IPV6 {
-        if let Err(x) = must_bind_socket_on_interface(socket, iface, socket2::Domain::IPV4) {
-            tracing::warn!("try bind dualstack socket on interface failed, it's ipv6 only:{x}");
+        if let Err(x) =
+            must_bind_socket_on_interface(socket, iface, socket2::Domain::IPV4)
+        {
+            tracing::warn!(
+                "try bind dualstack socket on interface failed, it's ipv6 only:{x}"
+            );
         }
     }
     Ok(())

--- a/clash-lib/src/proxy/utils/platform/win.rs
+++ b/clash-lib/src/proxy/utils/platform/win.rs
@@ -90,6 +90,11 @@ pub(crate) fn must_bind_socket_on_interface(
             return Err(new_io_error(err));
         }
     }
+    if family == socket2::Domain::IPV6 {
+        if let Err(x) = must_bind_socket_on_interface(socket, iface, socket2::Domain::IPV4) {
+            tracing::warn!("try bind dualstack socket on interface failed, it's ipv6 only:{x}");
+        }
+    }
     Ok(())
 }
 

--- a/clash-lib/src/proxy/utils/platform/win.rs
+++ b/clash-lib/src/proxy/utils/platform/win.rs
@@ -90,14 +90,13 @@ pub(crate) fn must_bind_socket_on_interface(
             return Err(new_io_error(err));
         }
     }
-    if family == socket2::Domain::IPV6 {
-        if let Err(x) =
+    if family == socket2::Domain::IPV6
+        && let Err(x) =
             must_bind_socket_on_interface(socket, iface, socket2::Domain::IPV4)
-        {
-            tracing::warn!(
-                "try bind dualstack socket on interface failed, it's ipv6 only:{x}"
-            );
-        }
+    {
+        tracing::warn!(
+            "try bind dualstack socket on interface failed, it's ipv6 only:{x}"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
### What does this PR do?

<!-- Briefly describe the change and why it's needed. Link related issues with `closes #xxx` if applicable. -->

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / cleanup
- [ ] Other

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows network binding: when IPv6 sockets are bound, the system now tries an IPv4 fallback on the same interface. Failures of the IPv4 fallback are logged but no longer cause the bind to fail, yielding more robust dual‑stack connectivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1413)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->