### PR TITLE
refactor(tls): consolidate PEM cert/key loading into common/tls.rs

### DIFF
--- a/clash-lib/src/common/tls.rs
+++ b/clash-lib/src/common/tls.rs
@@ -19,9 +19,10 @@ fn global_root_store() -> Arc<RootCertStore> {
 /// or file paths. A string containing `-----BEGIN` is treated as inline PEM;
 /// otherwise it is interpreted as a file path.
 ///
-/// Returns `(cert_chain, private_key)` for use with rustls client
-/// authentication (mTLS).
-pub fn load_client_cert_and_key(
+/// Returns `(cert_chain, private_key)` suitable for both rustls client auth
+/// (mTLS, via `with_client_auth_cert`) and rustls server config
+/// (`with_single_cert`).
+pub fn load_cert_and_key(
     cert: &str,
     key: &str,
 ) -> std::io::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
@@ -31,7 +32,7 @@ pub fn load_client_cert_and_key(
         std::fs::read_to_string(cert).map_err(|e| {
             std::io::Error::new(
                 e.kind(),
-                format!("failed to read client certificate '{cert}': {e}"),
+                format!("failed to read certificate '{cert}': {e}"),
             )
         })?
     };
@@ -42,7 +43,7 @@ pub fn load_client_cert_and_key(
         std::fs::read_to_string(key).map_err(|e| {
             std::io::Error::new(
                 e.kind(),
-                format!("failed to read client private key '{key}': {e}"),
+                format!("failed to read private key '{key}': {e}"),
             )
         })?
     };
@@ -50,7 +51,7 @@ pub fn load_client_cert_and_key(
     let certs: Vec<CertificateDer<'static>> =
         rustls_pemfile::certs(&mut cert_pem.as_bytes())
             .filter_map(|r| {
-                r.map_err(|e| warn!("failed to parse client certificate entry: {e}"))
+                r.map_err(|e| warn!("failed to parse certificate entry: {e}"))
                     .ok()
             })
             .collect();
@@ -58,7 +59,7 @@ pub fn load_client_cert_and_key(
     if certs.is_empty() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            "no valid certificates found in client certificate PEM",
+            "no valid certificates found in PEM",
         ));
     }
 
@@ -66,13 +67,13 @@ pub fn load_client_cert_and_key(
         .map_err(|e| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                format!("failed to parse client private key: {e}"),
+                format!("failed to parse private key: {e}"),
             )
         })?
         .ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                "no private key found in client private key PEM",
+                "no private key found in PEM",
             )
         })?;
 
@@ -93,7 +94,7 @@ pub fn build_tls_client_config(
 ) -> std::io::Result<rustls::ClientConfig> {
     match (tls_cert, tls_key) {
         (Some(cert), Some(key)) => {
-            let (certs, private_key) = load_client_cert_and_key(cert, key)?;
+            let (certs, private_key) = load_cert_and_key(cert, key)?;
             rustls::ClientConfig::builder()
                 .dangerous()
                 .with_custom_certificate_verifier(verifier)

--- a/clash-lib/src/proxy/anytls/inbound/tls.rs
+++ b/clash-lib/src/proxy/anytls/inbound/tls.rs
@@ -2,7 +2,8 @@
 
 use std::sync::Arc;
 use tokio_rustls::TlsAcceptor;
-use tracing::warn;
+
+use crate::common::tls::load_cert_and_key;
 
 /// Build a TLS acceptor from PEM certificate and private key.
 /// Strings containing `-----BEGIN` are treated as inline PEM; otherwise
@@ -13,61 +14,7 @@ pub(crate) fn build_tls_acceptor(
     private_key: Option<&str>,
 ) -> std::io::Result<TlsAcceptor> {
     let (certs, key) = match (certificate, private_key) {
-        (Some(cert), Some(key)) => {
-            let cert_pem = if cert.contains("-----BEGIN") {
-                cert.to_owned()
-            } else {
-                std::fs::read_to_string(cert).map_err(|e| {
-                    std::io::Error::new(
-                        e.kind(),
-                        format!("failed to read anytls certificate '{cert}': {e}"),
-                    )
-                })?
-            };
-            let key_pem = if key.contains("-----BEGIN") {
-                key.to_owned()
-            } else {
-                std::fs::read_to_string(key).map_err(|e| {
-                    std::io::Error::new(
-                        e.kind(),
-                        format!("failed to read anytls private key '{key}': {e}"),
-                    )
-                })?
-            };
-
-            let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-                rustls_pemfile::certs(&mut cert_pem.as_bytes())
-                    .filter_map(|r| {
-                        r.map_err(|e| {
-                            warn!("failed to parse anytls certificate: {e}")
-                        })
-                        .ok()
-                    })
-                    .collect();
-
-            if certs.is_empty() {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "no valid certificates found in anytls certificate PEM",
-                ));
-            }
-
-            let key = rustls_pemfile::private_key(&mut key_pem.as_bytes())
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!("failed to parse anytls private key: {e}"),
-                    )
-                })?
-                .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "no private key found in anytls private key PEM",
-                    )
-                })?;
-
-            (certs, key)
-        }
+        (Some(cert), Some(key)) => load_cert_and_key(cert, key)?,
         (None, None) => {
             let rcgen::CertifiedKey { cert, signing_key } =
                 rcgen::generate_simple_self_signed(vec!["localhost".to_string()])


### PR DESCRIPTION
Stacked on top of #1424.

## Summary
- `build_tls_acceptor` in `proxy/anytls/inbound/tls.rs` carried a near-duplicate of `load_client_cert_and_key` — same inline-PEM-vs-file-path detection, same `rustls_pemfile` parsing, same empty-cert / missing-key handling.
- Rename `load_client_cert_and_key` → `load_cert_and_key` (it works equally well for `with_single_cert` on the server side) and reuse it from the anytls inbound.
- Drops ~50 duplicated lines.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo test --all-features -p clash-lib --lib anytls` (36 passed, including the existing `build_tls_acceptor` round-trip + ephemeral + mismatched-args + invalid-PEM tests)
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)