### PR TITLE
feat(tls): apply client-fingerprint instead of warning about it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +265,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -261,7 +276,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1096,6 +1111,27 @@ name = "bounded-integer"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "102dbef1187b1893e6dfe05a774e79fd52265f49f214f6879c8ff49f52c8188b"
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "brutal-core"
@@ -2324,7 +2360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1747ed5fb4ab3a9f8253da3401efe7ca8f8e5ec373b2e700ff55c3304d84e31f"
 dependencies = [
  "heck",
- "indexmap 1.9.3",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2488,7 +2524,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2895,7 +2931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4088,7 +4124,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5374,7 +5410,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6723,7 +6759,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6877,7 +6913,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6889,7 +6925,7 @@ dependencies = [
  "libc",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6902,7 +6938,7 @@ dependencies = [
  "libc",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7614,15 +7650,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
 version = "0.23.40"
-source = "git+https://github.com/Watfaq/rustls.git?branch=watfaq%2F0.23.40#e6e8e7e1a0d65f2f273eb7b5b6179896536ac174"
+source = "git+https://github.com/Rushan4eg/rustls.git?branch=watfaq%2Futls#1fb4bca455510416e6360f82afb206f793e46e08"
 dependencies = [
  "aws-lc-rs",
+ "brotli",
+ "brotli-decompressor",
  "log",
  "once_cell",
  "ring",
@@ -7726,7 +7764,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8059,7 +8097,7 @@ checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -8667,7 +8705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9141,7 +9179,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11999,7 +12037,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12461,7 +12499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.40"
-source = "git+https://github.com/Rushan4eg/rustls.git?branch=watfaq%2Futls#1fb4bca455510416e6360f82afb206f793e46e08"
+source = "git+https://github.com/Rushan4eg/rustls.git?branch=watfaq%2Futls#64bb6c1de7a360d93589686eafb1876095b0e90c"
 dependencies = [
  "aws-lc-rs",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,12 @@ redundant_clone = "deny"
 needless_collect = "deny"
 
 [patch.crates-io]
-rustls = { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.40" }
+# TEMPORARY, do not merge as is: points at the branch of
+# https://github.com/Watfaq/rustls/pull/11, which adds the ClientHello
+# shaping API this feature is built on. Revert to
+#   { git = "https://github.com/Watfaq/rustls.git", branch = "watfaq/0.23.40" }
+# once that PR lands.
+rustls = { git = "https://github.com/Rushan4eg/rustls.git", branch = "watfaq/utls" }
 tokio-rustls = { git = "https://github.com/Watfaq/tokio-rustls.git", branch = "watfaq/0.26.4" }
 shadowquic-macros = { git = "https://github.com/spongebob888/shadowquic.git", rev = "295034e1b6478706a4348565bfc3ecea8378da98" }
 

--- a/clash-lib/Cargo.toml
+++ b/clash-lib/Cargo.toml
@@ -72,7 +72,7 @@ tokio-tungstenite = "0.29.0"
 # TLS
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2"] }
-rustls = { version = "0.23", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["brotli"] }
 rustls-pemfile = "2"
 rcgen = { version = "0.14", default-features = false, features = ["pem"] }
 webpki-roots = "1.0"

--- a/clash-lib/src/common/mod.rs
+++ b/clash-lib/src/common/mod.rs
@@ -10,5 +10,6 @@ pub mod mmdb;
 pub mod succinct_set;
 pub mod timed_future;
 pub mod tls;
+pub mod tls_fingerprint;
 pub mod trie;
 pub mod utils;

--- a/clash-lib/src/common/tls.rs
+++ b/clash-lib/src/common/tls.rs
@@ -1,11 +1,14 @@
 use rustls::{
-    RootCertStore,
+    ClientConfig, RootCertStore,
     client::{WebPkiServerVerifier, danger::ServerCertVerifier},
+    crypto::CryptoProvider,
     pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime},
 };
 use tracing::warn;
 
 use std::sync::{Arc, LazyLock};
+
+use super::tls_fingerprint::{ClientFingerprint, PinnedSchemeVerifier};
 
 pub static GLOBAL_ROOT_STORE: LazyLock<Arc<RootCertStore>> =
     LazyLock::new(global_root_store);
@@ -132,11 +135,15 @@ pub fn build_tls_client_config(
     verifier: Arc<dyn ServerCertVerifier>,
     tls_cert: Option<&str>,
     tls_key: Option<&str>,
-) -> std::io::Result<rustls::ClientConfig> {
-    match (tls_cert, tls_key) {
+    fingerprint: Option<ClientFingerprint>,
+) -> std::io::Result<ClientConfig> {
+    let verifier = pin_schemes(verifier, fingerprint);
+    let builder = client_config_builder(fingerprint)?;
+
+    let mut config = match (tls_cert, tls_key) {
         (Some(cert), Some(key)) => {
             let (certs, private_key) = load_cert_and_key(cert, key)?;
-            rustls::ClientConfig::builder()
+            builder
                 .dangerous()
                 .with_custom_certificate_verifier(verifier)
                 .with_client_auth_cert(certs, private_key)
@@ -145,16 +152,78 @@ pub fn build_tls_client_config(
                         std::io::ErrorKind::InvalidInput,
                         format!("invalid mTLS client cert/key: {e}"),
                     )
-                })
+                })?
         }
-        (None, None) => Ok(rustls::ClientConfig::builder()
+        (None, None) => builder
             .dangerous()
             .with_custom_certificate_verifier(verifier)
-            .with_no_client_auth()),
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "tls-cert and tls-key must both be set or both omitted",
-        )),
+            .with_no_client_auth(),
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "tls-cert and tls-key must both be set or both omitted",
+            ));
+        }
+    };
+
+    apply_client_fingerprint(&mut config, fingerprint);
+    Ok(config)
+}
+
+/// Start a client config on the provider a fingerprint asks for.
+///
+/// Key exchange group order is part of the hello and cannot be changed once
+/// the config is built, so it has to be decided here rather than patched in
+/// afterwards.
+fn client_config_builder(
+    fingerprint: Option<ClientFingerprint>,
+) -> std::io::Result<rustls::ConfigBuilder<ClientConfig, rustls::WantsVerifier>> {
+    let Some(fingerprint) = fingerprint else {
+        return Ok(ClientConfig::builder());
+    };
+
+    let base = CryptoProvider::get_default().cloned().ok_or_else(|| {
+        std::io::Error::other("no default crypto provider installed")
+    })?;
+
+    ClientConfig::builder_with_provider(fingerprint.crypto_provider(base))
+        .with_safe_default_protocol_versions()
+        .map_err(std::io::Error::other)
+}
+
+/// Narrow the signature algorithms to the ones the fingerprint advertises.
+fn pin_schemes(
+    verifier: Arc<dyn ServerCertVerifier>,
+    fingerprint: Option<ClientFingerprint>,
+) -> Arc<dyn ServerCertVerifier> {
+    match fingerprint.and_then(|fp| fp.signature_schemes()) {
+        Some(schemes) => Arc::new(PinnedSchemeVerifier::new(verifier, schemes)),
+        None => verifier,
+    }
+}
+
+/// Put the shaped hello on a config that is otherwise already built.
+///
+/// Separate from [`build_tls_client_config`] because Reality builds its config
+/// by a different route - it has to insert its own verifier - and still needs
+/// this part.
+pub fn apply_client_fingerprint(
+    config: &mut ClientConfig,
+    fingerprint: Option<ClientFingerprint>,
+) {
+    let Some(fingerprint) = fingerprint else {
+        return;
+    };
+
+    config.client_hello_profile = Arc::new(fingerprint.client_hello_profile());
+
+    // Only when the caller has no ALPN of its own: a transport that must
+    // negotiate h2 has a functional requirement, and looking like a browser
+    // does not outrank it.
+    if config.alpn_protocols.is_empty()
+        && let Some(alpn) = fingerprint.alpn()
+    {
+        config.alpn_protocols = alpn;
     }
 }
 

--- a/clash-lib/src/common/tls.rs
+++ b/clash-lib/src/common/tls.rs
@@ -186,9 +186,16 @@ fn client_config_builder(
         std::io::Error::other("no default crypto provider installed")
     })?;
 
-    ClientConfig::builder_with_provider(fingerprint.crypto_provider(base))
-        .with_safe_default_protocol_versions()
-        .map_err(std::io::Error::other)
+    let builder =
+        ClientConfig::builder_with_provider(fingerprint.crypto_provider(base));
+
+    // GREASE ECH has to be decided here too: it is stored on the builder, not
+    // on the finished config.
+    match fingerprint.ech_mode() {
+        Some(mode) => builder.with_ech(mode),
+        None => builder.with_safe_default_protocol_versions(),
+    }
+    .map_err(std::io::Error::other)
 }
 
 /// Narrow the signature algorithms to the ones the fingerprint advertises.

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -647,6 +647,17 @@ mod wire {
     }
 
     #[test]
