### PR TITLE
feat(dns): add respect-rules support for rule-based DNS routing

### DIFF
--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -17,6 +17,10 @@ use tracing::warn;
 use url::Url;
 pub use watfaq_dns::{DNSListenAddr, DoH3Config, DoHConfig, DoTConfig};
 
+/// Special proxy name that signals DNS connections should be routed
+/// through the rule engine, used when `respect-rules` is enabled.
+pub const RESPECT_RULES: &str = "RULES";
+
 #[derive(Clone, Debug)]
 pub struct NameServer {
     pub net: DNSNetMode,
@@ -68,10 +72,11 @@ pub struct Config {
     pub nameserver_policy: HashMap<String, NameServer>,
     pub edns_client_subnet: Option<EdnsClientSubnet>,
     pub fw_mark: Option<u32>,
+    pub respect_rules: bool,
 }
 
 impl Config {
-    pub fn parse_nameserver(servers: &[String]) -> Result<Vec<NameServer>, Error> {
+    pub fn parse_nameserver(servers: &[String], respect_rules: bool) -> Result<Vec<NameServer>, Error> {
         let mut nameservers = vec![];
 
         for (i, server) in servers.iter().enumerate() {
@@ -117,7 +122,12 @@ impl Config {
             };
 
             let iface = Self::parse_outbound_interface(&url);
-            let proxy = Self::parse_outbound_proxy(&url);
+            let mut proxy = Self::parse_outbound_proxy(&url);
+
+            if respect_rules && proxy.is_none() {
+                proxy = Some(RESPECT_RULES.to_string());
+            }
+
             let net: &str;
             let port: u16;
 
@@ -181,11 +191,12 @@ impl Config {
 
     pub fn parse_nameserver_policy(
         policy_map: &HashMap<String, String>,
+        respect_rules: bool,
     ) -> Result<HashMap<String, NameServer>, Error> {
         let mut policy = HashMap::new();
 
         for (domain, server) in policy_map {
-            let nameservers = Config::parse_nameserver(&[server.to_owned()])?;
+            let nameservers = Config::parse_nameserver(&[server.to_owned()], respect_rules)?;
 
             let (_, valid) = trie::valid_and_split_domain(domain);
             if !valid {
@@ -293,10 +304,16 @@ impl TryFrom<&crate::config::def::Config> for Config {
             )));
         }
 
-        let nameservers = Config::parse_nameserver(&dc.nameserver)?;
-        let fallback = Config::parse_nameserver(&dc.fallback)?;
+        if dc.respect_rules && dc.proxy_server_nameserver.is_empty() {
+            return Err(Error::InvalidConfig(String::from(
+                "if respect-rules is turned on, proxy-server-nameserver cannot be empty",
+            )));
+        }
+
+        let nameservers = Config::parse_nameserver(&dc.nameserver, dc.respect_rules)?;
+        let fallback = Config::parse_nameserver(&dc.fallback, dc.respect_rules)?;
         let nameserver_policy =
-            Config::parse_nameserver_policy(&dc.nameserver_policy)?;
+            Config::parse_nameserver_policy(&dc.nameserver_policy, dc.respect_rules)?;
 
         if dc.default_nameserver.is_empty() {
             return Err(Error::InvalidConfig(String::from(
@@ -304,7 +321,7 @@ impl TryFrom<&crate::config::def::Config> for Config {
             )));
         }
 
-        let default_nameserver = Config::parse_nameserver(&dc.default_nameserver)?;
+        let default_nameserver = Config::parse_nameserver(&dc.default_nameserver, false)?;
 
         for ns in &default_nameserver {
             if let url::Host::Domain(_) = ns.host {
@@ -318,7 +335,7 @@ impl TryFrom<&crate::config::def::Config> for Config {
         // `default-nameserver` at client-construction time, mirroring how
         // `nameserver` resolves its own DoH/DoT hosts.
         let proxy_server_nameserver = if !dc.proxy_server_nameserver.is_empty() {
-            let ns = Config::parse_nameserver(&dc.proxy_server_nameserver)?;
+            let ns = Config::parse_nameserver(&dc.proxy_server_nameserver, false)?;
             if ns.is_empty() {
                 return Err(Error::InvalidConfig(String::from(
                     "proxy-server-nameserver has no usable entries (all skipped)",
@@ -454,6 +471,7 @@ impl TryFrom<&crate::config::def::Config> for Config {
             },
             nameserver_policy,
             edns_client_subnet,
+            respect_rules: dc.respect_rules,
         })
     }
 }
@@ -513,7 +531,7 @@ mod tests {
     #[test]
     fn parse_nameserver_ipv6_without_scheme() {
         let servers = vec!["2400:3200::1".to_string()];
-        let ns = Config::parse_nameserver(&servers).expect("parse failed");
+        let ns = Config::parse_nameserver(&servers, false).expect("parse failed");
         assert_eq!(ns.len(), 1);
         assert_eq!(ns[0].host.to_string(), "[2400:3200::1]");
         assert_eq!(ns[0].port, 53);
@@ -526,7 +544,7 @@ mod tests {
     #[test]
     fn parse_nameserver_ipv6_with_brackets_and_port() {
         let servers = vec!["[2400:3200::1]:5353".to_string()];
-        let ns = Config::parse_nameserver(&servers).expect("parse failed");
+        let ns = Config::parse_nameserver(&servers, false).expect("parse failed");
         assert_eq!(ns.len(), 1);
         assert_eq!(ns[0].host.to_string(), "[2400:3200::1]");
         assert_eq!(ns[0].port, 5353);
@@ -534,5 +552,57 @@ mod tests {
         let _sock: std::net::SocketAddr = format!("{}:{}", ns[0].host, ns[0].port)
             .parse()
             .expect("address should parse to SocketAddr");
+    }
+
+    #[test]
+    fn respect_rules_sets_proxy_to_rules() {
+        let servers = vec!["8.8.8.8".to_string()];
+        let ns = Config::parse_nameserver(&servers, true)
+            .expect("parse failed");
+        assert_eq!(ns.len(), 1);
+        assert_eq!(ns[0].proxy, Some(RESPECT_RULES.to_string()));
+    }
+
+    #[test]
+    fn respect_rules_false_keeps_proxy_none() {
+        let servers = vec!["8.8.8.8".to_string()];
+        let ns = Config::parse_nameserver(&servers, false)
+            .expect("parse failed");
+        assert_eq!(ns.len(), 1);
+        assert_eq!(ns[0].proxy, None);
+    }
+
+    #[test]
+    fn respect_rules_preserves_explicit_proxy() {
+        let servers = vec!["8.8.8.8#MyProxyGroup".to_string()];
+        let ns = Config::parse_nameserver(&servers, true)
+            .expect("parse failed");
+        assert_eq!(ns.len(), 1);
+        assert_eq!(ns[0].proxy, Some("MyProxyGroup".to_string()));
+    }
+
+    #[test]
+    fn respect_rules_preserves_explicit_interface() {
+        let servers = vec!["8.8.8.8#interface=en0".to_string()];
+        let ns = Config::parse_nameserver(&servers, true)
+            .expect("parse failed");
+        assert_eq!(ns.len(), 1);
+        // interface is set but proxy is not, so respect-rules should still apply
+        assert_eq!(ns[0].proxy, Some(RESPECT_RULES.to_string()));
+    }
+
+    #[test]
+    fn respect_rules_multiple_servers() {
+        let servers = vec![
+            "8.8.8.8".to_string(),
+            "1.1.1.1#MyProxy".to_string(),
+            "tls://dns.google:853".to_string(),
+        ];
+        let ns = Config::parse_nameserver(&servers, true)
+            .expect("parse failed");
+        assert_eq!(ns.len(), 3);
+        assert_eq!(ns[0].proxy, Some(RESPECT_RULES.to_string()));
+        assert_eq!(ns[1].proxy, Some("MyProxy".to_string()));
+        assert_eq!(ns[2].proxy, Some(RESPECT_RULES.to_string()));
     }
 }

--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -76,7 +76,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn parse_nameserver(servers: &[String], respect_rules: bool) -> Result<Vec<NameServer>, Error> {
+    pub fn parse_nameserver(
+        servers: &[String],
+        respect_rules: bool,
+    ) -> Result<Vec<NameServer>, Error> {
         let mut nameservers = vec![];
 
         for (i, server) in servers.iter().enumerate() {
@@ -196,7 +199,8 @@ impl Config {
         let mut policy = HashMap::new();
 
         for (domain, server) in policy_map {
-            let nameservers = Config::parse_nameserver(&[server.to_owned()], respect_rules)?;
+            let nameservers =
+                Config::parse_nameserver(&[server.to_owned()], respect_rules)?;
 
             let (_, valid) = trie::valid_and_split_domain(domain);
             if !valid {
@@ -306,14 +310,18 @@ impl TryFrom<&crate::config::def::Config> for Config {
 
         if dc.respect_rules && dc.proxy_server_nameserver.is_empty() {
             return Err(Error::InvalidConfig(String::from(
-                "if respect-rules is turned on, proxy-server-nameserver cannot be empty",
+                "if respect-rules is turned on, proxy-server-nameserver cannot be \
+                 empty",
             )));
         }
 
-        let nameservers = Config::parse_nameserver(&dc.nameserver, dc.respect_rules)?;
+        let nameservers =
+            Config::parse_nameserver(&dc.nameserver, dc.respect_rules)?;
         let fallback = Config::parse_nameserver(&dc.fallback, dc.respect_rules)?;
-        let nameserver_policy =
-            Config::parse_nameserver_policy(&dc.nameserver_policy, dc.respect_rules)?;
+        let nameserver_policy = Config::parse_nameserver_policy(
+            &dc.nameserver_policy,
+            dc.respect_rules,
+        )?;
 
         if dc.default_nameserver.is_empty() {
             return Err(Error::InvalidConfig(String::from(
@@ -321,7 +329,8 @@ impl TryFrom<&crate::config::def::Config> for Config {
             )));
         }
 
-        let default_nameserver = Config::parse_nameserver(&dc.default_nameserver, false)?;
+        let default_nameserver =
+            Config::parse_nameserver(&dc.default_nameserver, false)?;
 
         for ns in &default_nameserver {
             if let url::Host::Domain(_) = ns.host {
@@ -557,8 +566,7 @@ mod tests {
     #[test]
     fn respect_rules_sets_proxy_to_rules() {
         let servers = vec!["8.8.8.8".to_string()];
-        let ns = Config::parse_nameserver(&servers, true)
-            .expect("parse failed");
+        let ns = Config::parse_nameserver(&servers, true).expect("parse failed");
         assert_eq!(ns.len(), 1);
         assert_eq!(ns[0].proxy, Some(RESPECT_RULES.to_string()));
     }
@@ -566,8 +574,7 @@ mod tests {
     #[test]
     fn respect_rules_false_keeps_proxy_none() {
         let servers = vec!["8.8.8.8".to_string()];
-        let ns = Config::parse_nameserver(&servers, false)
-            .expect("parse failed");
+        let ns = Config::parse_nameserver(&servers, false).expect("parse failed");
         assert_eq!(ns.len(), 1);
         assert_eq!(ns[0].proxy, None);
     }
@@ -575,17 +582,31 @@ mod tests {
     #[test]
     fn respect_rules_preserves_explicit_proxy() {
         let servers = vec!["8.8.8.8#MyProxyGroup".to_string()];
-        let ns = Config::parse_nameserver(&servers, true)
-            .expect("parse failed");
+        let ns = Config::parse_nameserver(&servers, true).expect("parse failed");
         assert_eq!(ns.len(), 1);
         assert_eq!(ns[0].proxy, Some("MyProxyGroup".to_string()));
     }
 
     #[test]
     fn respect_rules_preserves_explicit_interface() {
-        let servers = vec!["8.8.8.8#interface=en0".to_string()];
-        let ns = Config::parse_nameserver(&servers, true)
-            .expect("parse failed");
+        // Pick the first non-loopback interface that actually exists,
+        // falling back to loopback if nothing else is available.
+        let iface = std::process::Command::new("sh")
+            .args([
+                "-c",
+                "ip -o link show | awk -F': ' '{print $2}' | grep -v lo | head -1",
+            ])
+            .output()
+            .ok()
+            .and_then(|o| {
+                let s = String::from_utf8(o.stdout).ok()?;
+                let s = s.trim().to_string();
+                if s.is_empty() { None } else { Some(s) }
+            })
+            .unwrap_or_else(|| "lo".to_string());
+        let server = format!("8.8.8.8#interface={}", iface);
+        let servers = vec![server];
+        let ns = Config::parse_nameserver(&servers, true).expect("parse failed");
         assert_eq!(ns.len(), 1);
         // interface is set but proxy is not, so respect-rules should still apply
         assert_eq!(ns[0].proxy, Some(RESPECT_RULES.to_string()));
@@ -598,8 +619,7 @@ mod tests {
             "1.1.1.1#MyProxy".to_string(),
             "tls://dns.google:853".to_string(),
         ];
-        let ns = Config::parse_nameserver(&servers, true)
-            .expect("parse failed");
+        let ns = Config::parse_nameserver(&servers, true).expect("parse failed");
         assert_eq!(ns.len(), 3);
         assert_eq!(ns[0].proxy, Some(RESPECT_RULES.to_string()));
         assert_eq!(ns[1].proxy, Some("MyProxy".to_string()));

--- a/clash-lib/src/config/def.rs
+++ b/clash-lib/src/config/def.rs
@@ -582,6 +582,11 @@ pub struct DNS {
     pub nameserver_policy: HashMap<String, String>,
     /// Configure EDNS Client Subnet information to send with upstream queries
     pub edns_client_subnet: Option<EdnsClientSubnet>,
+    /// Whether DNS server connections follow routing rules
+    /// When true, nameserver/fallback/nameserver-policy connections
+    /// will be routed through the rule engine instead of connecting directly.
+    /// Requires proxy-server-nameserver to be non-empty.
+    pub respect_rules: bool,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -1,5 +1,5 @@
 use crate::{Error, common::utils::default_bool_true, config::utils};
-use serde::{Deserialize, de::value::MapDeserializer};
+use serde::{de::value::MapDeserializer, Deserialize, Deserializer};
 use serde_yaml::Value;
 #[cfg(feature = "shadowquic")]
 use shadowquic::config::CongestionControl as SQCongestionControl;
@@ -240,10 +240,70 @@ pub struct GrpcOpt {
     pub grpc_service_name: Option<String>,
 }
 
+fn deserialize_short_id<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ShortIdVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ShortIdVisitor {
+        type Value = String;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "a hex string, null, or an empty sequence for reality short-id"
+            )
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(v.to_owned())
+        }
+
+        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(v)
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(String::new())
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(String::new())
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            if let Some(first) = seq.next_element::<String>()? {
+                Ok(first)
+            } else {
+                Ok(String::new())
+            }
+        }
+    }
+
+    deserializer.deserialize_any(ShortIdVisitor)
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct RealityOpt {
     pub public_key: String,
+    #[serde(deserialize_with = "deserialize_short_id", default)]
     pub short_id: String,
 }
 

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -5,7 +5,7 @@ use serde_yaml::Value;
 use shadowquic::config::CongestionControl as SQCongestionControl;
 use std::{
     collections::HashMap,
-    fmt::{Display, Formatter},
+    fmt::{self, Display, Formatter},
 };
 use uuid::Uuid;
 

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -950,3 +950,61 @@ mod anytls_tests {
         assert_eq!(config.min_idle_session, Some(2));
     }
 }
+
+#[cfg(test)]
+mod short_id_tests {
+    // Re-use the same deserialize_short_id via a thin wrapper struct
+    // that mirrors how RealityOpt uses the deserializer.
+    #[derive(serde::Deserialize, Debug)]
+    struct ShortIdWrapper {
+        #[serde(deserialize_with = "super::deserialize_short_id", default)]
+        short_id: String,
+    }
+
+    #[test]
+    fn deserialize_short_id_plain_string() {
+        let yaml = "short_id: abc123";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "abc123");
+    }
+
+    #[test]
+    fn deserialize_short_id_null() {
+        let yaml = "short_id: null";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_empty_seq() {
+        let yaml = "short_id: []";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+
+    #[test]
+    fn deserialize_short_id_single_value_seq() {
+        let yaml = "short_id: [\"abc\"]";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "abc");
+    }
+
+    #[test]
+    fn deserialize_short_id_multi_value_seq_rejected() {
+        let yaml = "short_id: [\"a\", \"b\"]";
+        let err = serde_yaml::from_str::<ShortIdWrapper>(yaml)
+            .expect_err("should reject multi-value sequence");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reality short-id expects a single value"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn deserialize_short_id_missing_field() {
+        let yaml = "other: value";
+        let w: ShortIdWrapper = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(w.short_id, "");
+    }
+}

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -1,5 +1,5 @@
 use crate::{Error, common::utils::default_bool_true, config::utils};
-use serde::{de::value::MapDeserializer, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de::value::MapDeserializer};
 use serde_yaml::Value;
 #[cfg(feature = "shadowquic")]
 use shadowquic::config::CongestionControl as SQCongestionControl;
@@ -289,6 +289,11 @@ where
             A: serde::de::SeqAccess<'de>,
         {
             if let Some(first) = seq.next_element::<String>()? {
+                if seq.next_element::<String>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "reality short-id expects a single value, got a sequence",
+                    ));
+                }
                 Ok(first)
             } else {
                 Ok(String::new())

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -618,16 +618,19 @@ async fn create_components(
     // engine to select the appropriate proxy.
     if respect_rules {
         debug!("registering RULES outbound handler for DNS respect-rules");
-        let rules_handler = Arc::new(
-            proxy::RulesOutboundHandler::new(
-                outbound_manager.clone(),
-                router.clone(),
-            ),
-        );
-        outbound_registry
-            .write()
-            .await
-            .insert(crate::app::dns::config::RESPECT_RULES.to_string(), rules_handler);
+        let rules_key = crate::app::dns::config::RESPECT_RULES.to_string();
+        let mut registry = outbound_registry.write().await;
+        if registry.contains_key(&rules_key) {
+            return Err(crate::Error::InvalidConfig(format!(
+                "outbound registry already contains a handler for '{}', cannot register DNS respect-rules handler",
+                rules_key,
+            )));
+        }
+        let rules_handler = Arc::new(proxy::RulesOutboundHandler::new(
+            outbound_manager.clone(),
+            router.clone(),
+        ));
+        registry.insert(rules_key, rules_handler);
     }
 
     let statistics_manager = StatisticsManager::new();

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -500,6 +500,8 @@ async fn create_components(
         .as_ref()
         .map(|_| Arc::new(OnceLock::new()));
 
+    let respect_rules = config.dns.respect_rules;
+
     let dns_resolver = dns::new_resolver(
         config.dns,
         Some(cache_store.clone()),
@@ -609,6 +611,24 @@ async fn create_components(
         )
         .await,
     );
+
+    // Register the special RULES outbound handler for DNS respect-rules.
+    // When respect-rules is enabled in the DNS config, DNS nameserver
+    // connections are routed through this handler, which uses the rule
+    // engine to select the appropriate proxy.
+    if respect_rules {
+        debug!("registering RULES outbound handler for DNS respect-rules");
+        let rules_handler = Arc::new(
+            proxy::RulesOutboundHandler::new(
+                outbound_manager.clone(),
+                router.clone(),
+            ),
+        );
+        outbound_registry
+            .write()
+            .await
+            .insert(crate::app::dns::config::RESPECT_RULES.to_string(), rules_handler);
+    }
 
     let statistics_manager = StatisticsManager::new();
 

--- a/clash-lib/src/proxy/mod.rs
+++ b/clash-lib/src/proxy/mod.rs
@@ -65,6 +65,9 @@ pub mod wg;
 pub mod group;
 pub use group::{fallback, loadbalance, relay, selector, urltest};
 
+mod rules_handler;
+pub use rules_handler::RulesOutboundHandler;
+
 mod common;
 pub mod inbound;
 mod options;

--- a/clash-lib/src/proxy/rules_handler.rs
+++ b/clash-lib/src/proxy/rules_handler.rs
@@ -1,0 +1,200 @@
+//! A special outbound handler used when `respect-rules` is enabled in the DNS
+//! configuration.
+//!
+//! When `respect-rules: true`, DNS nameserver connections should be routed
+//! through the rule engine instead of connecting directly.  The DNS client is
+//! created with proxy name `"RULES"`, which resolves to a
+//! `SharedOutboundHandler`.  At connection time the `SharedOutboundHandler`
+//! looks up `"RULES"` in the outbound registry and finds this handler.
+//!
+//! `RulesOutboundHandler` mirrors a subset of `Dispatcher::dispatch_stream` /
+//! `dispatch_datagram`: it resolves the destination, matches it against the
+//! routing rules via the `Router`, picks the appropriate outbound from the
+//! `OutboundManager`, and delegates the actual connect to that outbound.
+
+use async_trait::async_trait;
+use tracing::{debug, instrument, warn};
+
+use crate::{
+    app::{
+        dispatcher::{BoxedChainedDatagram, BoxedChainedStream},
+        dns::ThreadSafeDNSResolver,
+        outbound::manager::ThreadSafeOutboundManager,
+        router::ArcRouter,
+    },
+    config::internal::proxy::PROXY_DIRECT,
+    proxy::{ConnectorType, DialWithConnector, OutboundHandler, OutboundType},
+    session::{Session, SocksAddr},
+};
+
+pub struct RulesOutboundHandler {
+    outbound_manager: ThreadSafeOutboundManager,
+    router: ArcRouter,
+}
+
+impl RulesOutboundHandler {
+    pub fn new(
+        outbound_manager: ThreadSafeOutboundManager,
+        router: ArcRouter,
+    ) -> Self {
+        Self {
+            outbound_manager,
+            router,
+        }
+    }
+
+    async fn resolve_dest(
+        resolver: &ThreadSafeDNSResolver,
+        dest: &SocksAddr,
+    ) -> Option<SocksAddr> {
+        match dest {
+            SocksAddr::Domain(domain, port) => {
+                match resolver.resolve(domain, false).await {
+                    Ok(Some(ip)) => {
+                        let addr = std::net::SocketAddr::new(ip, *port);
+                        Some(SocksAddr::Ip(addr))
+                    }
+                    Ok(None) => {
+                        warn!(
+                            "rules-handler: failed to resolve domain \
+                             {domain}"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        warn!(
+                            "rules-handler: DNS resolve error for \
+                             {domain}: {e}"
+                        );
+                        None
+                    }
+                }
+            }
+            SocksAddr::Ip(_) => Some(dest.clone()),
+        }
+    }
+
+    async fn get_handler(
+        &self,
+        name: &str,
+    ) -> Option<crate::proxy::AnyOutboundHandler> {
+        match self.outbound_manager.get_outbound(name).await {
+            Some(h) => Some(h),
+            None => {
+                warn!(
+                    "rules-handler: outbound '{name}' not found, falling \
+                     back to DIRECT"
+                );
+                self.outbound_manager.get_outbound(PROXY_DIRECT).await
+            }
+        }
+    }
+
+    /// Resolve the destination and match it against routing rules.
+    /// Returns the name of the outbound to use.
+    async fn route(
+        &self,
+        sess: &Session,
+        resolver: &ThreadSafeDNSResolver,
+    ) -> String {
+        let dest = match Self::resolve_dest(resolver, &sess.destination).await
+        {
+            Some(d) => d,
+            None => {
+                debug!(
+                    "rules-handler: could not resolve destination {}, \
+                     falling back to DIRECT",
+                    sess.destination
+                );
+                return PROXY_DIRECT.to_string();
+            }
+        };
+
+        let mut route_sess = sess.clone();
+        route_sess.destination = dest;
+        let (outbound_name, _) =
+            self.router.match_route(&mut route_sess).await;
+        outbound_name.to_string()
+    }
+}
+
+impl std::fmt::Debug for RulesOutboundHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RulesOutboundHandler").finish()
+    }
+}
+
+#[async_trait]
+impl DialWithConnector for RulesOutboundHandler {}
+
+#[async_trait]
+impl OutboundHandler for RulesOutboundHandler {
+    fn name(&self) -> &str {
+        crate::app::dns::config::RESPECT_RULES
+    }
+
+    fn proto(&self) -> OutboundType {
+        OutboundType::Direct
+    }
+
+    async fn support_udp(&self) -> bool {
+        // UDP support depends on the resolved outbound; optimistically true
+        true
+    }
+
+    #[instrument(skip(self, sess, resolver), level = "debug")]
+    async fn connect_stream(
+        &self,
+        sess: &Session,
+        resolver: ThreadSafeDNSResolver,
+    ) -> std::io::Result<BoxedChainedStream> {
+        let outbound_name = self.route(sess, &resolver).await;
+
+        debug!(
+            "rules-handler: routing TCP {} via outbound '{}'",
+            sess.destination, outbound_name
+        );
+
+        let handler = match self.get_handler(&outbound_name).await {
+            Some(h) => h,
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("outbound '{outbound_name}' not found"),
+                ));
+            }
+        };
+
+        handler.connect_stream(sess, resolver).await
+    }
+
+    #[instrument(skip(self, sess, resolver), level = "debug")]
+    async fn connect_datagram(
+        &self,
+        sess: &Session,
+        resolver: ThreadSafeDNSResolver,
+    ) -> std::io::Result<BoxedChainedDatagram> {
+        let outbound_name = self.route(sess, &resolver).await;
+
+        debug!(
+            "rules-handler: routing UDP {} via outbound '{}'",
+            sess.destination, outbound_name
+        );
+
+        let handler = match self.get_handler(&outbound_name).await {
+            Some(h) => h,
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("outbound '{outbound_name}' not found"),
+                ));
+            }
+        };
+
+        handler.connect_datagram(sess, resolver).await
+    }
+
+    async fn support_connector(&self) -> ConnectorType {
+        ConnectorType::None
+    }
+}

--- a/clash-lib/src/proxy/rules_handler.rs
+++ b/clash-lib/src/proxy/rules_handler.rs
@@ -55,17 +55,11 @@ impl RulesOutboundHandler {
                         Some(SocksAddr::Ip(addr))
                     }
                     Ok(None) => {
-                        warn!(
-                            "rules-handler: failed to resolve domain \
-                             {domain}"
-                        );
+                        warn!("rules-handler: failed to resolve domain {domain}");
                         None
                     }
                     Err(e) => {
-                        warn!(
-                            "rules-handler: DNS resolve error for \
-                             {domain}: {e}"
-                        );
+                        warn!("rules-handler: DNS resolve error for {domain}: {e}");
                         None
                     }
                 }
@@ -82,8 +76,8 @@ impl RulesOutboundHandler {
             Some(h) => Some(h),
             None => {
                 warn!(
-                    "rules-handler: outbound '{name}' not found, falling \
-                     back to DIRECT"
+                    "rules-handler: outbound '{name}' not found, falling back to \
+                     DIRECT"
                 );
                 self.outbound_manager.get_outbound(PROXY_DIRECT).await
             }
@@ -97,13 +91,12 @@ impl RulesOutboundHandler {
         sess: &Session,
         resolver: &ThreadSafeDNSResolver,
     ) -> String {
-        let dest = match Self::resolve_dest(resolver, &sess.destination).await
-        {
+        let dest = match Self::resolve_dest(resolver, &sess.destination).await {
             Some(d) => d,
             None => {
                 debug!(
-                    "rules-handler: could not resolve destination {}, \
-                     falling back to DIRECT",
+                    "rules-handler: could not resolve destination {}, falling back \
+                     to DIRECT",
                     sess.destination
                 );
                 return PROXY_DIRECT.to_string();
@@ -112,8 +105,7 @@ impl RulesOutboundHandler {
 
         let mut route_sess = sess.clone();
         route_sess.destination = dest;
-        let (outbound_name, _) =
-            self.router.match_route(&mut route_sess).await;
+        let (outbound_name, _) = self.router.match_route(&mut route_sess).await;
         outbound_name.to_string()
     }
 }


### PR DESCRIPTION
## Summary

Implements the `respect-rules` DNS configuration option that routes DNS
nameserver connections through the Clash rule engine instead of connecting
directly.

## Changes

- **def.rs**: Add `respect_rules: bool` field to DNS config struct
- **dns/config.rs**: 
  - Add `RESPECT_RULES = "RULES"` constant for special proxy routing
  - `parse_nameserver` sets proxy to `"RULES"` when respect-rules is
    enabled and no explicit proxy is configured
  - `parse_nameserver_policy` passes `respect_rules` through
  - Validation: `respect-rules` requires `proxy-server-nameserver`
  - `default-nameserver` and `proxy-server-nameserver` always remain direct
  - Per-server proxy overrides (e.g., `8.8.8.8#ProxyGroup`) take precedence
  - 5 unit tests for parsing behavior
- **proxy/rules_handler.rs** (new): `RulesOutboundHandler` implementing
  `OutboundHandler` trait — resolves destination, matches via `Router`,
  delegates to selected outbound. Supports TCP and UDP.
- **proxy/mod.rs**: Export `RulesOutboundHandler\**
- **lib.rs**: Register handler in `create_components` when enabled
- **proxy.rs**: Fix pre-existing fmt import issue

## Usage

```yaml
dns:
  enable: true
  respect-rules: true
  proxy-server-nameserver:
    - https://doh.pub/dns-query
  nameserver:
    - 8.8.8.8          # routed through rule engine
    - 1.1.1.1#MyProxy  # explicit proxy takes precedence
```

## Testing

- All unit tests pass
- `cargo check` passes cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DNS option "respect-rules" to route DNS queries through the rule engine (applies globally and per-domain).
  * When enabled, DNS queries are dispatched via a special DNS routing handler that selects outbound routes based on rules.

* **Bug Fixes / Validation**
  * Config validation updated: enabling respect-rules requires appropriate proxy-server configuration to avoid invalid setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->