### PR TITLE
config: tolerate multiple YAML shapes for reality.short-id

### DIFF
--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -1,5 +1,5 @@
 use crate::{Error, common::utils::default_bool_true, config::utils};
-use serde::{Deserialize, de::value::MapDeserializer};
+use serde::{de::value::MapDeserializer, Deserialize, Deserializer};
 use serde_yaml::Value;
 #[cfg(feature = "shadowquic")]
 use shadowquic::config::CongestionControl as SQCongestionControl;
@@ -240,10 +240,70 @@ pub struct GrpcOpt {
     pub grpc_service_name: Option<String>,
 }
 
+fn deserialize_short_id<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ShortIdVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ShortIdVisitor {
+        type Value = String;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "a hex string, null, or an empty sequence for reality short-id"
+            )
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(v.to_owned())
+        }
+
+        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(v)
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(String::new())
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(String::new())
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            if let Some(first) = seq.next_element::<String>()? {
+                Ok(first)
+            } else {
+                Ok(String::new())
+            }
+        }
+    }
+
+    deserializer.deserialize_any(ShortIdVisitor)
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct RealityOpt {
     pub public_key: String,
+    #[serde(deserialize_with = "deserialize_short_id", default)]
     pub short_id: String,
 }
 

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -986,3 +986,203 @@ mod anytls_tests {
         assert_eq!(config.min_idle_session, Some(2));
     }
 }
