### PR TITLE
fix: pass through CORS preflight requests in auth middleware

### DIFF
--- a/clash-lib/src/app/api/middlewares/auth.rs
+++ b/clash-lib/src/app/api/middlewares/auth.rs
@@ -1,6 +1,6 @@
 use axum::{body::Body, extract::Query, http::Request, response::Response};
 use futures::future::BoxFuture;
-
+use http::Method;
 use serde::Deserialize;
 use tower::{Layer, Service};
 
@@ -65,6 +65,14 @@ where
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         if self.token.is_empty() {
+            return Box::pin(self.inner.call(req));
+        }
+
+        // CORS preflight requests never include credentials per the CORS spec.
+        // Pass them through so the CorsLayer can add proper CORS headers.
+        if req.method() == Method::OPTIONS
+            && req.headers().contains_key(http::header::ORIGIN)
+        {
             return Box::pin(self.inner.call(req));
         }
 

--- a/clash-lib/tests/api_tests.rs
+++ b/clash-lib/tests/api_tests.rs
@@ -105,6 +105,74 @@ async fn test_wildcard_cors_returns_any_origin_header() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn test_cors_preflight_without_auth_returns_cors_headers() {
+    let port_base = alloc_ports(CLIENT_PORT_BLOCK);
+    let wd =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/config/client");
+    let config_str = format!(
+        "{}\ncors-allow-origins:\n  - \"*\"\n",
+        make_client_config_str(port_base)
+    );
+    let _clash = ClashInstance::start(
+        Options {
+            config: Config::Str(config_str),
+            cwd: Some(wd.to_string_lossy().to_string()),
+            rt: None,
+            log_file: None,
+            config_path: None,
+        },
+        (port_base..port_base + CLIENT_PORT_BLOCK).collect(),
+    )
+    .expect("Failed to start client with wildcard CORS origins");
+
+    // Preflight OPTIONS request WITHOUT Authorization header
+    // This is what browsers send and it must return CORS headers.
+    let version_url = format!("http://127.0.0.1:{}/version", port_base);
+    let req = hyper::Request::builder()
+        .uri(&version_url)
+        .header(http::header::ORIGIN, "https://example.com")
+        .header(http::header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .method(http::method::Method::OPTIONS)
+        .body(http_body_util::Empty::<Bytes>::new())
+        .expect("Failed to build request");
+
+    let res = send_http_request(version_url.parse().unwrap(), req)
+        .await
+        .expect("Failed to send OPTIONS preflight request");
+
+    // Preflight must succeed, not return 401
+    assert_eq!(res.status(), http::StatusCode::OK);
+
+    // Must include CORS headers so the browser allows the actual request
+    assert_eq!(
+        res.headers()
+            .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|v| v.to_str().ok()),
+        Some("*")
+    );
+
+    // Must allow the actual request method
+    assert!(
+        res.headers()
+            .get(http::header::ACCESS_CONTROL_ALLOW_METHODS)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.contains("GET"))
+            .unwrap_or(false),
+        "preflight response should allow GET method"
+    );
+
+    // Must allow the Authorization header that the actual request will send
+    assert!(
+        res.headers()
+            .get(http::header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.contains("authorization"))
+            .unwrap_or(false),
+        "preflight response should allow Authorization header"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn test_config_reload_via_payload() {
     let wd =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/config/client");


### PR DESCRIPTION
## Problem

When a `secret` is configured, browsers cannot use REST API dashboards (e.g. https://clash.razord.top) because the CORS preflight `OPTIONS` request fails.

### Root cause

Per the [CORS spec](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request), browsers send `OPTIONS` preflight requests **without credentials** (no `Authorization` header). The `AuthMiddleware` was unconditionally rejecting these requests with `401 Unauthorized`, and the response lacked `Access-Control-Allow-Origin`. Since the preflight fails, the browser blocks the actual request.

The middleware chain is: `AuthMiddleware → CorsLayer → handler`. Even though `cors-allow-origins: ["*"]` was configured, `CorsLayer` never got to run on preflight requests because `AuthMiddleware` rejected them first.

### Fix

Pass through CORS preflight requests (`OPTIONS` with `Origin` header) in `AuthMiddleware` without requiring authentication. The inner `CorsLayer` then handles the preflight properly, returning `200 OK` with the required CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`).

This is the standard pattern: auth middleware should not block CORS preflight because:
1. Browsers never send credentials on preflight by spec
2. A preflight response is just metadata about allowed origins/methods/headers, not sensitive data
3. The actual authenticated request (`GET`/`POST`/etc.) is still protected by auth

### Testing

Added `test_cors_preflight_without_auth_returns_cors_headers` which sends an `OPTIONS` preflight **without** `Authorization` header and verifies:
- Response status is `200 OK` (not 401)
- `Access-Control-Allow-Origin: *` is present
- `Access-Control-Allow-Methods` contains GET
- `Access-Control-Allow-Headers` contains authorization

All existing auth tests (`test_auth_required`, `test_wildcard_cors_returns_any_origin_header`, etc.) remain unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CORS preflight (`OPTIONS`) requests no longer require authentication.
  * Preflight responses now consistently return the expected CORS headers (allowed origin, methods, and headers), allowing browser requests to proceed.

* **Tests**
  * Added an async test to verify unauthenticated CORS preflight behavior for `/version`, including `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, and `Access-Control-Allow-Headers`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->