### PR TITLE
refactor(tuic): use tuic-core re-exported quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "amplify_num"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bcb75a2982047f733547042fc3968c0f460dfcf7d90b90dea3b2744580e9ad"
+checksum = "afed304556696656d2d71495e1e5f2c4b524a3fb6eb0f2f3778ffc482a40b8a8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -551,9 +551,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -743,6 +743,15 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1372,7 +1381,6 @@ dependencies = [
  "protox",
  "public-suffix",
  "quinn 0.11.9",
- "quinn 0.12.0",
  "quinn-proto 0.11.14",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -1397,7 +1405,7 @@ dependencies = [
  "sock2proc",
  "socket2 0.6.3",
  "ssh-key",
- "sysinfo 0.39.0",
+ "sysinfo 0.39.2",
  "tailscale",
  "tar",
  "tempfile",
@@ -2105,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2139,14 +2147,14 @@ version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
 dependencies = [
- "defmt 1.0.1",
+ "defmt 1.1.0",
 ]
 
 [[package]]
 name = "defmt"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -2154,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -2881,6 +2889,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "rand 0.9.4",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4601,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -5221,9 +5242,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -6122,18 +6143,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6404,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
@@ -6656,6 +6677,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-congestions"
+version = "0.1.0"
+source = "git+https://github.com/proxy-rs/quinn-congestions.git#2bdc356f57a7fc3ae1a49ab963a221f42d61012f"
+dependencies = [
+ "quinn 0.12.0",
+ "quinn-proto 0.12.0",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "quinn-jls"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6702,8 +6733,8 @@ name = "quinn-proto"
 version = "0.12.0"
 source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#ce60e5b5c115db2a6053f4e0ca7fc52103cb76b9"
 dependencies = [
- "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
@@ -6712,6 +6743,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -6955,9 +6987,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -7285,9 +7317,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.60.2"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e358980fe9b079b99da387117864ee6f0a3fd02f39e5b5fde6af9c2895374"
+checksum = "324b92f459d3e42da294e14e8eb150d2215fcfb7c966838bc1127cd68bc05a0d"
 dependencies = [
  "aead 0.6.0-rc.10",
  "aes 0.8.4",
@@ -7368,12 +7400,12 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.59.0"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+checksum = "37cb4d0360bdd8935392a306d8b5edb539cc455b30e8bf13dd213a0cf7879b40"
 dependencies = [
  "log",
- "nix 0.31.2",
+ "nix 0.31.3",
  "ssh-encoding",
  "windows-sys 0.61.2",
 ]
@@ -8882,9 +8914,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "memchr",
@@ -9291,7 +9323,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -9335,7 +9367,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -9344,7 +9376,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -11115,7 +11147,7 @@ dependencies = [
 [[package]]
 name = "tuic-core"
 version = "1.8.1"
-source = "git+https://github.com/Itsusinn/tuic.git?tag=v1.8.1#cc583dc3372783e8ec09ba3707b7c1b9680a8a2e"
+source = "git+https://github.com/Itsusinn/tuic.git?branch=build%2Ftuic#562ea5706d28529e8db74128bb4a23edfe9c0ffa"
 dependencies = [
  "bytes",
  "eyre",
@@ -11123,6 +11155,7 @@ dependencies = [
  "parking_lot",
  "peekable",
  "quinn 0.12.0",
+ "quinn-congestions",
  "register-count",
  "serde",
  "thiserror 2.0.18",
@@ -11150,7 +11183,7 @@ dependencies = [
  "libloading 0.9.0",
  "log",
  "netconfig-rs",
- "nix 0.31.2",
+ "nix 0.31.3",
  "route_manager",
  "scopeguard",
  "tokio",
@@ -12161,9 +12194,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -12352,10 +12385,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 
@@ -12404,9 +12438,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11536,7 +11536,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11147,7 +11147,7 @@ dependencies = [
 [[package]]
 name = "tuic-core"
 version = "1.8.1"
-source = "git+https://github.com/Itsusinn/tuic.git?branch=build%2Ftuic#562ea5706d28529e8db74128bb4a23edfe9c0ffa"
+source = "git+https://github.com/Itsusinn/tuic.git?branch=build%2Ftuic#2e58dae059b9f6e5324e9abc14dbb2b609ff95d4"
 dependencies = [
  "bytes",
  "eyre",

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -16,7 +16,7 @@ aws-lc-rs = [
     "russh/aws-lc-rs",
     "boringtun/aws-lc-rs",
     "hickory-client/https-aws-lc-rs",
-    "tuic-quinn?/rustls-aws-lc-rs",
+
 ]
 ring = [
     "rustls/ring",
@@ -26,12 +26,12 @@ ring = [
     "russh/ring",
     "boringtun/ring",
     "hickory-client/https-ring",
-    "tuic-quinn?/rustls-ring",
+
 ]
 
 # Protos
 shadowsocks = ["dep:shadowsocks", "dep:blake3"]
-tuic = ["dep:tuic-core", "dep:register-count", "dep:tuic-quinn"]
+tuic = ["dep:tuic-core", "dep:register-count"]
 ssh = ["dep:russh", "dep:dirs", "dep:totp-rs"]
 onion = ["dep:arti-client", "dep:tor-rtcompat", "arti-client/onion-service-client"]
 shadowquic = ["dep:shadowquic"]
@@ -184,10 +184,8 @@ tor-rtcompat = { version = "0.42", optional = true, default-features = false, fe
 
 
 # tuic
-tuic-core= { tag = "v1.8.1", optional = true, git = "https://github.com/Itsusinn/tuic.git", features = ["async_marshal", "marshal", "model"] }
+tuic-core= { branch = "build/tuic", optional = true, git = "https://github.com/Itsusinn/tuic.git", features = ["async_marshal", "marshal", "model"] }
 register-count = { version = "0.1", optional = true }
-# tuic-quinn gives tuic-specific quinn fork with rustls support (same fork as tuic-core uses internally)
-tuic-quinn = { package = "quinn", branch = "bbrv3", git = "https://github.com/Tipuch/quinn.git", optional = true, default-features = false, features = ["runtime-tokio"] }
 
 quinn = { version = "0.11", default-features = false, features = ["futures-io", "runtime-tokio", "rustls"] }
 

--- a/clash-lib/src/proxy/converters/tuic.rs
+++ b/clash-lib/src/proxy/converters/tuic.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tuic_quinn::VarInt;
+use tuic_core::quinn::VarInt;
 
 use crate::{
     config::internal::proxy::OutboundTuic,

--- a/clash-lib/src/proxy/tuic/handle_stream.rs
+++ b/clash-lib/src/proxy/tuic/handle_stream.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use bytes::Bytes;
 use register_count::Register;
 use std::sync::{Arc, atomic::Ordering};
-use tuic_core::quinn::{Task, RecvStream, SendStream, VarInt};
+use tuic_core::quinn::{RecvStream, SendStream, Task, VarInt};
 
 impl TuicConnection {
     pub async fn accept_uni_stream(&self) -> anyhow::Result<(RecvStream, Register)> {

--- a/clash-lib/src/proxy/tuic/handle_stream.rs
+++ b/clash-lib/src/proxy/tuic/handle_stream.rs
@@ -4,10 +4,7 @@ use anyhow::anyhow;
 use bytes::Bytes;
 use register_count::Register;
 use std::sync::{Arc, atomic::Ordering};
-use tuic_core::quinn::{
-    Task,
-    quinn::{RecvStream, SendStream, VarInt},
-};
+use tuic_core::quinn::{Task, RecvStream, SendStream, VarInt};
 
 impl TuicConnection {
     pub async fn accept_uni_stream(&self) -> anyhow::Result<(RecvStream, Register)> {

--- a/clash-lib/src/proxy/tuic/handle_task.rs
+++ b/clash-lib/src/proxy/tuic/handle_task.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use std::{sync::Arc, time::Duration};
 use tuic_core::{
     Address,
-    quinn::{Connect, Packet, quinn::ZeroRttAccepted},
+    quinn::{Connect, Packet, ZeroRttAccepted},
 };
 
 use super::types::{TuicConnection, UdpRelayMode};

--- a/clash-lib/src/proxy/tuic/mod.rs
+++ b/clash-lib/src/proxy/tuic/mod.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use tracing::debug;
-use tuic_quinn::{
+use tuic_core::quinn::{
     ClientConfig as QuinnConfig, Endpoint as QuinnEndpoint, EndpointConfig,
     TokioRuntime, TransportConfig as QuinnTransportConfig, VarInt,
     congestion::{Bbr3Config, CubicConfig, NewRenoConfig},

--- a/clash-lib/src/proxy/tuic/types.rs
+++ b/clash-lib/src/proxy/tuic/types.rs
@@ -14,7 +14,8 @@ use std::{
 use tokio::sync::RwLock as AsyncRwLock;
 use tracing::debug;
 use tuic_core::quinn::{
-    Connection as InnerConnection, QuinnConnection, Endpoint as QuinnEndpoint, ZeroRttAccepted,
+    Connection as InnerConnection, Endpoint as QuinnEndpoint, QuinnConnection,
+    ZeroRttAccepted,
 };
 use uuid::Uuid;
 

--- a/clash-lib/src/proxy/tuic/types.rs
+++ b/clash-lib/src/proxy/tuic/types.rs
@@ -14,10 +14,7 @@ use std::{
 use tokio::sync::RwLock as AsyncRwLock;
 use tracing::debug;
 use tuic_core::quinn::{
-    Connection as InnerConnection,
-    quinn::{
-        Connection as QuinnConnection, Endpoint as QuinnEndpoint, ZeroRttAccepted,
-    },
+    Connection as InnerConnection, QuinnConnection, Endpoint as QuinnEndpoint, ZeroRttAccepted,
 };
 use uuid::Uuid;
 


### PR DESCRIPTION
Switch tuic-core dep from tag v1.8.1 to `build/tuic` branch which re-exports quinn internally.

Changes:
- Remove `tuic-quinn` direct quinn dependency
- Replace all `tuic_quinn::` imports with `tuic_core::quinn::`
- Fix nested `tuic_core::quinn::quinn::` paths → `tuic_core::quinn::`

Assisted-by: OpenClaw:deepseek-v4-flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * TUIC core dependency now tracks an active development branch for ongoing improvements.
  * Removed an older TUIC-related dependency and simplified TUIC feature flags.
  * Internal QUIC library integration/imports were consolidated for cleaner maintenance.
  * No user-facing behavior or public APIs were changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->