### PR TITLE
build: upgrade tuic-core to v1.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -55,7 +55,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -82,7 +82,7 @@ checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
 dependencies = [
  "aead 0.6.0-rc.10",
  "aes 0.9.0",
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "ctr 0.10.0",
  "ghash 0.6.0",
  "subtle",
@@ -368,9 +368,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -1083,7 +1083,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad6745f4f269c4d93d7f414eeaaaf16705571a68dee59557f5b80a82e3e76be"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1229,12 +1229,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -1402,7 +1402,7 @@ dependencies = [
  "sock2proc",
  "socket2 0.6.3",
  "ssh-key",
- "sysinfo 0.39.1",
+ "sysinfo 0.39.2",
  "tailscale",
  "tar",
  "tempfile",
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
@@ -1912,7 +1912,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "derive-deftly"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc7a4d4fef137732d8d0d4e58a9e46e168e5b2a7f728c20f87e7cda69a14e9"
+checksum = "219c002a60a3baf5d3fa28db4e1c98733aa2bc784aa63b83c011a72ae9335fb2"
 dependencies = [
  "derive-deftly-macros",
  "heck",
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "derive-deftly-macros"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a93511fd122bc7b22e361806e84f1c31a53894f0564a4ba7f28e799104318c7"
+checksum = "bd5850ec9ad2d9ba0aa33fb22c0b0ef4d91e524566be497ac2a6e40b847e67bb"
 dependencies = [
  "heck",
  "indexmap 2.14.0",
@@ -2257,7 +2257,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "strum",
  "syn 2.0.117",
  "unicode-ident",
@@ -2376,7 +2376,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2613,7 +2613,7 @@ checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct 1.0.0",
  "crypto-bigint 0.7.0-rc.28",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "digest 0.11.3",
  "hkdf 0.13.0",
  "hybrid-array",
@@ -2736,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96a4a12fe60ac746ae295a1a4ecb5bb02debc20856506c8635288065f142de"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]
@@ -2874,6 +2874,19 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "rand 0.9.4",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -4500,7 +4513,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
 ]
 
@@ -5267,9 +5280,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -5670,13 +5683,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix 0.30.1",
+ "nix 0.31.3",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -6335,7 +6348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
  "crypto-bigint 0.7.0-rc.28",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
@@ -6552,11 +6565,22 @@ dependencies = [
  "quinn-proto 0.12.0",
  "quinn-udp 0.6.1",
  "rustc-hash 2.1.2",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
+]
+
+[[package]]
+name = "quinn-congestions"
+version = "0.1.0"
+source = "git+https://github.com/proxy-rs/quinn-congestions.git#2bdc356f57a7fc3ae1a49ab963a221f42d61012f"
+dependencies = [
+ "quinn 0.12.0",
+ "quinn-proto 0.12.0",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -6607,13 +6631,16 @@ version = "0.12.0"
 source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#ce60e5b5c115db2a6053f4e0ca7fc52103cb76b9"
 dependencies = [
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
  "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -7135,9 +7162,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
@@ -7195,7 +7222,7 @@ dependencies = [
  "bytes",
  "cbc 0.1.2",
  "cbc 0.2.0",
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "crypto-bigint 0.7.0-rc.28",
  "ctr 0.10.0",
  "ctr 0.9.2",
@@ -7531,7 +7558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -8113,6 +8140,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "shadowquic"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8470,10 +8508,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.3"
+name = "sponge-cursor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd578e94101503d97e2b286bbf8db2135035ca24b2ce4cbf3f9e2fb2bbf1eee"
 dependencies = [
  "cc",
  "js-sys",
@@ -8752,9 +8796,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.1"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "memchr",
@@ -8828,9 +8872,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -10316,9 +10360,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -10973,7 +11017,8 @@ dependencies = [
 
 [[package]]
 name = "tuic-core"
-version = "1.8.2"
+version = "1.8.4"
+source = "git+https://github.com/Itsusinn/tuic.git?tag=v1.8.4#649c10fe4efd557c5b5cb2cbc555c0e3f9e67298"
 dependencies = [
  "bytes",
  "eyre",
@@ -10981,6 +11026,7 @@ dependencies = [
  "parking_lot",
  "peekable",
  "quinn 0.12.0",
+ "quinn-congestions",
  "register-count",
  "serde",
  "thiserror 2.0.18",
@@ -11161,7 +11207,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2876,19 +2876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fastbloom"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
-dependencies = [
- "foldhash 0.2.0",
- "libm",
- "portable-atomic",
- "rand 0.9.4",
- "siphasher",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6565,22 +6552,11 @@ dependencies = [
  "quinn-proto 0.12.0",
  "quinn-udp 0.6.1",
  "rustc-hash 2.1.2",
- "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "quinn-congestions"
-version = "0.1.0"
-source = "git+https://github.com/proxy-rs/quinn-congestions.git#2bdc356f57a7fc3ae1a49ab963a221f42d61012f"
-dependencies = [
- "quinn 0.12.0",
- "quinn-proto 0.12.0",
- "rand 0.9.4",
 ]
 
 [[package]]
@@ -6631,16 +6607,13 @@ version = "0.12.0"
 source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#ce60e5b5c115db2a6053f4e0ca7fc52103cb76b9"
 dependencies = [
  "bytes",
- "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
  "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
- "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -11000,8 +10973,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-core"
-version = "1.8.1"
-source = "git+https://github.com/Itsusinn/tuic.git?branch=build%2Ftuic#2e58dae059b9f6e5324e9abc14dbb2b609ff95d4"
+version = "1.8.2"
 dependencies = [
  "bytes",
  "eyre",
@@ -11009,7 +10981,6 @@ dependencies = [
  "parking_lot",
  "peekable",
  "quinn 0.12.0",
- "quinn-congestions",
  "register-count",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ needless_collect = "deny"
 [patch.crates-io]
 rustls = { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.40" }
 tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", branch = "watfaq/0.26.4" }
+
+[patch."https://github.com/Itsusinn/tuic.git"]
+tuic-core = { path = "../../Itsusinn/tuic/v1.8.2/tuic-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,3 @@ needless_collect = "deny"
 rustls = { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.40" }
 tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", branch = "watfaq/0.26.4" }
 
-[patch."https://github.com/Itsusinn/tuic.git"]
-tuic-core = { path = "/home/ihsin/.openclaw/workspace/Itsusinn/tuic/v1.8.2/tuic-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,4 @@ rustls = { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.4
 tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", branch = "watfaq/0.26.4" }
 
 [patch."https://github.com/Itsusinn/tuic.git"]
-tuic-core = { path = "../../Itsusinn/tuic/v1.8.2/tuic-core" }
+tuic-core = { path = "/home/ihsin/.openclaw/workspace/Itsusinn/tuic/v1.8.2/tuic-core" }

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -182,7 +182,7 @@ tor-rtcompat = { version = "0.42", optional = true, default-features = false, fe
 
 
 # tuic
-tuic-core= { path = "/home/ihsin/.openclaw/workspace/Itsusinn/tuic/v1.8.2/tuic-core", optional = true, features = ["async_marshal", "marshal", "model"] }
+tuic-core= { tag = "v1.8.4", optional = true, git = "https://github.com/Itsusinn/tuic.git", features = ["async_marshal", "marshal", "model"] }
 register-count = { version = "0.1", optional = true }
 
 quinn = { version = "0.11", default-features = false, features = ["futures-io", "runtime-tokio"] }

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -182,7 +182,7 @@ tor-rtcompat = { version = "0.42", optional = true, default-features = false, fe
 
 
 # tuic
-tuic-core= { tag = "v1.8.2", optional = true, git = "https://github.com/Itsusinn/tuic.git", features = ["async_marshal", "marshal", "model"] }
+tuic-core= { path = "/home/ihsin/.openclaw/workspace/Itsusinn/tuic/v1.8.2/tuic-core", optional = true, features = ["async_marshal", "marshal", "model"] }
 register-count = { version = "0.1", optional = true }
 
 quinn = { version = "0.11", default-features = false, features = ["futures-io", "runtime-tokio"] }

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -182,7 +182,7 @@ tor-rtcompat = { version = "0.42", optional = true, default-features = false, fe
 
 
 # tuic
-tuic-core= { branch = "build/tuic", optional = true, git = "https://github.com/Itsusinn/tuic.git", features = ["async_marshal", "marshal", "model"] }
+tuic-core= { tag = "v1.8.2", optional = true, git = "https://github.com/Itsusinn/tuic.git", features = ["async_marshal", "marshal", "model"] }
 register-count = { version = "0.1", optional = true }
 
 quinn = { version = "0.11", default-features = false, features = ["futures-io", "runtime-tokio"] }

--- a/clash-lib/src/proxy/tuic/mod.rs
+++ b/clash-lib/src/proxy/tuic/mod.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 use tuic_core::quinn::{
     ClientConfig as QuinnConfig, Endpoint as QuinnEndpoint, EndpointConfig,
     TokioRuntime, TransportConfig as QuinnTransportConfig, VarInt,
-    congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
+    bbr::BbrConfig, congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
     crypto::rustls::QuicClientConfig,
 };
 
@@ -235,6 +235,8 @@ impl Handler {
             CongestionControl::NewReno => transport_config
                 .congestion_controller_factory(Arc::new(NewRenoConfig::default())),
             CongestionControl::Bbr => transport_config
+                .congestion_controller_factory(Arc::new(BbrConfig::default())),
+            CongestionControl::Bbr3 => transport_config
                 .congestion_controller_factory(Arc::new(Bbr3Config::default())),
         };
 

--- a/clash-lib/src/proxy/tuic/mod.rs
+++ b/clash-lib/src/proxy/tuic/mod.rs
@@ -14,7 +14,8 @@ use tracing::debug;
 use tuic_core::quinn::{
     ClientConfig as QuinnConfig, Endpoint as QuinnEndpoint, EndpointConfig,
     TokioRuntime, TransportConfig as QuinnTransportConfig, VarInt,
-    bbr::BbrConfig, congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
+    bbr::BbrConfig,
+    congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
     crypto::rustls::QuicClientConfig,
 };
 

--- a/clash-lib/src/proxy/tuic/types.rs
+++ b/clash-lib/src/proxy/tuic/types.rs
@@ -263,6 +263,7 @@ pub enum CongestionControl {
     NewReno,
     #[default]
     Bbr,
+    Bbr3,
 }
 impl From<&str> for CongestionControl {
     #[inline]
@@ -275,6 +276,8 @@ impl From<&str> for CongestionControl {
             Self::NewReno
         } else if s.eq_ignore_ascii_case("bbr") {
             Self::Bbr
+        } else if s.eq_ignore_ascii_case("bbr3") {
+            Self::Bbr3
         } else {
             tracing::warn!(
                 "Unknown congestion controller {s}. Use default controller"


### PR DESCRIPTION
Upgrade `tuic-core` from branch-based dependency (`build/tuic`) to `v1.8.4` tag.

Changes in `Itsusinn/tuic` v1.8.4:
- Restore public re-exports of quinn types/submodules from `tuic_core::quinn`
- Restore `quinn-congestions` dependency and feature flags (`quinn/rustls-ring`, `quinn/rustls-aws-lc-rs`, `runtime-tokio`)

Congestion controller update:
- `bbr`: now uses `BbrConfig` from `quinn-congestions` (instead of incorrectly using built-in `Bbr3Config`)
- `bbr3`: new option, uses Quinn built-in `Bbr3Config`

Tested: `cargo build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional QUIC congestion controller variant ("bbr3") and enabled BBR configuration for TUIC transport.
* **Chores**
  * Switched a core dependency from a development branch to a stable release tag.
  * Added a patch configuration entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->