### PR TITLE
fix(socket): skip SO_BINDTODEVICE on Android

### DIFF
--- a/clash-lib/src/proxy/utils/platform/unix.rs
+++ b/clash-lib/src/proxy/utils/platform/unix.rs
@@ -7,7 +7,13 @@ pub(crate) fn must_bind_socket_on_interface(
     iface: &OutboundInterface,
     #[allow(unused_variables)] family: socket2::Domain,
 ) -> io::Result<()> {
-    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux",))]
+    // SO_BINDTODEVICE needs CAP_NET_RAW; on Android the host handles routing.
+    #[cfg(target_os = "android")]
+    {
+        let _ = (socket, iface);
+        Ok(())
+    }
+    #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
     {
         use tracing::error;
         socket


### PR DESCRIPTION
### What does this PR do?

`socket.bind_device()` (SO_BINDTODEVICE) needs CAP_NET_RAW. Unprivileged Android apps don't have it — Android 12+ enforces this via SELinux.

With `tun.enable: true`, `init_net_config` populates `DEFAULT_OUTBOUND_INTERFACE`, which `app::dns::helper::make_clients` uses as the fallback iface for every nameserver. Every DNS client then fails to initialize with `EPERM` → resolver ends up with zero clients → all resolution fails (GEOSITE rules and DoT/DoH upstream break).

On Android the host (`VpnService.protect()` / `ConnectivityManager.bindProcessToNetwork`) owns network selection, so this socket option should be a no-op there. Other platforms unchanged.

Verified on Samsung Android 14:
- Before: clash.log shows `failed to bind socket to interface wlan0: Operation not permitted (os error 1)` per nameserver, then `dns error: no DNS clients available for query` on every connection.
- After: UDP and DoT upstream clients init fine; `GEOSITE,cn` / `GEOIP,cn` rules fire as expected.

### Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / cleanup
- [ ] Other

### Checklist

- [x] Tests added or not needed (Android-only no-op branch)
- [x] Docs updated or not needed

Assisted-by: Claude:claude-opus-4-7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform compatibility for Android by adjusting socket binding behavior across different platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->