### PR TITLE
fix(dns): skip caching NXDomain, ServFail, and all-unspecified responses

### DIFF
--- a/clash-lib/src/app/dns/resolver/enhanced.rs
+++ b/clash-lib/src/app/dns/resolver/enhanced.rs
@@ -424,6 +424,14 @@ impl EnhancedResolver {
             && let Some(lru) = &self.lru_cache
             && !(q.query_type() == rr::RecordType::TXT
                 && q.name().to_ascii().starts_with("_acme-challenge."))
+            && !matches!(
+                msg.metadata.response_code,
+                op::ResponseCode::NXDomain | op::ResponseCode::ServFail
+            )
+            && {
+                let ips = EnhancedResolver::ip_list_of_message(msg);
+                ips.is_empty() || ips.iter().any(|ip| !ip.is_unspecified())
+            }
         {
             lru.insert(q.clone(), Ok(msg.clone()), Instant::now());
         }


### PR DESCRIPTION
## Problem

DNS responses containing only unspecified addresses (`0.0.0.0` / `::`), `NXDomain`, or `ServFail` codes were being cached. This locks in a bad result for the full TTL, preventing fallback or retry on subsequent requests.

This is particularly problematic when ISP DNS or local firewalls poison responses with `0.0.0.0` — the poisoned result gets cached and all connections to the domain fail until TTL expires.

## Fix

Add additional guards to the `lru.insert` block in `EnhancedResolver::exchange`:

- Skip caching `NXDomain` responses
- Skip caching `ServFail` responses  
- Skip caching responses where all A/AAAA records are unspecified (`0.0.0.0` / `::`)

Non-IP responses (CNAME-only, TXT, etc.) are unaffected — an empty IP list passes through to be cached normally.

Note: `0.0.0.0` is intentionally **not** filtered from `ip_list_of_message` to preserve compatibility with Pi-hole/null-routing setups that deliberately return `0.0.0.0` for blocked domains.

### Type

- [x] Bug fix

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed