### PR TITLE
fix: remove v6 dns config from wintun 

### DIFF
--- a/clash-lib/src/proxy/tun/routes/mod.rs
+++ b/clash-lib/src/proxy/tun/routes/mod.rs
@@ -104,12 +104,6 @@ pub fn maybe_add_routes(cfg: &TunConfig, tun_name: &str) -> std::io::Result<()> 
                             .map_err(|e| {
                                 tracing::error!("failed to set dns due to:{}", e)
                             });
-                        let name_server_v6 =
-                            vec!["2606:4700:4700::1111".parse().unwrap()];
-                        let _ = windows::set_dns_v6(&tun_iface, &name_server_v6)
-                            .map_err(|e| {
-                                tracing::error!("failed to set dns due to:{}", e)
-                            });
                     }
                 }
                 #[cfg(target_os = "macos")]

--- a/clash-lib/src/proxy/tun/routes/windows.rs
+++ b/clash-lib/src/proxy/tun/routes/windows.rs
@@ -152,6 +152,7 @@ pub fn set_dns_v4(
 
 // SetInterfaceDnsSettings()
 // See https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-setinterfacednssettings
+#[allow(dead_code)]
 pub fn set_dns_v6(
     iface: &OutboundInterface,
     name_servers: &[Ipv6Addr],


### PR DESCRIPTION
### What does this PR do?

<!-- Briefly describe the change and why it's needed. Link related issues with `closes #xxx` if applicable. -->
Remove default ipv6 dns in wintun when auto route enabled
### Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / cleanup
- [ ] Other

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows DNS hijacking to configure only IPv4 DNS resolution, removing IPv6 DNS configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->