+
+#[cfg(test)]
+mod short_id_tests {
+    #[derive(serde::Deserialize, Debug)]
+    struct ShortIdWrapper {
+        #[serde(deserialize_with = "super::deserialize_short_id", default)]
+        short_id: String,
+    }
+
+    #[test]
+    fn deserialize_short_id_plain_string() {
+        let yaml = "short_id: abc123";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "abc123");
+    }
+
+    #[test]
+    fn deserialize_short_id_null() {
+        let yaml = "short_id: null";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_tilde_unit() {
+        let yaml = "short_id: ~";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_empty_string() {
+        let yaml = "short_id: \"\"";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_hex_string() {
+        let yaml = "short_id: 0123456789abcdef";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "0123456789abcdef");
+    }
+
+    #[test]
+    fn deserialize_short_id_empty_seq() {
+        let yaml = "short_id: []";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_single_value_seq() {
+        let yaml = "short_id: [\"abc\"]";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "abc");
+    }
+
+    #[test]
+    fn deserialize_short_id_single_empty_string_seq() {
+        let yaml = "short_id: [\"\"]";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_multi_value_seq_rejected() {
+        let yaml = "short_id: [\"a\", \"b\"]";
+        let err = serde_yaml::from_str::<ShortIdWrapper>(yaml)
+            .expect_err("should reject multi-value sequence");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reality short-id expects a single value"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn deserialize_short_id_triple_seq_rejected() {
+        let yaml = "short_id: [\"a\", \"b\", \"c\"]";
+        let err = serde_yaml::from_str::<ShortIdWrapper>(yaml)
+            .expect_err("should reject triple-value sequence");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reality short-id expects a single value"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn deserialize_short_id_missing_field() {
+        let yaml = "other: value";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    // --- Integration tests: RealityOpt within OutboundVless ---
+
+    #[test]
+    fn vless_reality_opts_with_short_id_string() {
+        let yaml = r#"
+  type: vless
+  name: test
+  server: example.com
+  port: 443
+  uuid: test-uuid
+  reality-opts:
+    public-key: abc123
+    short-id: deadbeef
+"#;
+        let v: super::OutboundVless = serde_yaml::from_str(yaml).unwrap();
+        let reality = v.reality_opts.expect("reality_opts should be Some");
+        assert_eq!(reality.public_key, "abc123");
+        assert_eq!(reality.short_id, "deadbeef");
+    }
+
+    #[test]
+    fn vless_reality_opts_with_null_short_id() {
+        let yaml = r#"
+  type: vless
+  name: test
+  server: example.com
+  port: 443
+  uuid: test-uuid
+  reality-opts:
+    public-key: abc123
+    short-id: null
+"#;
+        let v: super::OutboundVless = serde_yaml::from_str(yaml).unwrap();
+        let reality = v.reality_opts.expect("reality_opts should be Some");
+        assert_eq!(reality.short_id, "");
+    }
+
+    #[test]
+    fn vless_reality_opts_with_seq_short_id() {
+        let yaml = r#"
+  type: vless
+  name: test
+  server: example.com
+  port: 443
+  uuid: test-uuid
+  reality-opts:
+    public-key: abc123
+    short-id: ["ff"]
+"#;
+        let v: super::OutboundVless = serde_yaml::from_str(yaml).unwrap();
+        let reality = v.reality_opts.expect("reality_opts should be Some");
+        assert_eq!(reality.short_id, "ff");
+    }
+
+    #[test]
+    fn vless_reality_opts_without_short_id() {
+        let yaml = r#"
+  type: vless
+  name: test
+  server: example.com
+  port: 443
+  uuid: test-uuid
+  reality-opts:
+    public-key: abc123
+"#;
+        let v: super::OutboundVless = serde_yaml::from_str(yaml).unwrap();
+        let reality = v.reality_opts.expect("reality_opts should be Some");
+        assert_eq!(reality.short_id, "");
+    }
+
+    #[test]
+    fn vless_without_reality_opts() {
+        let yaml = r#"
+  type: vless
+  name: test
+  server: example.com
+  port: 443
+  uuid: test-uuid
+"#;
+        let v: super::OutboundVless = serde_yaml::from_str(yaml).unwrap();
+        assert!(v.reality_opts.is_none());
+    }
+
+    #[test]
+    fn vless_reality_opts_multi_seq_rejected() {
+        let yaml = r#"
+  type: vless
+  name: test
+  server: example.com
+  port: 443
+  uuid: test-uuid
+  reality-opts:
+    public-key: abc123
+    short-id: ["a", "b"]
+"#;
+        let err = serde_yaml::from_str::<super::OutboundVless>(yaml)
+            .expect_err("should reject multi-value short-id sequence");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reality short-id expects a single value"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -5,7 +5,7 @@ use serde_yaml::Value;
 use shadowquic::config::CongestionControl as SQCongestionControl;
 use std::{
     collections::HashMap,
-    fmt::{Display, Formatter},
+    fmt::{self, Display, Formatter},
 };
 use uuid::Uuid;
 

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -1,5 +1,5 @@
 use crate::{Error, common::utils::default_bool_true, config::utils};
-use serde::{de::value::MapDeserializer, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de::value::MapDeserializer};
 use serde_yaml::Value;
 #[cfg(feature = "shadowquic")]
 use shadowquic::config::CongestionControl as SQCongestionControl;
@@ -289,6 +289,11 @@ where
             A: serde::de::SeqAccess<'de>,
         {
             if let Some(first) = seq.next_element::<String>()? {
+                if seq.next_element::<String>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "reality short-id expects a single value, got a sequence",
+                    ));
+                }
                 Ok(first)
             } else {
                 Ok(String::new())


### PR DESCRIPTION
Make reality.short-id deserialization accept string / null / empty sequence / missing and normalize to empty string.

## Problem
Config parser currently expects `reality.short-id` to be a string. If users write `short-id:` (empty key) or an empty YAML sequence, serde errors with "invalid type: sequence, expected a string".

## Fix
Add a custom serde deserializer that accepts string / null / unit / empty sequence and normalizes empty cases to `""` (empty string). Existing non-empty short-id behavior unchanged.

## Rationale
Improves UX and tolerates common YAML styles; downstream `hex::decode("")` already returns empty `Vec<u8>`, so behavior is consistent.

## Changes
- `clash-lib/src/config/internal/proxy.rs`: added `deserialize_short_id` custom deserializer and annotated `RealityOpt.short_id` with `#[serde(deserialize_with = "deserialize_short_id", default)]`

## Testing
- `clash-lib` crate compiles successfully with the change
- Existing tests for short-id-too-long still apply
- Full test suite could not be run due to upstream dependency issues (forked rustls/boringtun API incompatibilities), unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing for the reality short-id setting: accepts plain strings, treats null or an empty sequence as an empty value, accepts single-item sequences as the value, and rejects multi-item sequences. Missing or default entries are now normalized to an empty value for consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->