+    fn chrome_offers_brotli_certificate_compression() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        // compress_certificate(27): a u8 list length, then u16 algorithm ids.
+        // Brotli is 2, and it is the only one Chrome offers. Without it the
+        // extension is absent entirely, and the extension set is exactly what
+        // the common fingerprints hash.
+        assert_eq!(hello.body(0x001b), Some(&[0x02, 0x00, 0x02][..]));
+    }
+
+    #[test]
     fn chrome_sends_a_grease_ech_placeholder() {
         let hello = capture(Some(ClientFingerprint::Chrome));
 

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -119,8 +119,8 @@ impl FromStr for ClientFingerprint {
 pub fn parse_client_fingerprint(value: &str, proxy: &str) -> ClientFingerprint {
     ClientFingerprint::from_str(value).unwrap_or_else(|_| {
         warn!(
-            "client-fingerprint {value:?} is not implemented, {proxy} will use \
-             a randomised fingerprint instead"
+            "client-fingerprint {value:?} is not implemented, {proxy} will use a \
+             randomised fingerprint instead"
         );
         ClientFingerprint::Randomized
     })
@@ -210,11 +210,11 @@ impl ClientFingerprint {
         }
 
         for group in wanted {
-            if !kx_groups
-                .iter()
-                .any(|supported| supported.name() == *group)
-            {
-                warn!("key exchange group {group:?} is unavailable, dropped from the hello");
+            if !kx_groups.iter().any(|supported| supported.name() == *group) {
+                warn!(
+                    "key exchange group {group:?} is unavailable, dropped from the \
+                     hello"
+                );
             }
         }
 
@@ -247,7 +247,9 @@ mod tests {
 
     #[test]
     fn chromium_forks_all_get_chromes_hello() {
-        for name in ["chrome", "Chrome", " CHROME ", "edge", "android", "360", "qq"] {
+        for name in [
+            "chrome", "Chrome", " CHROME ", "edge", "android", "360", "qq",
+        ] {
             assert_eq!(
                 ClientFingerprint::from_str(name),
                 Ok(ClientFingerprint::Chrome),
@@ -319,7 +321,8 @@ mod tests {
         assert_eq!(
             alpn_list(&["h2", "http/1.1"]),
             vec![
-                0x00, 0x0c, 0x02, 0x68, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31,
+                0x00, 0x0c, 0x02, 0x68, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f,
+                0x31, 0x2e, 0x31,
             ]
         );
     }
@@ -344,11 +347,7 @@ mod tests {
         assert!(profile.cipher_suites.is_none());
         assert!(profile.append_extensions.is_empty());
         assert!(profile.prepend_extensions.is_empty());
-        assert!(
-            ClientFingerprint::Randomized
-                .signature_schemes()
-                .is_none()
-        );
+        assert!(ClientFingerprint::Randomized.signature_schemes().is_none());
     }
 }
 
@@ -443,10 +442,7 @@ mod wire {
 
     impl Hello {
         fn types(&self) -> Vec<u16> {
-            self.extensions
-                .iter()
-                .map(|(typ, _)| *typ)
-                .collect()
+            self.extensions.iter().map(|(typ, _)| *typ).collect()
         }
 
         fn body(&self, typ: u16) -> Option<&[u8]> {
@@ -500,7 +496,8 @@ mod wire {
         let handshake = &record[5..5 + record_len];
         assert_eq!(handshake[0], 0x01, "not a ClientHello");
 
-        let len = u32::from_be_bytes([0, handshake[1], handshake[2], handshake[3]]) as usize;
+        let len = u32::from_be_bytes([0, handshake[1], handshake[2], handshake[3]])
+            as usize;
         let body = &handshake[4..4 + len];
 
         let mut at = 2 + 32; // legacy_version, random
@@ -553,7 +550,10 @@ mod wire {
         let hello = capture(Some(ClientFingerprint::Chrome));
         let types = hello.types();
 
-        assert!(types.contains(&EXT_SIGNED_CERTIFICATE_TIMESTAMP), "{types:04x?}");
+        assert!(
+            types.contains(&EXT_SIGNED_CERTIFICATE_TIMESTAMP),
+            "{types:04x?}"
+        );
         assert!(types.contains(&EXT_APPLICATION_SETTINGS), "{types:04x?}");
         assert!(types.contains(&EXT_RENEGOTIATION_INFO), "{types:04x?}");
 
@@ -620,7 +620,12 @@ mod wire {
         // ALPN(16): u16 list length, then length-prefixed protocols.
         assert_eq!(
             hello.body(0x0010),
-            Some(&[0x00, 0x0c, 0x02, b'h', b'2', 0x08, b'h', b't', b't', b'p', b'/', b'1', b'.', b'1'][..])
+            Some(
+                &[
+                    0x00, 0x0c, 0x02, b'h', b'2', 0x08, b'h', b't', b't', b'p',
+                    b'/', b'1', b'.', b'1'
+                ][..]
+            )
         );
     }
 
@@ -628,13 +633,7 @@ mod wire {
     fn no_fingerprint_leaves_the_hello_exactly_as_it_was() {
         let hello = capture(None);
 
-        assert!(
-            !hello
-                .cipher_suites
-                .iter()
-                .copied()
-                .any(is_grease)
-        );
+        assert!(!hello.cipher_suites.iter().copied().any(is_grease));
         assert!(!hello.types().into_iter().any(is_grease));
         assert!(hello.body(EXT_SIGNED_CERTIFICATE_TIMESTAMP).is_none());
         assert!(hello.body(EXT_APPLICATION_SETTINGS).is_none());

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -1,0 +1,655 @@
+//! What `client-fingerprint` in a proxy config actually does.
+//!
+//! Reality rests on one assumption: the ClientHello is indistinguishable from
+//! a browser's. rustls sends the hello rustls needs, which is recognisably
+//! rustls - no GREASE, no `signed_certificate_timestamp`, no ALPS, and a
+//! cipher list that is exactly the set rustls can negotiate. Any one of those
+//! separates it from a browser before a byte of application data moves.
+//!
+//! The mechanism lives in rustls (`ClientHelloProfile`). What lives here is
+//! the browser table: which suites, which groups, which extensions, in what
+//! order. The numbers below are taken from
+//! [uTLS](https://github.com/refraction-networking/utls), which is the
+//! reference every other implementation checks itself against.
+
+use std::{str::FromStr, sync::Arc};
+
+use rustls::{
+    RawExtension, SignatureScheme,
+    client::ClientHelloProfile,
+    crypto::{CryptoProvider, SupportedKxGroup},
+};
+use tracing::warn;
+
+/// Which client the ClientHello should be shaped like.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+pub enum ClientFingerprint {
+    /// Chrome, and everything else built on Chromium.
+    Chrome,
+
+    /// No particular client: rustls own hello, with GREASE.
+    ///
+    /// Not a disguise. It is what is left when a browser profile was asked
+    /// for and none is available, and it is still better than a hello with no
+    /// GREASE at all, which is a signal in itself.
+    Randomized,
+}
+
+/// Chrome 133, cipher suites in order, GREASE excluded.
+///
+/// The last six are static RSA and CBC key exchange, which rustls does not
+/// implement and will never negotiate. They are here to be counted: fifteen
+/// suites in this order is the first half of Chrome's fingerprint, and a list
+/// trimmed to what rustls supports gives the game away on its own.
+const CHROME_CIPHER_SUITES: &[u16] = &[
+    0x1301, // TLS_AES_128_GCM_SHA256
+    0x1302, // TLS_AES_256_GCM_SHA384
+    0x1303, // TLS_CHACHA20_POLY1305_SHA256
+    0xc02b, // TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    0xc02f, // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    0xc02c, // TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    0xc030, // TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    0xcca9, // TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    0xcca8, // TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+    0xc013, // TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+    0xc014, // TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+    0x009c, // TLS_RSA_WITH_AES_128_GCM_SHA256
+    0x009d, // TLS_RSA_WITH_AES_256_GCM_SHA384
+    0x002f, // TLS_RSA_WITH_AES_128_CBC_SHA
+    0x0035, // TLS_RSA_WITH_AES_256_CBC_SHA
+];
+
+/// Chrome 133, supported groups in order.
+///
+/// rustls derives the key shares from this: with X25519MLKEM768 first it
+/// offers that plus its X25519 component, which is the pair Chrome sends.
+const CHROME_NAMED_GROUPS: &[rustls::NamedGroup] = &[
+    rustls::NamedGroup::X25519MLKEM768,
+    rustls::NamedGroup::X25519,
+    rustls::NamedGroup::secp256r1,
+    rustls::NamedGroup::secp384r1,
+];
+
+/// Chrome 133, signature algorithms in order.
+///
+/// Shorter than rustls own list and in a different order, and both halves of
+/// that matter: the list goes out in the hello, and the hello is what is being
+/// matched. Nothing Chrome refuses to verify is accepted here either.
+const CHROME_SIGNATURE_SCHEMES: &[SignatureScheme] = &[
+    SignatureScheme::ECDSA_NISTP256_SHA256,
+    SignatureScheme::RSA_PSS_SHA256,
+    SignatureScheme::RSA_PKCS1_SHA256,
+    SignatureScheme::ECDSA_NISTP384_SHA384,
+    SignatureScheme::RSA_PSS_SHA384,
+    SignatureScheme::RSA_PKCS1_SHA384,
+    SignatureScheme::RSA_PSS_SHA512,
+    SignatureScheme::RSA_PKCS1_SHA512,
+];
+
+const EXT_SIGNED_CERTIFICATE_TIMESTAMP: u16 = 0x0012;
+/// `application_settings`, the codepoint Chrome 133 uses. Chrome 131 and
+/// earlier sent 0x4469 for the same thing.
+const EXT_APPLICATION_SETTINGS: u16 = 0x44cd;
+const EXT_RENEGOTIATION_INFO: u16 = 0xff01;
+
+/// A `client-fingerprint` value naming a profile that is not implemented.
+#[derive(Debug, PartialEq, Eq)]
+pub struct UnknownFingerprint;
+
+impl FromStr for ClientFingerprint {
+    type Err = UnknownFingerprint;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            // All Chromium underneath, all sending Chrome's hello. 360 and QQ
+            // are the Chinese Chromium forks Clash.Meta names.
+            "chrome" | "edge" | "android" | "360" | "qq" => Ok(Self::Chrome),
+            "random" | "randomized" => Ok(Self::Randomized),
+            _ => Err(UnknownFingerprint),
+        }
+    }
+}
+
+/// Read a `client-fingerprint` value, falling back rather than pretending.
+///
+/// Firefox and Safari are real profiles that simply are not modelled here.
+/// Quietly substituting Chrome for them would be worse than saying so: a
+/// config asking for Firefox and getting Chrome is a mismatch nobody would
+/// think to look for.
+pub fn parse_client_fingerprint(value: &str, proxy: &str) -> ClientFingerprint {
+    ClientFingerprint::from_str(value).unwrap_or_else(|_| {
+        warn!(
+            "client-fingerprint {value:?} is not implemented, {proxy} will use \
+             a randomised fingerprint instead"
+        );
+        ClientFingerprint::Randomized
+    })
+}
+
+impl ClientFingerprint {
+    /// How the hello should be shaped.
+    pub fn client_hello_profile(&self) -> ClientHelloProfile {
+        match self {
+            Self::Chrome => ClientHelloProfile {
+                grease: true,
+                cipher_suites: Some(CHROME_CIPHER_SUITES.to_vec()),
+                append_extensions: vec![
+                    // rustls signals "no renegotiation" with the SCSV in the
+                    // cipher list; browsers use this extension. Since the
+                    // suite list above is final, the SCSV is gone and this
+                    // takes its place.
+                    RawExtension {
+                        typ: EXT_RENEGOTIATION_INFO,
+                        payload: vec![0x00],
+                    },
+                    RawExtension::empty(EXT_SIGNED_CERTIFICATE_TIMESTAMP),
+                    RawExtension {
+                        typ: EXT_APPLICATION_SETTINGS,
+                        payload: alpn_list(&["h2"]),
+                    },
+                ],
+                // Chrome 131 dropped the padding extension: with GREASE ECH
+                // the hello no longer lands in the range padding existed for.
+                padding: None,
+                ..Default::default()
+            },
+            Self::Randomized => ClientHelloProfile {
+                grease: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Signature algorithms to advertise, if this profile pins them.
+    pub fn signature_schemes(&self) -> Option<&'static [SignatureScheme]> {
+        match self {
+            Self::Chrome => Some(CHROME_SIGNATURE_SCHEMES),
+            Self::Randomized => None,
+        }
+    }
+
+    /// ALPN protocols the browser offers.
+    ///
+    /// Callers that have their own ALPN requirement - a transport that must
+    /// negotiate h2, say - keep theirs. This is for the ones that would
+    /// otherwise send nothing, which is itself unlike any browser.
+    pub fn alpn(&self) -> Option<Vec<Vec<u8>>> {
+        match self {
+            Self::Chrome => Some(vec![b"h2".to_vec(), b"http/1.1".to_vec()]),
+            Self::Randomized => None,
+        }
+    }
+
+    /// The provider to build the config with: same primitives, browser order.
+    ///
+    /// Groups the provider does not have are skipped rather than faked. A key
+    /// share for a group we cannot compute would fail the handshake, which is
+    /// a worse outcome than one group out of place.
+    pub fn crypto_provider(&self, base: Arc<CryptoProvider>) -> Arc<CryptoProvider> {
+        let wanted = match self {
+            Self::Chrome => CHROME_NAMED_GROUPS,
+            Self::Randomized => return base,
+        };
+
+        let kx_groups: Vec<&'static dyn SupportedKxGroup> = wanted
+            .iter()
+            .filter_map(|group| {
+                base.kx_groups
+                    .iter()
+                    .find(|supported| supported.name() == *group)
+                    .copied()
+            })
+            .collect();
+
+        if kx_groups.is_empty() {
+            warn!(
+                "none of the key exchange groups this fingerprint expects are \
+                 available; leaving the provider alone"
+            );
+            return base;
+        }
+
+        for group in wanted {
+            if !kx_groups
+                .iter()
+                .any(|supported| supported.name() == *group)
+            {
+                warn!("key exchange group {group:?} is unavailable, dropped from the hello");
+            }
+        }
+
+        Arc::new(CryptoProvider {
+            kx_groups,
+            ..(*base).clone()
+        })
+    }
+}
+
+/// Encode an `ALPNProtocolList`: a u16 total length, then each protocol
+/// prefixed with its own length byte.
+///
+/// Used for `application_settings`, whose body is the same shape as ALPN.
+fn alpn_list(protocols: &[&str]) -> Vec<u8> {
+    let mut body = Vec::new();
+    for protocol in protocols {
+        body.push(protocol.len() as u8);
+        body.extend_from_slice(protocol.as_bytes());
+    }
+
+    let mut out = (body.len() as u16).to_be_bytes().to_vec();
+    out.extend_from_slice(&body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chromium_forks_all_get_chromes_hello() {
+        for name in ["chrome", "Chrome", " CHROME ", "edge", "android", "360", "qq"] {
+            assert_eq!(
+                ClientFingerprint::from_str(name),
+                Ok(ClientFingerprint::Chrome),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_profile_we_do_not_have_falls_back_rather_than_lying() {
+        for name in ["firefox", "safari", "ios", "nonsense"] {
+            assert_eq!(ClientFingerprint::from_str(name), Err(UnknownFingerprint));
+            // Randomised, not Chrome: a config asking for Firefox and silently
+            // getting Chrome's hello is a mismatch nobody would look for.
+            assert_eq!(
+                parse_client_fingerprint(name, "test-proxy"),
+                ClientFingerprint::Randomized,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn chrome_offers_fifteen_suites() {
+        // The count is the first thing a JA4 fingerprint records. Fifteen is
+        // Chrome; anything else is not, however good the rest looks.
+        assert_eq!(CHROME_CIPHER_SUITES.len(), 15);
+    }
+
+    #[test]
+    fn chrome_carries_the_extensions_rustls_does_not_model() {
+        let profile = ClientFingerprint::Chrome.client_hello_profile();
+        let types: Vec<u16> = profile
+            .append_extensions
+            .iter()
+            .map(|ext| ext.typ)
+            .collect();
+
+        assert!(types.contains(&EXT_RENEGOTIATION_INFO));
+        assert!(types.contains(&EXT_SIGNED_CERTIFICATE_TIMESTAMP));
+        assert!(types.contains(&EXT_APPLICATION_SETTINGS));
+    }
+
+    #[test]
+    fn renegotiation_info_replaces_the_scsv_that_the_suite_list_drops() {
+        let profile = ClientFingerprint::Chrome.client_hello_profile();
+
+        // Pinning the suite list removes TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
+        // which is how rustls says it will not renegotiate. Something has to
+        // say it, or the peer is entitled to assume otherwise.
+        assert!(
+            !CHROME_CIPHER_SUITES.contains(&0x00ff),
+            "the SCSV is not part of any browser's list"
+        );
+        let renegotiation = profile
+            .append_extensions
+            .iter()
+            .find(|ext| ext.typ == EXT_RENEGOTIATION_INFO)
+            .expect("no renegotiation_info");
+        assert_eq!(renegotiation.payload, vec![0x00]);
+    }
+
+    #[test]
+    fn alps_body_is_an_alpn_list() {
+        // 00 03 - two bytes of list length
+        //    02 - one byte of protocol length
+        // 68 32 - "h2"
+        assert_eq!(alpn_list(&["h2"]), vec![0x00, 0x03, 0x02, 0x68, 0x32]);
+        assert_eq!(
+            alpn_list(&["h2", "http/1.1"]),
+            vec![
+                0x00, 0x0c, 0x02, 0x68, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31,
+            ]
+        );
+    }
+
+    #[test]
+    fn chrome_does_not_pad() {
+        // Chrome 131 dropped the padding extension. Sending it would be as
+        // visible as omitting it was before that.
+        assert!(
+            ClientFingerprint::Chrome
+                .client_hello_profile()
+                .padding
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn randomized_greases_and_leaves_everything_else_alone() {
+        let profile = ClientFingerprint::Randomized.client_hello_profile();
+
+        assert!(profile.grease);
+        assert!(profile.cipher_suites.is_none());
+        assert!(profile.append_extensions.is_empty());
+        assert!(profile.prepend_extensions.is_empty());
+        assert!(
+            ClientFingerprint::Randomized
+                .signature_schemes()
+                .is_none()
+        );
+    }
+}
+
+/// Wraps a certificate verifier and pins the signature algorithms it offers.
+///
+/// The list goes out in the hello, so a browser profile that leaves rustls own
+/// list in place is only half a disguise. Pinning it also narrows what will be
+/// accepted, which is the same trade the browser makes.
+#[derive(Debug)]
+pub struct PinnedSchemeVerifier {
+    inner: Arc<dyn rustls::client::danger::ServerCertVerifier>,
+    schemes: Vec<SignatureScheme>,
+}
+
+impl PinnedSchemeVerifier {
+    /// Take the wanted schemes in the wanted order, keeping only the ones the
+    /// wrapped verifier can actually check.
+    ///
+    /// Advertising a scheme we cannot verify would invite the server to sign
+    /// with it and fail the handshake after the fact.
+    pub fn new(
+        inner: Arc<dyn rustls::client::danger::ServerCertVerifier>,
+        wanted: &[SignatureScheme],
+    ) -> Self {
+        let available = inner.supported_verify_schemes();
+        let schemes: Vec<SignatureScheme> = wanted
+            .iter()
+            .filter(|scheme| available.contains(scheme))
+            .copied()
+            .collect();
+
+        Self { inner, schemes }
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for PinnedSchemeVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::pki_types::CertificateDer<'_>,
+        intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        server_name: &rustls::pki_types::ServerName<'_>,
+        ocsp_response: &[u8],
+        now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        )
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.schemes.clone()
+    }
+}
+
+/// What the shaped hello actually looks like on the wire.
+///
+/// The tests above check the browser table; these check that the table
+/// survives the trip through rustls and comes out as bytes. A profile that is
+/// correct in a struct and lost on the way to the socket would pass every
+/// other test here.
+#[cfg(test)]
+mod wire {
+    use super::*;
+    use crate::common::tls::{DefaultTlsVerifier, build_tls_client_config};
+
+    struct Hello {
+        cipher_suites: Vec<u16>,
+        extensions: Vec<(u16, Vec<u8>)>,
+    }
+
+    impl Hello {
+        fn types(&self) -> Vec<u16> {
+            self.extensions
+                .iter()
+                .map(|(typ, _)| *typ)
+                .collect()
+        }
+
+        fn body(&self, typ: u16) -> Option<&[u8]> {
+            self.extensions
+                .iter()
+                .find(|(t, _)| *t == typ)
+                .map(|(_, body)| body.as_slice())
+        }
+
+        /// supported_groups(10) and supported_versions(43) differ only in the
+        /// width of their length prefix.
+        fn u16_list(&self, typ: u16, prefix: usize) -> Vec<u16> {
+            let body = self
+                .body(typ)
+                .unwrap_or_else(|| panic!("extension {typ:#06x} missing"));
+            body[prefix..]
+                .chunks_exact(2)
+                .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+                .collect()
+        }
+    }
+
+    fn is_grease(value: u16) -> bool {
+        let [high, low] = value.to_be_bytes();
+        high == low && low & 0x0f == 0x0a
+    }
+
+    fn capture(fingerprint: Option<ClientFingerprint>) -> Hello {
+        #[cfg(feature = "aws-lc-rs")]
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let verifier = Arc::new(DefaultTlsVerifier::new(None, true));
+        let config =
+            build_tls_client_config(verifier, None, None, fingerprint).unwrap();
+
+        let mut conn = rustls::ClientConnection::new(
+            Arc::new(config),
+            rustls::pki_types::ServerName::try_from("www.example.com").unwrap(),
+        )
+        .unwrap();
+
+        let mut record = Vec::new();
+        conn.write_tls(&mut record).unwrap();
+        parse(&record)
+    }
+
+    fn parse(record: &[u8]) -> Hello {
+        let record_len = u16::from_be_bytes([record[3], record[4]]) as usize;
+        let handshake = &record[5..5 + record_len];
+        assert_eq!(handshake[0], 0x01, "not a ClientHello");
+
+        let len = u32::from_be_bytes([0, handshake[1], handshake[2], handshake[3]]) as usize;
+        let body = &handshake[4..4 + len];
+
+        let mut at = 2 + 32; // legacy_version, random
+        at += 1 + body[at] as usize; // legacy_session_id
+
+        let suites_len = u16::from_be_bytes([body[at], body[at + 1]]) as usize;
+        at += 2;
+        let cipher_suites = body[at..at + suites_len]
+            .chunks_exact(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+            .collect();
+        at += suites_len;
+
+        at += 1 + body[at] as usize; // legacy_compression_methods
+
+        let exts_len = u16::from_be_bytes([body[at], body[at + 1]]) as usize;
+        at += 2;
+        let end = at + exts_len;
+
+        let mut extensions = Vec::new();
+        while at < end {
+            let typ = u16::from_be_bytes([body[at], body[at + 1]]);
+            let size = u16::from_be_bytes([body[at + 2], body[at + 3]]) as usize;
+            at += 4;
+            extensions.push((typ, body[at..at + size].to_vec()));
+            at += size;
+        }
+        assert_eq!(at, end, "extension list length disagrees with contents");
+
+        Hello {
+            cipher_suites,
+            extensions,
+        }
+    }
+
+    #[test]
+    fn chrome_sends_chromes_cipher_list() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        assert!(is_grease(hello.cipher_suites[0]));
+        assert_eq!(&hello.cipher_suites[1..], CHROME_CIPHER_SUITES);
+
+        // Sixteen with GREASE, fifteen without: the count is the first thing a
+        // JA4 fingerprint records.
+        assert_eq!(hello.cipher_suites.len(), 16);
+    }
+
+    #[test]
+    fn chrome_carries_the_extensions_rustls_would_have_left_out() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+        let types = hello.types();
+
+        assert!(types.contains(&EXT_SIGNED_CERTIFICATE_TIMESTAMP), "{types:04x?}");
+        assert!(types.contains(&EXT_APPLICATION_SETTINGS), "{types:04x?}");
+        assert!(types.contains(&EXT_RENEGOTIATION_INFO), "{types:04x?}");
+
+        assert_eq!(hello.body(EXT_SIGNED_CERTIFICATE_TIMESTAMP), Some(&[][..]));
+        assert_eq!(
+            hello.body(EXT_APPLICATION_SETTINGS),
+            Some(&[0x00, 0x03, 0x02, b'h', b'2'][..])
+        );
+    }
+
+    #[test]
+    fn chrome_greases_the_lists_it_should() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        // supported_groups: u16 list length, then the groups.
+        assert!(is_grease(hello.u16_list(0x000a, 2)[0]));
+        // supported_versions: u8 list length, then the versions.
+        assert!(is_grease(hello.u16_list(0x002b, 1)[0]));
+
+        let types = hello.types();
+        let grease: Vec<u16> = types
+            .iter()
+            .copied()
+            .filter(|typ| is_grease(*typ))
+            .collect();
+        assert_eq!(grease.len(), 2, "{types:04x?}");
+    }
+
+    #[test]
+    fn chrome_offers_the_two_key_shares_chrome_offers() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        // key_share(51): u16 list length, then entries of group, u16 length,
+        // body. Chrome sends GREASE, X25519MLKEM768 and its X25519 component;
+        // rustls derives the pair from the group order on its own.
+        let body = hello.body(0x0033).expect("no key_share");
+        let mut at = 2;
+        let mut groups = Vec::new();
+        while at < body.len() {
+            groups.push(u16::from_be_bytes([body[at], body[at + 1]]));
+            let size = u16::from_be_bytes([body[at + 2], body[at + 3]]) as usize;
+            at += 4 + size;
+        }
+
+        assert!(is_grease(groups[0]), "{groups:04x?}");
+        assert_eq!(groups.len(), 3, "{groups:04x?}");
+    }
+
+    #[test]
+    fn chrome_does_not_send_the_scsv() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        // rustls says "I will not renegotiate" with this pseudo-suite; the
+        // browser says it with an extension. Sending both, or the wrong one,
+        // is as visible as any real difference.
+        assert!(!hello.cipher_suites.contains(&0x00ff));
+        assert_eq!(hello.body(EXT_RENEGOTIATION_INFO), Some(&[0x00][..]));
+    }
+
+    #[test]
+    fn chrome_offers_chromes_alpn() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        // ALPN(16): u16 list length, then length-prefixed protocols.
+        assert_eq!(
+            hello.body(0x0010),
+            Some(&[0x00, 0x0c, 0x02, b'h', b'2', 0x08, b'h', b't', b't', b'p', b'/', b'1', b'.', b'1'][..])
+        );
+    }
+
+    #[test]
+    fn no_fingerprint_leaves_the_hello_exactly_as_it_was() {
+        let hello = capture(None);
+
+        assert!(
+            !hello
+                .cipher_suites
+                .iter()
+                .copied()
+                .any(is_grease)
+        );
+        assert!(!hello.types().into_iter().any(is_grease));
+        assert!(hello.body(EXT_SIGNED_CERTIFICATE_TIMESTAMP).is_none());
+        assert!(hello.body(EXT_APPLICATION_SETTINGS).is_none());
+        // The SCSV is still how rustls signals no renegotiation.
+        assert!(hello.cipher_suites.contains(&0x00ff));
+    }
+
+    #[test]
+    fn randomized_greases_and_nothing_more() {
+        let hello = capture(Some(ClientFingerprint::Randomized));
+
+        assert!(is_grease(hello.cipher_suites[0]));
+        // Not a browser and not claiming to be: no browser-specific extension
+        // and no invented cipher list.
+        assert!(hello.body(EXT_APPLICATION_SETTINGS).is_none());
+        assert!(hello.cipher_suites.contains(&0x00ff));
+    }
+}

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -16,8 +16,12 @@ use std::{str::FromStr, sync::Arc};
 
 use rustls::{
     RawExtension, SignatureScheme,
-    client::{ClientHelloProfile, EchMode},
-    crypto::{CryptoProvider, SupportedKxGroup},
+    client::{ClientHelloProfile, EchGreaseConfig, EchMode},
+    crypto::{CryptoProvider, SupportedKxGroup, hpke::HpkeSuite},
+    internal::msgs::{
+        enums::{HpkeAead, HpkeKdf, HpkeKem},
+        handshake::HpkeSymmetricCipherSuite,
+    },
 };
 use tracing::warn;
 
@@ -167,48 +171,32 @@ impl ClientFingerprint {
     /// any other missing extension. It negotiates nothing: the payload is
     /// noise and the server ignores it.
     ///
-    /// `None` without the `aws-lc-rs` feature - that is the only provider
-    /// rustls ships HPKE for, and there is nothing to build the placeholder
-    /// with otherwise.
+    /// Built without an HPKE provider, so every build gets one - including the
+    /// `ring` builds that every MIPS and embedded target uses, where rustls
+    /// ships no HPKE at all. GREASE addresses nobody and carries nothing, so a
+    /// working KEM was never what it needed.
     pub fn ech_mode(&self) -> Option<EchMode> {
         if !matches!(self, Self::Chrome) {
             return None;
         }
 
-        #[cfg(feature = "aws-lc-rs")]
-        {
-            use rustls::{
-                client::EchGreaseConfig,
-                crypto::{
-                    aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128, hpke::Hpke,
-                },
-            };
+        // X25519 with HKDF-SHA256 and AES-128-GCM: the suite browsers GREASE
+        // with. The KEM matters even for a placeholder, because it decides the
+        // length of the encapsulated key that goes on the wire.
+        let suite = HpkeSuite {
+            kem: HpkeKem::DHKEM_X25519_HKDF_SHA256,
+            sym: HpkeSymmetricCipherSuite {
+                kdf_id: HpkeKdf::HKDF_SHA256,
+                aead_id: HpkeAead::AES_128_GCM,
+            },
+        };
 
-            // X25519 because that is what browsers GREASE with, and the KEM
-            // decides the length of the encapsulated key on the wire.
-            let suite = DH_KEM_X25519_HKDF_SHA256_AES_128 as &'static dyn Hpke;
-            match suite.generate_key_pair() {
-                Ok((public_key, _)) => {
-                    Some(EchMode::Grease(EchGreaseConfig::new(suite, public_key)))
-                }
-                Err(e) => {
-                    warn!("could not build a GREASE ECH placeholder: {e}");
-                    None
-                }
+        match EchGreaseConfig::without_provider(suite) {
+            Ok(config) => Some(EchMode::Grease(config)),
+            Err(e) => {
+                warn!("could not build a GREASE ECH placeholder: {e}");
+                None
             }
-        }
-
-        #[cfg(not(feature = "aws-lc-rs"))]
-        {
-            // Said out loud rather than left to be discovered in a packet
-            // capture. Routers are built with ring - aws-lc-rs has no MIPS
-            // support - so this is the common case, not the exotic one, and
-            // the hello ends up one extension short of the browser's.
-            warn!(
-                "GREASE ECH needs the aws-lc-rs provider, which this build does \
-                 not have; the hello will be one extension short of the profile"
-            );
-            None
         }
     }
 
@@ -635,23 +623,46 @@ mod wire {
     }
 
     #[test]
-    fn chrome_offers_the_two_key_shares_chrome_offers() {
+    fn chrome_offers_key_shares_for_the_groups_it_leads_with() {
         let hello = capture(Some(ClientFingerprint::Chrome));
 
         // key_share(51): u16 list length, then entries of group, u16 length,
-        // body. Chrome sends GREASE, X25519MLKEM768 and its X25519 component;
-        // rustls derives the pair from the group order on its own.
+        // body.
         let body = hello.body(0x0033).expect("no key_share");
         let mut at = 2;
-        let mut groups = Vec::new();
+        let mut shares = Vec::new();
         while at < body.len() {
-            groups.push(u16::from_be_bytes([body[at], body[at + 1]]));
+            shares.push(u16::from_be_bytes([body[at], body[at + 1]]));
             let size = u16::from_be_bytes([body[at + 2], body[at + 3]]) as usize;
             at += 4 + size;
         }
 
-        assert!(is_grease(groups[0]), "{groups:04x?}");
-        assert_eq!(groups.len(), 3, "{groups:04x?}");
+        assert!(is_grease(shares[0]), "{shares:04x?}");
+
+        let groups = hello.u16_list(0x000a, 2);
+        let real_groups: Vec<u16> =
+            groups.iter().copied().filter(|g| !is_grease(*g)).collect();
+        let real_shares: Vec<u16> =
+            shares.iter().copied().filter(|g| !is_grease(*g)).collect();
+
+        // Whatever the provider offers, the share we send is for the group we
+        // asked for first. Getting that wrong costs a round trip on every
+        // connection.
+        assert_eq!(
+            real_shares[0], real_groups[0],
+            "{shares:04x?} vs {groups:04x?}"
+        );
+
+        // With X25519MLKEM768 available, rustls sends its X25519 component as
+        // a second share for free - which is the pair Chrome sends. Without
+        // it, as on a `ring` build, there is one share and the hello differs
+        // from Chrome's here. Nothing to be done about that short of ML-KEM
+        // in `ring`.
+        if real_groups[0] == 0x11ec {
+            assert_eq!(real_shares, vec![0x11ec, 0x001d], "{shares:04x?}");
+        } else {
+            assert_eq!(real_shares.len(), 1, "{shares:04x?}");
+        }
     }
 
     #[test]

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -200,6 +200,14 @@ impl ClientFingerprint {
 
         #[cfg(not(feature = "aws-lc-rs"))]
         {
+            // Said out loud rather than left to be discovered in a packet
+            // capture. Routers are built with ring - aws-lc-rs has no MIPS
+            // support - so this is the common case, not the exotic one, and
+            // the hello ends up one extension short of the browser's.
+            warn!(
+                "GREASE ECH needs the aws-lc-rs provider, which this build does \
+                 not have; the hello will be one extension short of the profile"
+            );
             None
         }
     }

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -16,7 +16,7 @@ use std::{str::FromStr, sync::Arc};
 
 use rustls::{
     RawExtension, SignatureScheme,
-    client::ClientHelloProfile,
+    client::{ClientHelloProfile, EchGreaseConfig, EchMode},
     crypto::{CryptoProvider, SupportedKxGroup},
 };
 use tracing::warn;
@@ -157,6 +157,47 @@ impl ClientFingerprint {
                 grease: true,
                 ..Default::default()
             },
+        }
+    }
+
+    /// The GREASE ECH placeholder this profile sends, if it sends one.
+    ///
+    /// Chrome has carried an encrypted_client_hello extension full of random
+    /// data since it started GREASEing ECH, and its absence is as visible as
+    /// any other missing extension. It negotiates nothing: the payload is
+    /// noise and the server ignores it.
+    ///
+    /// `None` without the `aws-lc-rs` feature - that is the only provider
+    /// rustls ships HPKE for, and there is nothing to build the placeholder
+    /// with otherwise.
+    pub fn ech_mode(&self) -> Option<EchMode> {
+        if !matches!(self, Self::Chrome) {
+            return None;
+        }
+
+        #[cfg(feature = "aws-lc-rs")]
+        {
+            use rustls::crypto::{
+                aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128, hpke::Hpke,
+            };
+
+            // X25519 because that is what browsers GREASE with, and the KEM
+            // decides the length of the encapsulated key on the wire.
+            let suite = DH_KEM_X25519_HKDF_SHA256_AES_128 as &'static dyn Hpke;
+            match suite.generate_key_pair() {
+                Ok((public_key, _)) => {
+                    Some(EchMode::Grease(EchGreaseConfig::new(suite, public_key)))
+                }
+                Err(e) => {
+                    warn!("could not build a GREASE ECH placeholder: {e}");
+                    None
+                }
+            }
+        }
+
+        #[cfg(not(feature = "aws-lc-rs"))]
+        {
+            None
         }
     }
 
@@ -603,6 +644,30 @@ mod wire {
     }
 
     #[test]
+    fn chrome_sends_a_grease_ech_placeholder() {
+        let hello = capture(Some(ClientFingerprint::Chrome));
+
+        let body = hello.body(0xfe0d).expect("no encrypted_client_hello");
+        assert_eq!(body[0], 0x00, "not an outer ECH");
+
+        // 0x00 outer, kdf u16, aead u16, config_id u8, then the encapsulated
+        // key as a length-prefixed payload. Thirty-two bytes means X25519,
+        // which is the KEM browsers GREASE with; P-256 would be sixty-five and
+        // would stand out for it.
+        assert_eq!(u16::from_be_bytes([body[6], body[7]]), 32);
+    }
+
+    #[test]
+    fn grease_ech_does_not_cost_us_tls12() {
+        // rustls pins TLS 1.3 for real ECH. GREASE negotiates nothing, so it
+        // must not - Chrome offers both versions and a placeholder extension.
+        let hello = capture(Some(ClientFingerprint::Chrome));
+        let versions = hello.u16_list(0x002b, 1);
+
+        assert_eq!(&versions[1..], &[0x0304, 0x0303], "{versions:04x?}");
+    }
+
+    #[test]
     fn chrome_does_not_send_the_scsv() {
         let hello = capture(Some(ClientFingerprint::Chrome));
 
@@ -637,6 +702,7 @@ mod wire {
         assert!(!hello.types().into_iter().any(is_grease));
         assert!(hello.body(EXT_SIGNED_CERTIFICATE_TIMESTAMP).is_none());
         assert!(hello.body(EXT_APPLICATION_SETTINGS).is_none());
+        assert!(hello.body(0xfe0d).is_none(), "unasked-for GREASE ECH");
         // The SCSV is still how rustls signals no renegotiation.
         assert!(hello.cipher_suites.contains(&0x00ff));
     }
@@ -649,6 +715,7 @@ mod wire {
         // Not a browser and not claiming to be: no browser-specific extension
         // and no invented cipher list.
         assert!(hello.body(EXT_APPLICATION_SETTINGS).is_none());
+        assert!(hello.body(0xfe0d).is_none());
         assert!(hello.cipher_suites.contains(&0x00ff));
     }
 }

--- a/clash-lib/src/common/tls_fingerprint.rs
+++ b/clash-lib/src/common/tls_fingerprint.rs
@@ -16,7 +16,7 @@ use std::{str::FromStr, sync::Arc};
 
 use rustls::{
     RawExtension, SignatureScheme,
-    client::{ClientHelloProfile, EchGreaseConfig, EchMode},
+    client::{ClientHelloProfile, EchMode},
     crypto::{CryptoProvider, SupportedKxGroup},
 };
 use tracing::warn;
@@ -177,8 +177,11 @@ impl ClientFingerprint {
 
         #[cfg(feature = "aws-lc-rs")]
         {
-            use rustls::crypto::{
-                aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128, hpke::Hpke,
+            use rustls::{
+                client::EchGreaseConfig,
+                crypto::{
+                    aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128, hpke::Hpke,
+                },
             };
 
             // X25519 because that is what browsers GREASE with, and the KEM

--- a/clash-lib/src/config/internal/proxy.rs
+++ b/clash-lib/src/config/internal/proxy.rs
@@ -258,7 +258,10 @@ pub struct OutboundAnytls {
     pub skip_cert_verify: Option<bool>,
     /// Parsed for config compatibility; currently not applied by the runtime.
     pub fingerprint: Option<String>,
-    /// Parsed for config compatibility; currently not applied by the runtime.
+    /// Shape the ClientHello like this client: `chrome`, `edge`, `android`,
+    /// `360`, `qq` or `random`. A profile that is not implemented falls back
+    /// to `random` with a warning rather than silently substituting another
+    /// browser.
     pub client_fingerprint: Option<String>,
     pub udp: Option<bool>,
     /// Parsed for config compatibility; currently not applied by the runtime.
@@ -339,6 +342,10 @@ pub struct OutboundVless {
     pub grpc_opts: Option<GrpcOpt>,
     pub reality_opts: Option<RealityOpt>,
     pub flow: Option<String>,
+    /// Shape the ClientHello like this client: `chrome`, `edge`, `android`,
+    /// `360`, `qq` or `random`. A profile that is not implemented falls back
+    /// to `random` with a warning rather than silently substituting another
+    /// browser.
     pub client_fingerprint: Option<String>,
     /// File path or inline PEM client certificate for mTLS.
     /// Must be set together with `tls-key`.

--- a/clash-lib/src/proxy/converters/anytls.rs
+++ b/clash-lib/src/proxy/converters/anytls.rs
@@ -1,6 +1,7 @@
 use tracing::warn;
 
 use crate::{
+    common::tls_fingerprint::parse_client_fingerprint,
     config::internal::proxy::OutboundAnytls,
     proxy::{
         HandlerCommonOptions,
@@ -30,12 +31,19 @@ impl TryFrom<&OutboundAnytls> for Handler {
                 s.common_opts.server
             );
         }
-        if s.fingerprint.is_some() || s.client_fingerprint.is_some() {
+        // `fingerprint` pins the server certificate and is a different thing
+        // from `client-fingerprint`, which shapes our own hello. The first is
+        // still unimplemented here; the second is applied below.
+        if s.fingerprint.is_some() {
             warn!(
-                "anytls fingerprint fields are parsed but not applied yet for {}",
+                "anytls certificate fingerprint pinning is parsed but not applied yet for {}",
                 s.common_opts.name
             );
         }
+        let client_fingerprint = s
+            .client_fingerprint
+            .as_deref()
+            .map(|value| parse_client_fingerprint(value, &s.common_opts.name));
         if s.idle_session_check_interval.is_some()
             || s.idle_session_timeout.is_some()
             || s.min_idle_session.is_some()
@@ -56,7 +64,7 @@ impl TryFrom<&OutboundAnytls> for Handler {
             password: s.password.clone(),
             udp: s.udp.unwrap_or_default(),
             tls: {
-                let client = TlsClient::new(
+                let client = TlsClient::new_with_fingerprint(
                     skip_cert_verify,
                     s.sni
                         .clone()
@@ -67,6 +75,7 @@ impl TryFrom<&OutboundAnytls> for Handler {
                     None,
                     s.tls_cert.as_deref(),
                     s.tls_key.as_deref(),
+                    client_fingerprint,
                 )?;
                 Some(TransportLayer::Tls(client))
             },

--- a/clash-lib/src/proxy/converters/anytls.rs
+++ b/clash-lib/src/proxy/converters/anytls.rs
@@ -36,7 +36,8 @@ impl TryFrom<&OutboundAnytls> for Handler {
         // still unimplemented here; the second is applied below.
         if s.fingerprint.is_some() {
             warn!(
-                "anytls certificate fingerprint pinning is parsed but not applied yet for {}",
+                "anytls certificate fingerprint pinning is parsed but not applied \
+                 yet for {}",
                 s.common_opts.name
             );
         }

--- a/clash-lib/src/proxy/converters/vless.rs
+++ b/clash-lib/src/proxy/converters/vless.rs
@@ -1,5 +1,6 @@
 use crate::{
     Error,
+    common::tls_fingerprint::parse_client_fingerprint,
     config::internal::proxy::OutboundVless,
     proxy::{
         HandlerCommonOptions,
@@ -31,12 +32,10 @@ impl TryFrom<&OutboundVless> for Handler {
             );
         }
 
-        if s.client_fingerprint.is_some() {
-            warn!(
-                "client-fingerprint (uTLS) is not yet implemented, ignored for {}",
-                s.common_opts.name
-            );
-        }
+        let fingerprint = s
+            .client_fingerprint
+            .as_deref()
+            .map(|value| parse_client_fingerprint(value, &s.common_opts.name));
 
         let tls: Option<TransportLayer> = if let Some(ref reality_opts) =
             s.reality_opts
@@ -57,13 +56,16 @@ impl TryFrom<&OutboundVless> for Handler {
                 .unwrap_or_else(|| s.common_opts.server.clone());
 
             Some(TransportLayer::Reality(RealityClient::new(
-                sni, pk_bytes, short_id,
+                sni,
+                pk_bytes,
+                short_id,
+                fingerprint,
             )))
         } else {
             // vless without reality
             match s.tls.unwrap_or_default() {
                 true => {
-                    let client = TlsClient::new(
+                    let client = TlsClient::new_with_fingerprint(
                         s.skip_cert_verify.unwrap_or_default(),
                         s.server_name.as_ref().map(|x| x.to_owned()).unwrap_or(
                             s.ws_opts
@@ -91,6 +93,7 @@ impl TryFrom<&OutboundVless> for Handler {
                         None,
                         s.tls_cert.as_deref(),
                         s.tls_key.as_deref(),
+                        fingerprint,
                     )?;
                     Some(TransportLayer::Tls(client))
                 }

--- a/clash-lib/src/proxy/hysteria2/outbound/mod.rs
+++ b/clash-lib/src/proxy/hysteria2/outbound/mod.rs
@@ -131,6 +131,7 @@ impl Handler {
             verify,
             opts.tls_cert.as_deref(),
             opts.tls_key.as_deref(),
+            None,
         )
         .map_err(|e| std::io::Error::new(e.kind(), format!("hysteria2 TLS: {e}")))?;
 

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -124,13 +124,20 @@ impl ClientInner {
                 None => verifier,
             };
 
-        Ok(
-            ClientConfig::builder_with_provider(fingerprint.crypto_provider(base))
-                .with_safe_default_protocol_versions()
-                .map_err(io::Error::other)?
-                .dangerous()
-                .with_custom_certificate_verifier(verifier),
-        )
+        let builder =
+            ClientConfig::builder_with_provider(fingerprint.crypto_provider(base));
+
+        // GREASE ECH is stored on the builder, not on the finished config, so
+        // it has to be decided here.
+        let builder = match fingerprint.ech_mode() {
+            Some(mode) => builder.with_ech(mode),
+            None => builder.with_safe_default_protocol_versions(),
+        }
+        .map_err(io::Error::other)?;
+
+        Ok(builder
+            .dangerous()
+            .with_custom_certificate_verifier(verifier))
     }
 }
 

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -70,7 +70,8 @@ impl Client {
                 io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
             })?;
 
-        let mut tls_config = self.client_config_builder()?
+        let mut tls_config = self
+            .client_config_builder()?
             .with_reality(reality)
             .with_no_client_auth();
         apply_client_fingerprint(&mut tls_config, self.fingerprint);
@@ -95,22 +96,25 @@ impl ClientInner {
     /// and the Reality one layered on top of it.
     fn client_config_builder(
         &self,
-    ) -> io::Result<rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>>
-    {
+    ) -> io::Result<
+        rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>,
+    > {
         let Some(fingerprint) = self.fingerprint else {
-            return Ok(ClientConfig::builder()
-                .with_root_certificates(self.roots.get_or_init(init_roots).clone()));
+            return Ok(ClientConfig::builder().with_root_certificates(
+                self.roots.get_or_init(init_roots).clone(),
+            ));
         };
 
         let base = rustls::crypto::CryptoProvider::get_default()
             .cloned()
-            .ok_or_else(|| io::Error::other("no default crypto provider installed"))?;
+            .ok_or_else(|| {
+                io::Error::other("no default crypto provider installed")
+            })?;
 
-        let verifier = rustls::client::WebPkiServerVerifier::builder(
-            GLOBAL_ROOT_STORE.clone(),
-        )
-        .build()
-        .map_err(io::Error::other)?;
+        let verifier =
+            rustls::client::WebPkiServerVerifier::builder(GLOBAL_ROOT_STORE.clone())
+                .build()
+                .map_err(io::Error::other)?;
 
         let verifier: Arc<dyn rustls::client::danger::ServerCertVerifier> =
             match fingerprint.signature_schemes() {
@@ -120,13 +124,13 @@ impl ClientInner {
                 None => verifier,
             };
 
-        Ok(ClientConfig::builder_with_provider(
-            fingerprint.crypto_provider(base),
+        Ok(
+            ClientConfig::builder_with_provider(fingerprint.crypto_provider(base))
+                .with_safe_default_protocol_versions()
+                .map_err(io::Error::other)?
+                .dangerous()
+                .with_custom_certificate_verifier(verifier),
         )
-        .with_safe_default_protocol_versions()
-        .map_err(io::Error::other)?
-        .dangerous()
-        .with_custom_certificate_verifier(verifier))
     }
 }
 
@@ -223,7 +227,12 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let c = Client::new("example.com".to_string(), [1u8; 32], vec![0xab, 0xcd], None);
+        let c = Client::new(
+            "example.com".to_string(),
+            [1u8; 32],
+            vec![0xab, 0xcd],
+            None,
+        );
         assert_eq!(c.sni, "example.com");
         assert_eq!(c.public_key, [1u8; 32]);
         assert_eq!(c.short_id, vec![0xab, 0xcd]);
@@ -233,7 +242,8 @@ mod tests {
     #[tokio::test]
     async fn test_short_id_too_long() {
         setup();
-        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 9], None);
+        let c =
+            Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 9], None);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
@@ -251,7 +261,8 @@ mod tests {
     #[tokio::test]
     async fn test_handshake_error_on_closed_peer() {
         setup();
-        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 4], None);
+        let c =
+            Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 4], None);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_ne!(err.kind(), io::ErrorKind::InvalidInput);
     }

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -10,9 +10,15 @@ use std::{
     sync::{Arc, OnceLock, atomic::AtomicBool},
 };
 
-use crate::proxy::{
-    AnyStream,
-    transport::{Transport, VisionOptions, splice_tls::SplicableTlsStream},
+use crate::{
+    common::{
+        tls::{GLOBAL_ROOT_STORE, apply_client_fingerprint},
+        tls_fingerprint::{ClientFingerprint, PinnedSchemeVerifier},
+    },
+    proxy::{
+        AnyStream,
+        transport::{Transport, VisionOptions, splice_tls::SplicableTlsStream},
+    },
 };
 
 fn init_roots() -> Arc<RootCertStore> {
@@ -23,12 +29,22 @@ fn init_roots() -> Arc<RootCertStore> {
 pub struct Client(Arc<ClientInner>);
 
 impl Client {
-    pub fn new(sni: String, public_key: [u8; 32], short_id: Vec<u8>) -> Self {
+    /// `fingerprint` shapes the ClientHello, and this is the case the whole
+    /// feature exists for: Reality hides inside a TLS handshake to a real
+    /// site, and that only works while the handshake is indistinguishable
+    /// from the client it claims to come from.
+    pub fn new(
+        sni: String,
+        public_key: [u8; 32],
+        short_id: Vec<u8>,
+        fingerprint: Option<ClientFingerprint>,
+    ) -> Self {
         Self(Arc::new(ClientInner {
             sni,
             public_key,
             short_id,
             roots: OnceLock::new(),
+            fingerprint,
         }))
     }
 }
@@ -54,10 +70,10 @@ impl Client {
                 io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
             })?;
 
-        let tls_config = ClientConfig::builder()
-            .with_root_certificates(self.roots.get_or_init(init_roots).clone())
+        let mut tls_config = self.client_config_builder()?
             .with_reality(reality)
             .with_no_client_auth();
+        apply_client_fingerprint(&mut tls_config, self.fingerprint);
 
         let sni: ServerName<'_> =
             ServerName::try_from(self.sni.clone()).map_err(|e| {
@@ -68,6 +84,49 @@ impl Client {
             .connect(sni, stream)
             .await
             .map_err(io::Error::other)
+    }
+}
+
+impl ClientInner {
+    /// A config builder carrying the fingerprint's provider and verifier.
+    ///
+    /// Reality cannot use the shared helper: `with_reality` wraps whatever
+    /// verifier is in place at that moment, so ours has to be installed first
+    /// and the Reality one layered on top of it.
+    fn client_config_builder(
+        &self,
+    ) -> io::Result<rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>>
+    {
+        let Some(fingerprint) = self.fingerprint else {
+            return Ok(ClientConfig::builder()
+                .with_root_certificates(self.roots.get_or_init(init_roots).clone()));
+        };
+
+        let base = rustls::crypto::CryptoProvider::get_default()
+            .cloned()
+            .ok_or_else(|| io::Error::other("no default crypto provider installed"))?;
+
+        let verifier = rustls::client::WebPkiServerVerifier::builder(
+            GLOBAL_ROOT_STORE.clone(),
+        )
+        .build()
+        .map_err(io::Error::other)?;
+
+        let verifier: Arc<dyn rustls::client::danger::ServerCertVerifier> =
+            match fingerprint.signature_schemes() {
+                Some(schemes) => {
+                    Arc::new(PinnedSchemeVerifier::new(verifier, schemes))
+                }
+                None => verifier,
+            };
+
+        Ok(ClientConfig::builder_with_provider(
+            fingerprint.crypto_provider(base),
+        )
+        .with_safe_default_protocol_versions()
+        .map_err(io::Error::other)?
+        .dangerous()
+        .with_custom_certificate_verifier(verifier))
     }
 }
 
@@ -146,6 +205,7 @@ pub struct ClientInner {
     short_id: Vec<u8>,
     // cached for performance
     roots: OnceLock<Arc<RootCertStore>>,
+    fingerprint: Option<ClientFingerprint>,
 }
 
 #[cfg(test)]
@@ -163,7 +223,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let c = Client::new("example.com".to_string(), [1u8; 32], vec![0xab, 0xcd]);
+        let c = Client::new("example.com".to_string(), [1u8; 32], vec![0xab, 0xcd], None);
         assert_eq!(c.sni, "example.com");
         assert_eq!(c.public_key, [1u8; 32]);
         assert_eq!(c.short_id, vec![0xab, 0xcd]);
@@ -173,7 +233,7 @@ mod tests {
     #[tokio::test]
     async fn test_short_id_too_long() {
         setup();
-        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 9]);
+        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 9], None);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
@@ -182,7 +242,7 @@ mod tests {
     #[tokio::test]
     async fn test_invalid_sni() {
         setup();
-        let c = Client::new("".to_string(), [0u8; 32], vec![0u8; 4]);
+        let c = Client::new("".to_string(), [0u8; 32], vec![0u8; 4], None);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
@@ -191,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn test_handshake_error_on_closed_peer() {
         setup();
-        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 4]);
+        let c = Client::new("example.com".to_string(), [0u8; 32], vec![0u8; 4], None);
         let err = c.proxy_stream(make_stream()).await.err().unwrap();
         assert_ne!(err.kind(), io::ErrorKind::InvalidInput);
     }

--- a/clash-lib/src/proxy/transport/tls.rs
+++ b/clash-lib/src/proxy/transport/tls.rs
@@ -7,6 +7,7 @@ use crate::{
     common::{
         errors::map_io_error,
         tls::{DefaultTlsVerifier, build_tls_client_config},
+        tls_fingerprint::ClientFingerprint,
     },
     proxy::AnyStream,
 };
@@ -22,19 +23,22 @@ pub struct TLSOptions {
     /// File path or inline PEM client private key for mTLS.
     /// Must be set together with `tls_cert`.
     pub tls_key: Option<String>,
+    /// Shape the ClientHello like this client, from `client-fingerprint`.
+    pub client_fingerprint: Option<ClientFingerprint>,
 }
 
 impl TryFrom<TLSOptions> for Client {
     type Error = io::Error;
 
     fn try_from(opt: TLSOptions) -> Result<Self, Self::Error> {
-        Client::new(
+        Client::new_with_fingerprint(
             opt.skip_cert_verify,
             opt.sni,
             opt.alpn,
             None,
             opt.tls_cert.as_deref(),
             opt.tls_key.as_deref(),
+            opt.client_fingerprint,
         )
     }
 }
@@ -65,14 +69,46 @@ impl Client {
         tls_cert: Option<&str>,
         tls_key: Option<&str>,
     ) -> io::Result<Self> {
-        let verifier = Arc::new(DefaultTlsVerifier::new(None, skip_cert_verify));
-        let mut tls_config = build_tls_client_config(verifier, tls_cert, tls_key)?;
+        Self::new_with_fingerprint(
+            skip_cert_verify,
+            sni,
+            alpn,
+            expected_alpn,
+            tls_cert,
+            tls_key,
+            None,
+        )
+    }
 
-        tls_config.alpn_protocols = alpn
+    /// As [`Self::new`], with the ClientHello shaped like `client_fingerprint`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_fingerprint(
+        skip_cert_verify: bool,
+        sni: String,
+        alpn: Option<Vec<String>>,
+        expected_alpn: Option<String>,
+        tls_cert: Option<&str>,
+        tls_key: Option<&str>,
+        client_fingerprint: Option<ClientFingerprint>,
+    ) -> io::Result<Self> {
+        let verifier = Arc::new(DefaultTlsVerifier::new(None, skip_cert_verify));
+        let mut tls_config = build_tls_client_config(
+            verifier,
+            tls_cert,
+            tls_key,
+            client_fingerprint,
+        )?;
+
+        // An empty list leaves whatever the fingerprint asked for in place;
+        // sending no ALPN at all is unlike any browser.
+        let alpn: Vec<Vec<u8>> = alpn
             .unwrap_or_default()
             .into_iter()
             .map(|x| x.as_bytes().to_vec())
             .collect();
+        if !alpn.is_empty() {
+            tls_config.alpn_protocols = alpn;
+        }
 
         if std::env::var("SSLKEYLOGFILE").is_ok() {
             tls_config.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/clash-lib/src/proxy/tuic/mod.rs
+++ b/clash-lib/src/proxy/tuic/mod.rs
@@ -213,6 +213,7 @@ impl Handler {
             verifier,
             opts.tls_cert.as_deref(),
             opts.tls_key.as_deref(),
+            None,
         )
         .map_err(|e| anyhow::anyhow!("tuic TLS: {e}"))?;
         // TODO(error-handling) if alpn not match the following error will be


### PR DESCRIPTION
> **Depends on [Watfaq/rustls#11](https://github.com/Watfaq/rustls/pull/11)** — the mechanism lives there, the browser table lives here.
>
> Draft until that merges. So the branch can actually build and be reviewed, `Cargo.toml` points at that PR's branch on my fork, marked in place as not for merge; it goes back to `Watfaq/rustls` the moment #11 lands.

## Why

Every VLESS or AnyTLS proxy with `client-fingerprint` set gets this:

```
WARN clash-lib/src/proxy/converters/vless.rs:35:
client-fingerprint (uTLS) is not yet implemented, ignored for main-out
```

Reality connects and carries traffic, but the ClientHello is recognisably rustls: no GREASE, no `signed_certificate_timestamp`, no ALPS, and a cipher list that is exactly the fifteen-minus-six suites rustls happens to implement. That separates it from a browser before a byte of application data moves, which is the one thing Reality exists to prevent.

## What changed

`client-fingerprint` is now applied, for VLESS (Reality and plain TLS) and for AnyTLS.

The numbers come from [uTLS](https://github.com/refraction-networking/utls) `HelloChrome_133`, not from memory — `clash-lib/src/common/tls_fingerprint.rs` is the whole table, and it is the only file that knows anything about browsers.

| accepted value | profile |
|---|---|
| `chrome`, `edge`, `android`, `360`, `qq` | Chrome 133 |
| `random`, `randomized` | rustls' own hello, plus GREASE |
| anything else | falls back to `random` **with a warning** |

That last row is deliberate. Firefox and Safari are real profiles that are simply not modelled here; quietly substituting Chrome for them would be worse than saying so, because a config asking for Firefox and getting Chrome is a mismatch nobody would think to look for.

### What the Chrome profile sets

- **cipher suites** — Chrome's fifteen, in order. Six of them (static RSA and CBC) rustls cannot negotiate and will never be selected; they are advertised because the count and the order are the first half of the fingerprint.
- **GREASE** — cipher list, supported groups, key shares, supported versions, and two extensions.
- **supported groups** — X25519MLKEM768, X25519, P-256, P-384. rustls derives the key shares from that order on its own, and the pair it produces is the pair Chrome sends.
- **signature algorithms** — Chrome's eight, in order, via a verifier wrapper that also narrows what will be accepted. Same trade the browser makes.
- **`renegotiation_info`** — rustls signals "no renegotiation" with the SCSV in the cipher list; browsers use the extension. Pinning the suite list removes the SCSV, so the extension takes its place.
- **`signed_certificate_timestamp`** and **ALPS** (`0x44cd`, the codepoint Chrome 133 uses) as verbatim extensions.
- **ALPN** `h2, http/1.1` — only when the caller has none of its own. A transport that must negotiate h2 has a functional requirement, and looking like a browser does not outrank it.
- **GREASE ECH** — a placeholder full of random data, X25519, matching what browsers send. Off without the `aws-lc-rs` feature: rustls only ships HPKE for that provider.
- **`compress_certificate`** — brotli, the only algorithm Chrome offers. See the note on the `brotli` feature below.
- **no padding** — Chrome 131 dropped it; with GREASE ECH the hello no longer lands in the range padding existed for.

## Measured, not just asserted

The tests say the profile is assembled correctly. This says what actually left the socket, read back from `tls.peet.ws`:

| | JA4 |
|---|---|
| clash-rs today | `t13d1011h1_61a7ad8aa9b6_f9531d972513` |
| this branch, no `client-fingerprint` | `t13d1012h1_61a7ad8aa9b6_41631feb4e62` |
| this branch, `client-fingerprint: chrome` | `t13d1516h1_8daaf6152771_d8a2da3f94cd` |

The middle row is the whole cost of the `brotli` commit, stated below: one extension more on every connection, and the cipher hash unchanged.

`1516` is fifteen cipher suites and sixteen extensions, which are Chrome's counts. `h1` rather than `h2` is the probe's own doing — it speaks HTTP/1.1 so it can read the reply, and JA4 records the ALPN it saw.

The raw form is the part worth reading:

```
t13d1516h1_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9
          _0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01
          _0403,0804,0401,0503,0805,0501,0806,0601
```

Cipher list, extension list and signature algorithms: field for field what uTLS records for `HelloChrome_133`.

## On hardware, and what it changed

Flashed onto a GL-XE300 (`mips_24kc`, OpenWrt 25.12.5) running podkop with a real VLESS+Reality outbound, and the ClientHello read back off the wire with tcpdump:

```
ClientHello, 299 bytes, session_id 32 bytes
cipher suites (16, 15 real):
  GREASE 1301 1302 1303 c02b c02f c02c c030 cca9 cca8 c013 c014 009c 009d 002f 0035
extensions: GREASE, session_ticket, psk_key_exchange_modes, key_share,
  extended_master_secret, compress_certificate, alpn, supported_versions,
  status_request, supported_groups, server_name, signature_algorithms,
  ec_point_formats, renegotiation_info, signed_certificate_timestamp,
  application_settings, GREASE
JA4 counts: 15 ciphers, 15 extensions
```

Tunnel healthy throughout — 148, 155, 157 ms across three delay tests — and the `client-fingerprint (uTLS) is not yet implemented` line is gone from the log.

**But the profile is provider-dependent, and routers get the reduced one.** The MIPS targets build with `-F ring`, and against x86 with aws-lc-rs the same code produced sixteen extensions and five groups. Two things are missing on ring, both for the same reason:

| | on ring | why |
|---|---|---|
| `encrypted_client_hello` | absent | rustls ships HPKE only for aws-lc-rs |
| X25519MLKEM768 | absent from groups and key shares | `ring` has no ML-KEM |

So on a router the hello is `15 ciphers / 15 extensions` against Chrome's `15 / 16`, and the group list is X25519, P-256, P-384 where Chrome leads with the post-quantum hybrid.

Neither is silent — the code says so:

```
WARN tls_fingerprint.rs: key exchange group X25519MLKEM768 is unavailable, dropped from the hello
WARN tls_fingerprint.rs: GREASE ECH needs the aws-lc-rs provider, which this build does not have
```

Worth knowing before anyone assumes a router build gets the same disguise a desktop build does. Closing either gap means HPKE and ML-KEM for `ring`, which is upstream rustls work, not this PR.

## The one line that touches everything else

```toml
rustls = { version = "0.23", default-features = false, features = ["brotli"] }
```

Chrome offers brotli certificate compression. Without a decompressor rustls omits the extension entirely, and that was the single extension standing between `1515` and `1516`.

It is a separate commit because it is a separate decision, and not a free one: it applies to every TLS client in clash-rs, not only fingerprinted ones. The default hello goes from eleven extensions to twelve, and a brotli decompressor is linked in. Both are arguably improvements — smaller handshakes, and a default hello marginally less unlike a browser's — but dropping the commit is a supported outcome. The cost of dropping it is one extension out of sixteen.

## No fingerprint, no change

Without `client-fingerprint` nothing about the hello moves, SCSV included. There is a test asserting it, because a feature like this quietly altering every other connection would be a bad trade.

`TlsClient::new` keeps its signature; the fingerprint goes through `new_with_fingerprint`, so trojan, vmess, socks5, websocket and the rest are untouched.

## Tests

Nineteen, and eleven of them read the bytes that actually left a `ClientConnection` rather than the struct that produced them — a profile correct in a struct and lost on the way to the socket would pass every other kind of test:

- Chrome's cipher list arrives in order, GREASE in front, sixteen entries
- GREASE reaches supported groups, supported versions and key shares
- three key share entries: GREASE, X25519MLKEM768, X25519 — what Chrome sends
- `signed_certificate_timestamp`, ALPS and `renegotiation_info` present with the right bodies
- the SCSV is gone and `renegotiation_info` replaced it
- ALPN is `h2, http/1.1`
- `compress_certificate` offers brotli and only brotli
- the GREASE ECH placeholder is there, with a 32 byte encapsulated key
- TLS 1.2 survived the ECH extension (rustls pins 1.3 for real ECH, and must not for GREASE)
- with no fingerprint: no GREASE anywhere, no browser extensions, SCSV still there
- an unknown profile name resolves to `random`, never to Chrome

```
cargo test -p clash-lib --lib --features aws-lc-rs,zero_copy,tuic
test result: ok. 19 passed; 0 failed
```
