### PR TITLE
chore: bump workflows to v1.0.35, enable sccache & cross-rs integration

### DIFF
--- a/.cross/Dockerfile
+++ b/.cross/Dockerfile
@@ -1,0 +1,18 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends clang llvm && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CC=clang
+ENV CXX=clang++
+ENV AR=llvm-ar
+
+# sccache: distributed compilation cache via host TCP server
+ARG SCCACHE_VERSION=0.15.0
+RUN curl -LSfs https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    | tar xzf - -C /usr/local/bin --strip-components=1
+
+# Container-local sccache server port (isolated from host on 4226)
+ENV SCCACHE_SERVER_PORT=14266

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.15
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.35
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -34,14 +34,14 @@ jobs:
       target-config-file: ".github/target.toml"
       rustflags: ""
       enable-tmate: true
-      enable-sccache: false
+      enable-sccache: true
       only-clippy-tests-on-pr: true
 
   release:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.15
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.35
     with:
       cliff-config: '.github/cliff.toml'
       create-latest-on-push: true
@@ -49,7 +49,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.15
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.35
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'clash-rs'

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[build.dockerfile]
+file = ".cross/Dockerfile"
+
 [build]
 pre-build = [
     "apt-get update -qq && apt-get install -y --no-install-recommends curl ca-certificates && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs",
@@ -5,7 +8,7 @@ pre-build = [
 
 [build.env]
 volumes = ["/var/run/docker.sock=/var/run/docker.sock", "/tmp=/tmp"] # Docker in docker
-passthrough = ["CLASH_GIT_REF", "CLASH_GIT_SHA", "GITHUB_REF", "GITHUB_SHA", "RUSTFLAGS", "RUST_LOG", "CLASH_DOCKER_TEST", "SENTRY_DSN", "RUSTC_BOOTSTRAP", "TS_AUTH_KEY"]
+passthrough = ["CLASH_GIT_REF", "CLASH_GIT_SHA", "GITHUB_REF", "GITHUB_SHA", "RUSTFLAGS", "RUST_LOG", "CLASH_DOCKER_TEST", "SENTRY_DSN", "RUSTC_BOOTSTRAP", "TS_AUTH_KEY", "RUSTC_WRAPPER", "SCCACHE_DIR"]
 
 [target.mips-unknown-linux-musl]
 image = "ghcr.io/cross-rs/mips-unknown-linux-musl:edge"


### PR DESCRIPTION
### Changes

Update `rust-proxy/workflows` tag from `v1.0.17` to `v1.0.35`, enable sccache.

**sccache:**
- Enable sccache (`enable-sccache: true`)
- sccache dir: Linux → `/tmp/sccache` (shared with cross containers via `/tmp` volume), Windows → `%USERPROFILE%/.sccache`, macOS → `$HOME/.sccache`
- `CROSS_CONTAINER_OPTS=--network host` for cross containers
- Container sccache isolation via port mismatch: host server on `4226`, Dockerfile declares `SCCACHE_SERVER_PORT=14266`

**Cross.toml:**
- Add `[build.dockerfile]` targeting `.cross/Dockerfile`
- Add `RUSTC_WRAPPER`, `SCCACHE_DIR` to passthrough

**.cross/Dockerfile (new):**
- Install clang/llvm (fix aws-lc-sys GCC memcmp bug)
- Install sccache binary
- `ENV SCCACHE_SERVER_PORT=14266` (isolated from host)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow versions for build, release, and deployment jobs
  * Added custom cross-compilation container configuration with enhanced tooling support
  * Extended build environment variable passthrough to optimize compilation performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Watfaq/clash-rs/pull/1443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->