### PR TITLE
fix: remove unused shadowquic git patch and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git add Cargo.toml clash-bin/Cargo.toml clash-dns/Cargo.toml clash-doc/Cargo.toml clash-ffi/Cargo.toml clash-lib/Cargo.toml Cargo.lock
+          git add Cargo.toml clash-bin/Cargo.toml clash-dns/Cargo.toml clash-doc/Cargo.toml clash-ffi/Cargo.toml clash-lib/Cargo.toml clash-netstack/Cargo.toml Cargo.lock
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
 
       - name: Create tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11783,7 +11783,7 @@ dependencies = [
 
 [[package]]
 name = "watfaq-netstack"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "env_logger",
@@ -12756,8 +12756,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "shadowquic"
-version = "0.3.11"
-source = "git+https://github.com/spongebob888/shadowquic.git?rev=295034e1b6478706a4348565bfc3ecea8378da98#295034e1b6478706a4348565bfc3ecea8378da98"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,5 @@ needless_collect = "deny"
 [patch.crates-io]
 rustls = { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.40" }
 tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", branch = "watfaq/0.26.4" }
-# shadowquic 0.3.11 (registry) is incompatible with quinn-proto-jls 0.3.6 which
-# added an `_is_ecn: bool` parameter to CongestionController::on_congestion_event.
-# The fix is in the main branch but not yet released as a new crate version.
-shadowquic = { git = "https://github.com/spongebob888/shadowquic.git", rev = "295034e1b6478706a4348565bfc3ecea8378da98" }
 shadowquic-macros = { git = "https://github.com/spongebob888/shadowquic.git", rev = "295034e1b6478706a4348565bfc3ecea8378da98" }
 


### PR DESCRIPTION
### What does this PR do?

 1. Remove unused shadowquic git patch from [patch.crates-io]

 The shadowquic git patch was added in #1463 to work around a quinn-proto-jls 0.3.6 API breaking change. However, shadowquic 0.3.12 on crates.io already includes the fix, making the git patch unused — Cargo.lock marks it as [[patch.unused]].

 While harmless for normal builds, this breaks offline/vendored builds (e.g., Nix, cargo vendor): cargo still attempts to
 resolve the git source, but only shadowquic-macros was vendored from that repository, causing:

 ```
   error: patch location `https://github.com/spongebob888/shadowquic.git?rev=...`
   does not contain packages matching `shadowquic`
 ```

 2. Fix release workflow missing clash-netstack/Cargo.toml

 #886 added clash-netstack as a workspace member and updated the git add list in release.yml for renamed crates, but omitted clash-netstack/Cargo.toml. Since then, every cargo set-version --bump modifies it without staging, causing a recurring watfaq-netstack version mismatch between Cargo.toml (0.1.0) and Cargo.lock (0.1.1). This PR fixes the workflow and corrects the version in Cargo.lock.

### Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / cleanup
- [ ] Other

### Checklist

- [ ] Tests added or not needed
- [ ] Docs updated or not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation so version updates are applied consistently across all project components.
  * Enhanced build consistency and reliability for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->